### PR TITLE
chore(release): v2.0.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.2"
+version = "2.0.0-rc.3"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Third release candidate for 2.0.0. **Code-identical to rc.2** — cut solely to validate the Node-24 action bumps (#126) on a real pipeline run and confirm a warning-free release build before the final `v2.0.0`.

Once merged, I tag `v2.0.0-rc.3` → the pipeline runs with checkout@v7 / upload-artifact@v7 / download-artifact@v8 / setup-zig@v2 / attest-build-provenance@v4 / cosign-installer@v4. Expect all green + no Node-20 warnings + a published pre-release.

## Test plan

- Version-only bump; the tag run is the validation.

Generated with [Claude Code](https://claude.com/claude-code)