### PR TITLE
chore(deps): migrate toml 0.8 → 1.1 (spec 1.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3562,7 +3562,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4172,11 +4172,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "1.98.5"
+version = "1.98.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -4756,23 +4756,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "serde_core",
  "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -4786,28 +4779,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -4816,14 +4795,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -5765,15 +5744,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
@@ -5964,7 +5934,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.3",
+ "winnow",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -5992,7 +5962,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow",
  "zvariant",
 ]
 
@@ -6080,7 +6050,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.3",
+ "winnow",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -6108,5 +6078,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "winnow 1.0.3",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "1.98.5"
+version = "1.98.6"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"
@@ -52,7 +52,7 @@ glob = "0.3"
 diffy = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
+toml = { version = "1", default-features = false, features = ["parse", "display", "serde"] }
 notify = { version = "6", default-features = false, features = ["macos_fsevent"] }
 portable-pty = "0.9"
 vt100 = "0.16"

--- a/tests/keymap_roundtrip.rs
+++ b/tests/keymap_roundtrip.rs
@@ -11,7 +11,10 @@ use tempfile::tempdir;
 
 /// Parse a `.spycrc.toml` file and verify the TOML structure is accepted.
 fn parse_toml(content: &str) -> toml::Value {
-    content.parse::<toml::Value>().expect("valid TOML")
+    // `toml::from_str` is the whole-DOCUMENT parser the config loader itself
+    // uses. (toml 1.1's `str::parse::<Value>` / `FromStr` parses a single
+    // VALUE, not a document, so it rejects a `key = ...` file outright.)
+    toml::from_str(content).expect("valid TOML")
 }
 
 #[test]


### PR DESCRIPTION
## What

Migrates the `toml` crate from 0.8.23 to 1.1.2 (TOML spec 1.1) — the bump Dependabot proposed in #107, done properly. Also trims the tree: toml 1.x drops `toml_edit`/`toml_datetime`/`toml_write` for a single `toml_writer` (net −27 lines of lockfile).

## The two real changes

1. **`serde` feature** — toml 1.x gates the dynamic `Value`/`Table` types and serde-based `from_str`/`to_string` behind a `serde` feature that 0.8 bundled implicitly. Added it to the existing `parse` + `display` set. The lib's `toml::from_str::<Value>` / `to_string_pretty` usage (mcp config/hooks, config loader) is otherwise **unchanged** — no production code edits.
2. **`FromStr for Value` semantics** — toml 1.1 changed `str::parse::<Value>()` to parse a single *value* rather than a whole *document*, so it now rejects a `key = …` file. The `keymap_roundtrip` integration test's helper switches from `content.parse::<toml::Value>()` to `toml::from_str(content)` — the document parser the config loader itself uses. Assertions unchanged.

## Testing

`make check` green — 1581 lib tests + the 5 `keymap_roundtrip` config-grammar tests (which caught the `FromStr` change), clippy clean, cargo-deny ok. Version → 1.98.6.

Closes the work deferred when #107 was closed.

Generated with [Claude Code](https://claude.com/claude-code)