### PR TITLE
docs(readme): add CI, audit, license, and rust badges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,7 +4346,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "1.97.4"
+version = "1.97.5"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "1.97.4"
+version = "1.97.5"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Tripstack-Corp/spyc/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Tripstack-Corp/spyc/ci.yml?branch=main&label=CI&style=flat-square" alt="CI"></a>
+  <a href="https://github.com/Tripstack-Corp/spyc/actions/workflows/audit.yml"><img src="https://img.shields.io/github/actions/workflow/status/Tripstack-Corp/spyc/audit.yml?label=audit&style=flat-square" alt="Audit"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-BSD--3--Clause-blue?style=flat-square" alt="License: BSD-3-Clause"></a>
+  <img src="https://img.shields.io/badge/rust-1.96-orange?style=flat-square&logo=rust" alt="Rust 1.96">
+</p>
+
+<p align="center">
   <img src="docs/assets/demo.gif" alt="spyc demo: navigate, ask the agent, gf jump" width="720">
 </p>
 


### PR DESCRIPTION
## Summary

Adds a badge row to the README header now that the repo is public with GitHub Actions CI:

- **CI** — `ci.yml` status on `main`
- **Audit** — weekly RUSTSEC sweep (`audit.yml`)
- **License** — BSD-3-Clause
- **Rust** — pinned toolchain (1.96, from `rust-toolchain.toml`)

Skipped version/tag (tags aren't pushed to GitHub) and crates.io/coverage (not applicable). All shields.io `flat-square` to match the centered header.

## Test plan

- Badge URLs are standard shields.io endpoints; render on GitHub.
- Version bumped 1.97.4 → 1.97.5; `Cargo.lock` synced. No code changed.

Generated with [Claude Code](https://claude.com/claude-code)