### PR TITLE
test(git): serialize worktree mutations under the parallel test runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4346,7 +4346,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "1.98.2"
+version = "1.98.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "1.98.2"
+version = "1.98.3"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -118,12 +118,35 @@ pub fn list(dir: &Path) -> Option<Vec<Worktree>> {
     }
 }
 
+/// Serialize worktree mutations across the whole test process.
+///
+/// gix acquires `<admin>/index.lock` and loose-ref locks with
+/// `Fail::Immediately` while building or tearing down a worktree. The parallel
+/// test runner starts many worktree-mutating tests at once, and on a loaded CI
+/// filesystem their lock lifecycles overlap enough that an acquire fails
+/// outright — an intermittent flake with no production analogue, since spyc
+/// drives worktree ops one at a time through its single update loop + the
+/// off-thread worktree worker. Holding this mutex for the whole mutation means
+/// at most one worktree is built or removed at a time under test,
+/// deterministically. Compiled out of release builds (`cfg(test)`), so
+/// production keeps its lock-free path plus the transient-contention retry in
+/// [`write_index_with_lock_retry`]. Poison is recovered so one panicking test
+/// can't wedge every other worktree test behind it.
+#[cfg(test)]
+fn serialize_worktree_mutation() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// Create a new worktree under a per-repo `<repo>.worktrees/` dir next to
 /// the working-tree root (`<repo_parent>/<repo>.worktrees/<branch>`): use an
 /// EXISTING branch `<branch>` if present, else create it at `base` (a ref/rev,
 /// typically the repo's default branch), or HEAD when `base` is `None`.
 /// Returns the new worktree's path.
 pub fn add(dir: &Path, branch: &str, base: Option<&str>) -> std::io::Result<PathBuf> {
+    #[cfg(test)]
+    let _serial = serialize_worktree_mutation();
     // `gix::discover` (not `gix::open`) so adding from a repo subdirectory
     // resolves the enclosing repo and anchors the new worktree on its root,
     // matching `git worktree add` from anywhere in the tree.
@@ -431,6 +454,8 @@ pub fn remove_force(path: &Path) -> std::io::Result<()> {
 }
 
 fn remove_inner(path: &Path, force_dirty: bool) -> std::io::Result<()> {
+    #[cfg(test)]
+    let _serial = serialize_worktree_mutation();
     // Resolve the admin dir from the worktree's `.git` gitfile.
     let admin_dir = admin_dir_of(path)?;
 
@@ -1068,6 +1093,38 @@ mod tests {
         assert!(
             !index_path.exists(),
             "index must not be written out under a held lock"
+        );
+    }
+
+    #[test]
+    fn worktree_mutations_are_serialized_under_test() {
+        // The cfg(test) mutex must give strict mutual exclusion so parallel
+        // worktree tests never overlap their gix lock lifecycles — the concurrency
+        // that produced the CI "could not acquire lock for index file" flake.
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let inside = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let handles: Vec<_> = (0..8)
+            .map(|_| {
+                let inside = Arc::clone(&inside);
+                let max_seen = Arc::clone(&max_seen);
+                std::thread::spawn(move || {
+                    let _serial = super::serialize_worktree_mutation();
+                    let now = inside.fetch_add(1, Ordering::SeqCst) + 1;
+                    max_seen.fetch_max(now, Ordering::SeqCst);
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                    inside.fetch_sub(1, Ordering::SeqCst);
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().expect("serialized worker joins");
+        }
+        assert_eq!(
+            max_seen.load(Ordering::SeqCst),
+            1,
+            "at most one worktree mutation may hold the serialization lock at a time"
         );
     }
 }


### PR DESCRIPTION
## What

Gate a process-global mutex (`cfg(test)`) inside `worktree::add` and `remove_inner` so at most one worktree is built or torn down at a time **under test**. Compiled out of release builds.

## Why

Worktree tests each isolate to their own tempdir, yet CI intermittently failed them with `"write index: Could not acquire lock for index file"`. gix acquires the index and loose-ref locks with `Fail::Immediately` (no wait), so under `cargo test`'s parallel runner — especially on a loaded CI filesystem — concurrent worktree builds' lock lifecycles overlap enough that an acquire fails outright. It's flaky, CI-only (not reproducible locally across 27+ full-suite runs), and hit a rotating cast of tests (`add_succeeds_after_a_prior_failed_attempt`, then `safe_remove_keeps_unmerged_branch` + `lock_claims…`).

This has **no production analogue** — spyc drives worktree operations one at a time through its single update loop + the off-thread worktree worker — so serializing only the tests removes concurrency that never happens in production. The complementary #117 `write_index_with_lock_retry` remains for genuine transient contention in real use.

## Testing

`make check` green — 1581 tests, incl. the new `worktree_mutations_are_serialized_under_test` (asserts strict mutual exclusion across 8 threads). clippy clean, cargo-deny ok.

Generated with [Claude Code](https://claude.com/claude-code)