### PR TITLE
fix(git): track branch-ref mtime so committed files clear their markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,7 +4346,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "1.97.2"
+version = "1.97.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "1.97.2"
+version = "1.97.3"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -19,7 +19,7 @@
 //! re-filtered per listing dir via [`map_to_listing`] on each chdir.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use crate::ui::list_view::{GitChange, GitFileStatus};
@@ -364,8 +364,9 @@ pub fn repo_status(repo_root: &Path) -> Option<Vec<StatusEntry>> {
 }
 
 /// [`repo_status`] guarded against the racy-snapshot pitfall, returning the
-/// entries alongside the `.git/index` + `HEAD` mtimes they're consistent with
-/// (the `GitWorkerResult` shape the off-thread git worker sends).
+/// entries alongside the `.git/index` + resolved-HEAD-ref mtimes (see
+/// [`head_ref_mtime`]) they're consistent with (the `GitWorkerResult` shape the
+/// off-thread git worker sends).
 ///
 /// The status walk takes hundreds of ms on a large tree. If `.git/index` or
 /// `HEAD` is rewritten *during* it (a `commit` / `checkout` / `git add` landing
@@ -397,14 +398,62 @@ pub fn repo_status_stable(
             let index = std::fs::metadata(gd.join("index"))
                 .and_then(|m| m.modified())
                 .ok();
-            let head = std::fs::metadata(gd.join("HEAD"))
-                .and_then(|m| m.modified())
-                .ok();
+            let head = head_ref_mtime(gd);
             (index, head)
         })
     };
     let (entries, (index_mtime, head_mtime)) = stable_walk(stat, || repo_status(repo_root), 3);
     (entries, index_mtime, head_mtime)
+}
+
+/// The mtime that moves when the checked-out branch advances (a **commit**) or
+/// changes (a **checkout**) — the marker poll's HEAD-side freshness key.
+///
+/// `<gitdir>/HEAD` alone is insufficient: for an attached HEAD it's the symbolic
+/// `ref: refs/heads/<branch>` pointer, which git rewrites only on checkout —
+/// **never on commit**. A commit moves the resolved ref instead
+/// (`<common>/refs/heads/<branch>`, or `<common>/packed-refs` when the ref is
+/// packed). Watching only the pointer means an external commit (another shell,
+/// an agent) leaves this key unchanged, the poll short-circuits, and committed
+/// files keep showing as modified. We return the latest of the HEAD-file and
+/// resolved-ref mtimes so both a commit *and* a checkout refresh the poll. A
+/// detached HEAD stores the commit id in the HEAD file itself, so its own mtime
+/// already tracks commits — the `None` ref branch falls back to it.
+fn head_ref_mtime(gitdir: &Path) -> Option<SystemTime> {
+    let head_file = gitdir.join("HEAD");
+    let head_mtime = std::fs::metadata(&head_file)
+        .and_then(|m| m.modified())
+        .ok();
+    let ref_mtime = std::fs::read_to_string(&head_file)
+        .ok()
+        .and_then(|contents| {
+            let refname = contents.strip_prefix("ref: ")?.trim().to_string();
+            // Worktree branch refs live in the *common* gitdir, not the per-worktree one.
+            let common = common_gitdir(gitdir);
+            std::fs::metadata(common.join(&refname))
+                .and_then(|m| m.modified())
+                .ok()
+                // Ref packed away → no loose file; the packed-refs mtime is the signal.
+                .or_else(|| {
+                    std::fs::metadata(common.join("packed-refs"))
+                        .and_then(|m| m.modified())
+                        .ok()
+                })
+        });
+    match (head_mtime, ref_mtime) {
+        (Some(h), Some(r)) => Some(h.max(r)),
+        (h, r) => h.or(r),
+    }
+}
+
+/// The common gitdir shared across linked worktrees. A linked worktree's gitdir
+/// (`.git/worktrees/<name>`) records the shared dir in a `commondir` file
+/// (typically `../..`); a normal `.git` has none and is its own common dir. The
+/// returned path may keep unresolved `..` components — the OS resolves them on
+/// `stat`, so we skip a hot-path `canonicalize`.
+fn common_gitdir(gitdir: &Path) -> PathBuf {
+    std::fs::read_to_string(gitdir.join("commondir"))
+        .map_or_else(|_| gitdir.to_path_buf(), |rel| gitdir.join(rel.trim()))
 }
 
 /// Generic stat-walk-stat consistency guard (see [`repo_status_stable`]).

