### PR TITLE
docs: community-health files + public-repo doc fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Something in spyc misbehaves
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. spyc is a terminal app, so the debug log and your
+        terminal/OS/multiplexer matter a lot — please fill in the environment and
+        attach a `--debug` log if you can.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you do, what did you expect, and what happened instead?
+      placeholder: |
+        1. ...
+        2. ...
+        Expected: ...
+        Actual: ...
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: spyc version
+      description: "`spyc --version`, or the version shown in the status bar."
+      placeholder: "1.97.3"
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Terminal + OS
+      description: Terminal emulator, multiplexer (tmux?), OS + version, and whether over SSH.
+      placeholder: "WezTerm, macOS 15.5, local (no tmux)"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debug log
+      description: >
+        Reproduce with `spyc --debug`, then paste the relevant lines from
+        `/tmp/spyc-debug-*.log`. For pane/agent issues, `--status-trace` adds
+        the status-hook payloads to `mcp.log`.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question or open-ended idea
+    url: https://github.com/Tripstack-Corp/spyc/discussions
+    about: For usage questions and discussion, start a Discussion instead of filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest a capability or change
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that spyc makes hard or impossible today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        What should spyc do? Say what surface it fits — a keybinding, a `:`
+        command, an MCP tool, a `.spycrc.toml` knob, or Lua — if you have a view.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other designs you weighed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+-
+
+## Test plan
+
+-
+
+---
+
+<!-- The repo's conventions — see CONTRIBUTING.md / AGENTS.md. -->
+
+- [ ] `make check` passes (fmt-check + clippy + test + deny)
+- [ ] Version bumped in `Cargo.toml` if user-visible (`cargo update -p spyc` to sync the lock)
+- [ ] Docs updated in the same commit where applicable (FEATURES / AGENTS / DESIGN / `src/ui/help.rs`)
+- [ ] Commit subject is a conventional-commit line (`type(scope): subject`) — it becomes the CHANGELOG entry

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+# Dependabot version updates.
+#
+# Security coverage is elsewhere: GitHub Dependabot *alerts* + the weekly
+# cargo-deny advisory sweep (.github/workflows/audit.yml) catch CVEs. This
+# file opens the routine, non-security dependency-bump PRs.
+#
+# Bumps are grouped and conventional-commit-prefixed so:
+#   - git-cliff files each PR under a CHANGELOG section (the commit subject
+#     is the changelog line — see cliff.toml / CONTRIBUTING.md), and
+#   - the spyc-semver merge driver still auto-resolves the Cargo.toml
+#     version-line collision every PR creates on rebase.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      # Fold routine minor/patch bumps into a single PR to keep merge-train
+      # churn down; major bumps still open individually for a deliberate look.
+      cargo-minor-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+derek.marshall@tripstack.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,11 @@ We use GitHub pull requests. The target branch is `main`.
    Run `spyc --debug` to reproduce the issue, then attach the
    relevant lines from the `/tmp/spyc-debug-*.log` file.
 
-6. **One approval required** before merge. Squash-merge preferred to
-   keep `main` history clean.
+6. **Merge.** `main` is branch-protected: a PR is required and the CI
+   checks (lint + tests) must pass, then **squash-merge** to keep the
+   history clean. As a solo-maintained project `main` does not require a
+   separate approving review (the maintainer can't approve their own PR);
+   external contributions are reviewed by the maintainer before merge.
 
 ## Code conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,7 +4346,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "1.97.3"
+version = "1.97.4"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "1.97.3"
+version = "1.97.4"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,9 +9,9 @@ If you find something wrong, contact derek.marshall@tripstack.com.
 ## Threat model
 
 spyc is a single-binary terminal file manager. It runs locally as the
-invoking user, has no network code of its own, and is distributed
-internally to Tripstack engineers from a private GitHub repo. The
-realistic threats are:
+invoking user, has no network code of its own, and is distributed as
+source from a public GitHub repo (engineers build it locally via
+`make install`). The realistic threats are:
 
 - **Supply-chain compromise of a Rust dependency** — a transitive
   crate is yanked + republished with malicious code, or an unmaintained


### PR DESCRIPTION
## Summary

Now that the repo is public with branch protection, add the standard community-health scaffolding and correct two now-stale statements.

- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (enforcement contact matches `SECURITY.md`).
- **Issue + PR templates** — `.github/ISSUE_TEMPLATE/` bug + feature issue forms + a `config.yml` that routes open-ended questions to Discussions; `PULL_REQUEST_TEMPLATE.md` encoding the `make check` / version-bump / docs-in-sync / conventional-commit conventions.
- **`.github/dependabot.yml`** — weekly cargo + github-actions version bumps, grouped and conventional-commit-prefixed so git-cliff files each under a CHANGELOG section and the `spyc-semver` merge driver still auto-resolves the version-line collision. Security is already covered (Dependabot alerts + weekly `cargo-deny` in `audit.yml`).
- **SECURITY.md** — distributed as source from a *public* GitHub repo, not private.
- **CONTRIBUTING.md** — `main` is branch-protected and requires a passing-checks PR, not a separate approving review (a solo maintainer can't approve their own PR); external contributions are reviewed before merge.

## Test plan

- All four new YAML files validated locally (parse cleanly).
- No Rust changed — GitHub Actions CI (lint + tests) is the gate.
- Version bumped 1.97.3 → 1.97.4; `Cargo.lock` synced.

Generated with [Claude Code](https://claude.com/claude-code)
