### PR TITLE
chore(release): v2.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "1.98.8"
+version = "2.0.0-rc.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "1.98.8"
+version = "2.0.0-rc.1"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

First **release candidate** for the public **2.0.0** launch. Bumps `Cargo.toml` 1.98.8 → `2.0.0-rc.1`.

Once merged, I'll tag the merged commit `v2.0.0-rc.1` and push it — that fires `release.yml` for its **first real run**: build macOS-universal + Linux x86_64/aarch64 musl, sign (keyless attestations + cosign), and publish a GitHub **pre-release** with the 3 tarballs + `SHA256SUMS`.

No CHANGELOG prepend on the RC — the GitHub Release notes are git-cliff-generated at tag time; the curated CHANGELOG section lands with final `v2.0.0`.

## Test plan

- Version-only bump; CI (lint + tests) is the gate.
- The real end-to-end validation is the tag push firing `release.yml` (the pipeline dry-run, RELENG §12 step 10).

Generated with [Claude Code](https://claude.com/claude-code)