### PR TITLE
ci: add release.yml — build, sign, publish on v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,139 @@
+# spyc release pipeline — build, sign, and publish on a version tag.
+#
+# Trigger: pushing a tag matching `v*` (e.g. `v2.0.0-rc.1`, `v2.0.0`,
+# `v2.0.1`). `-alpha`/`-beta`/`-rc` tags publish as GitHub *pre-releases*;
+# a bare `vN.M.P` publishes as the latest release. The build jobs CALL the
+# existing Makefile targets so local `make dist` and CI never drift
+# (AGENTS.md; RELEASE_ENGINEERING.md §8).
+#
+# Artifacts (RELEASE_ENGINEERING.md §9):
+#   spyc-<tag>-macos-universal.tar.gz   arm64 + x86_64 lipo
+#   spyc-<tag>-linux-x86_64.tar.gz      static, musl
+#   spyc-<tag>-linux-aarch64.tar.gz     static, musl
+#   SHA256SUMS                          checksums over all three tarballs
+#
+# Signing is keyless — no stored secrets (RELEASE_ENGINEERING.md §13.8):
+#   - GitHub build-provenance attestations   verify: `gh attestation verify <file>`
+#   - cosign-signed SHA256SUMS bundle (OIDC)  verify: `cosign verify-blob`
+# GPG signing, the Homebrew tap, and cargo-binstall are documented fast-follows.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# Don't cancel an in-flight release if another tag lands; releases are cheap
+# to let finish and cancelling mid-publish is worse than a little overlap.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: "0"
+  CARGO_TERM_COLOR: always
+
+jobs:
+  macos:
+    name: Build macOS universal
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Toolchain (auto from rust-toolchain.toml)
+        run: rustc --version && cc --version
+      - uses: Swatinem/rust-cache@v2
+      - name: Build universal binary
+        run: make release-macos-universal
+      - name: Package tarball
+        run: |
+          install -m 0755 dist/spyc-macos-universal spyc
+          tar -czf "spyc-${GITHUB_REF_NAME}-macos-universal.tar.gz" spyc LICENSE README.md
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-universal
+          path: spyc-*-macos-universal.tar.gz
+          if-no-files-found: error
+
+  linux:
+    name: Build Linux musl (x86_64 + aarch64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # zig is cargo-zigbuild's cross-linker; the Makefile's musl targets shell
+      # out to `cargo zigbuild`.
+      - uses: mlugg/setup-zig@v1
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-zigbuild
+      - name: Toolchain (auto from rust-toolchain.toml)
+        run: rustc --version
+      - uses: Swatinem/rust-cache@v2
+      - name: Build static musl binaries
+        run: |
+          make release-linux-x86
+          make release-linux-arm
+      - name: Package tarballs
+        run: |
+          install -m 0755 target/x86_64-unknown-linux-musl/release/spyc spyc
+          tar -czf "spyc-${GITHUB_REF_NAME}-linux-x86_64.tar.gz" spyc LICENSE README.md
+          install -m 0755 target/aarch64-unknown-linux-musl/release/spyc spyc
+          tar -czf "spyc-${GITHUB_REF_NAME}-linux-aarch64.tar.gz" spyc LICENSE README.md
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-musl
+          path: spyc-*-linux-*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: Sign + publish release
+    needs: [macos, linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the release + upload assets
+      id-token: write # OIDC for attestations + cosign keyless signing
+      attestations: write # build-provenance attestations
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so git-cliff can build the notes for this tag.
+          fetch-depth: 0
+      - name: Collect build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Stage dist/ + checksums
+        run: |
+          mkdir -p dist
+          find artifacts -name 'spyc-*.tar.gz' -exec cp {} dist/ \;
+          cd dist && shasum -a 256 spyc-*.tar.gz > SHA256SUMS
+          echo "=== SHA256SUMS ===" && cat SHA256SUMS
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/spyc-*.tar.gz"
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign checksums (cosign keyless)
+        run: |
+          cd dist
+          cosign sign-blob --yes SHA256SUMS --bundle SHA256SUMS.cosign.bundle
+      - name: Generate release notes (git-cliff, this tag's section)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+      - run: git cliff --config cliff.toml --latest --strip header > RELEASE_NOTES.md
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          args=()
+          case "${GITHUB_REF_NAME}" in
+            *-alpha*|*-beta*|*-rc*) args+=(--prerelease) ;;
+          esac
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "spyc ${GITHUB_REF_NAME}" \
+            --notes-file RELEASE_NOTES.md \
+            "${args[@]}" \
+            dist/spyc-*.tar.gz \
+            dist/SHA256SUMS \
+            dist/SHA256SUMS.cosign.bundle

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -157,10 +157,10 @@ are the source of truth — Actions *call them* so local and CI never drift.
 > **Dev-platform: RESOLVED (2026-07-02) — full move to GitHub.** All dev + CI run
 > on GitHub Actions; `bitbucket-pipelines.yml` is retired (archived under
 > `docs/archive/`). **`ci.yml` and `audit.yml` are implemented** — direct ports
-> of the retired pipeline. `release.yml`, `snapshot.yml`, and `homebrew.yml`
-> remain to build; they gate on the launch-distribution decisions (signing, org
-> secrets, the Homebrew tap), so they land with the distribution work, not the
-> dev-CI move.
+> of the retired pipeline, and **`release.yml` is implemented** (keyless signing,
+> no secrets). `snapshot.yml` and `homebrew.yml` remain to build; they gate on
+> the remaining distribution decisions (the Homebrew tap, nightly cadence), so
+> they land with that work.
 
 ### `ci.yml` — quality gate (PR + push to `main`) — **IMPLEMENTED**
 - Direct port of the retired `bitbucket-pipelines.yml`: `lint` (fmt + clippy +
@@ -175,9 +175,9 @@ are the source of truth — Actions *call them* so local and CI never drift.
   `stable/*` / `releng/*` once Stage 2 branches exist. Both are cheap once the
   Linux gate is confirmed green on GitHub.
 
-### `release.yml` — build, sign, publish (on tag `v*`)
-- **Trigger:** `push: tags: ['v*']`. Detect `-beta`/`-rc` → mark GitHub Release
-  as *pre-release*.
+### `release.yml` — build, sign, publish (on tag `v*`) — **IMPLEMENTED**
+- **Trigger:** `push: tags: ['v*']`. Detect `-alpha`/`-beta`/`-rc` → mark GitHub
+  Release as *pre-release*.
 - **Build matrix** (calls the existing Makefile targets):
   - `macos-latest` → `make release-macos-universal` (arm64 + x86_64 lipo).
   - `ubuntu-latest` → `make release-linux-x86` + `release-linux-arm` (musl
@@ -194,6 +194,17 @@ are the source of truth — Actions *call them* so local and CI never drift.
   `SHA256SUMS`, signatures. Trigger `homebrew.yml`.
 - **Permissions:** `contents: write`, `id-token: write` (attestations),
   `attestations: write`.
+- **As built (deviations from the sketch above):** the `macos`/`linux` build
+  jobs run per-runner and call the platform Makefile targets directly (rather
+  than `make dist` / `make dist-checksums`, which build *all* platforms on one
+  host); a final `publish` job downloads the artifacts, computes `SHA256SUMS`,
+  and creates the release with `gh release create` (no third-party publish
+  action). Three platform tarballs ship (macOS universal counts once). Signing
+  is **keyless only** — build-provenance attestations + a cosign-signed
+  `SHA256SUMS.cosign.bundle`; GPG (`make dist-sign`), the Homebrew tap, and the
+  hand-written highlights block are fast-follows. Zig for the musl cross-links
+  comes from `mlugg/setup-zig`; `cargo-zigbuild` + `git-cliff` from
+  `taiki-e/install-action`.
 
 ### `snapshot.yml` — nightly CURRENT builds (schedule + manual)
 - `schedule` (nightly) + `workflow_dispatch`. Build `main` with the release


### PR DESCRIPTION
## Summary

Implements the release pipeline from `RELEASE_ENGINEERING.md §8`. On a `v*` tag push:

- **Build** (calls existing Makefile targets, per-runner):
  - `macos-latest` → `make release-macos-universal` (arm64 + x86_64 lipo)
  - `ubuntu-latest` → `make release-linux-x86` + `release-linux-arm` (static musl via cargo-zigbuild)
- **Publish job:** collect artifacts → `SHA256SUMS` → **keyless** signing (GitHub build-provenance attestations + cosign-signed checksums bundle, no secrets) → `gh release create` (pre-release for `-alpha`/`-beta`/`-rc`).
- Ships 3 tarballs (macOS universal counts once) + `SHA256SUMS` + `SHA256SUMS.cosign.bundle`.

Deferred fast-follows (per §13): GPG signing, Homebrew tap, cargo-binstall, nightly `snapshot.yml`.

## Notes

- **Dormant until a tag is pushed** — won't run on this PR or on merge to main. We dry-run it by tagging **v2.0.0-rc.1** once your 1.97.6 (L) change lands.
- **No version bump:** pure CI infra, and it avoids a merge-train collision with the in-flight 1.97.6.
- RELENG §8 updated to mark `release.yml` implemented + note the build's deviations from the original sketch.

## Test plan

- `release.yml` validated as well-formed YAML; all three referenced Makefile targets exist.
- Real end-to-end validation is the `v2.0.0-rc.1` dry-run (RELENG §12 step 10).

Generated with [Claude Code](https://claude.com/claude-code)