--- a/src/git/status/tests.rs
+++ b/src/git/status/tests.rs
@@ -226,10 +226,12 @@ mod map_tests {
 #[cfg(test)]
 mod parity_tests {
     use super::super::{
-        StatusEntry, decode_porcelain, map_to_listing, repo_status, repo_status_stable,
+        StatusEntry, decode_porcelain, head_ref_mtime, map_to_listing, repo_status,
+        repo_status_stable,
     };
     use crate::git::test_support::run_git;
     use std::path::{Path, PathBuf};
+    use std::time::SystemTime;
 
     /// Hermetic `git status --porcelain -unormal` stdout for `dir`, via the
     /// shared `run_git` fixture (so config — e.g. rename detection — matches
@@ -461,6 +463,55 @@ mod parity_tests {
         assert!(
             index_mtime.is_some() && head_mtime.is_some(),
             "quiescent repo → both cache-key mtimes stamped"
+        );
+    }
+
+    /// Set a file's mtime to a fixed instant (no wall-clock dependence, so the
+    /// assertions below don't flake under the parallel suite's timing).
+    fn set_mtime(path: &Path, t: SystemTime) {
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .and_then(|f| f.set_modified(t))
+            .unwrap_or_else(|e| panic!("set mtime on {path:?}: {e}"));
+    }
+
+    /// The HEAD-side freshness key must follow the branch ref (which a *commit*
+    /// moves), not the static `ref: refs/heads/…` HEAD pointer (which only a
+    /// *checkout* moves). Regression test for the stale-marker-after-commit bug.
+    #[test]
+    fn head_ref_mtime_tracks_branch_ref_not_static_head_pointer() {
+        let (_t, root) = repo_with_commit(); // attached HEAD → refs/heads/main
+        let gd = crate::git::discovery::gitdir(&root).expect("gitdir");
+        let branch_ref = gd.join("refs/heads/main");
+        assert!(
+            branch_ref.exists(),
+            "a fresh repo keeps the branch ref loose"
+        );
+        let older = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000);
+        let newer = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(2_000_000_000);
+        set_mtime(&gd.join("HEAD"), older); // the pointer file last "moved" long ago
+        set_mtime(&branch_ref, newer); // a commit just advanced the ref
+        assert_eq!(
+            head_ref_mtime(&gd),
+            Some(newer),
+            "head key must follow the branch ref (moves on commit), not the HEAD pointer",
+        );
+    }
+
+    /// A detached HEAD stores the commit id in the HEAD file itself — no branch
+    /// ref to resolve — so the HEAD file's own mtime is the freshness signal.
+    #[test]
+    fn head_ref_mtime_detached_falls_back_to_head_file() {
+        let (_t, root) = repo_with_commit();
+        run_git(&root, &["checkout", "-q", "--detach"]);
+        let gd = crate::git::discovery::gitdir(&root).expect("gitdir");
+        let newer = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(2_000_000_000);
+        set_mtime(&gd.join("HEAD"), newer);
+        assert_eq!(
+            head_ref_mtime(&gd),
+            Some(newer),
+            "detached HEAD → the HEAD file's own mtime tracks commits",
         );
     }
 }


### PR DESCRIPTION
Fixes the stale git markers we caught live: after an external `git commit` (another shell / an agent) lands while spyc is running, committed files kept showing the modified `~` marker.

**Root cause:** the marker poll's HEAD-freshness key stats `<gitdir>/HEAD` — the symbolic `ref: refs/heads/<branch>` pointer, which git rewrites only on *checkout*, never on *commit*. The branch ref that a commit actually moves wasn't watched, so the poll short-circuited on a stale walk.

**Fix:** `head_ref_mtime` resolves a symbolic HEAD to its branch ref and stats that (worktree-aware via `commondir`; `packed-refs` fallback; detached HEAD falls back to the HEAD file), returning the latest of HEAD-file + ref mtimes so both commit and checkout refresh the poll. Two non-flaky regression tests (`File::set_modified`).

First code PR through the new GitHub Actions CI.

Closes #101.