### PR TITLE
fix(ci): pin Zig 0.14.0 in release.yml; bump v2.0.0-rc.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # zig is cargo-zigbuild's cross-linker; the Makefile's musl targets shell
-      # out to `cargo zigbuild`.
+      # out to `cargo zigbuild`. Pin an explicit stable — the unpinned default
+      # resolves to an unreleased Zig (0.16.0) that 404s on every mirror.
       - uses: mlugg/setup-zig@v1
+        with:
+          version: 0.14.0
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-zigbuild

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.2"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

The `v2.0.0-rc.1` pipeline run ([28711198094](https://github.com/Tripstack-Corp/spyc/actions/runs/28711198094)) failed in **Build Linux musl**: `mlugg/setup-zig@v1` with no pinned version resolved to an **unreleased Zig 0.16.0** that 404s on every mirror + the official host.

- **Fix:** pin `version: 0.14.0` (a real stable `cargo-zigbuild` supports).
- **macOS-universal passed clean** on rc.1, so this is the only fix.
- Bump to `2.0.0-rc.2` and re-spin (avoids force-moving the rc.1 tag; matches RELENG §5 "re-tag -rc.2 as needed").

## Test plan

- Once merged, I tag `v2.0.0-rc.2` → the pipeline re-runs; expect all 3 jobs green and a published pre-release with signed artifacts.

Generated with [Claude Code](https://claude.com/claude-code)