### PR TITLE
fix(ci): pin cosign-installer to v4.1.2; bump v2.0.0-rc.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,10 @@ jobs:
         with:
           subject-path: "dist/spyc-*.tar.gz"
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        # Pinned to an exact tag: sigstore/cosign-installer does NOT publish a
+        # moving `v4` major alias (only exact `v4.x.y`), so `@v4` fails to
+        # resolve. Dependabot bumps this as new versions ship.
+        uses: sigstore/cosign-installer@v4.1.2
       - name: Sign checksums (cosign keyless)
         run: |
           cd dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.3"
+version = "2.0.0-rc.4"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

rc.3 validated the Node-24 action bumps and **caught a publish-job regression**: `sigstore/cosign-installer` doesn't maintain a moving `v4` major tag (only exact `v4.x.y`), so `@v4` failed to resolve — the publish job errored at *Set up job*.

- **Fix:** pin `sigstore/cosign-installer@v4.1.2` (exact, resolves, still Node 24). Dependabot bumps it as new versions ship.
- The **macOS + Linux build jobs passed clean** on rc.3 with all the other bumps (checkout v7, upload-artifact v7, download-artifact v8, setup-zig v2, attest-build-provenance v4) — verified those major tags resolve. This is the only fix.
- Re-spin as `v2.0.0-rc.4`.

## Test plan

- Tag `v2.0.0-rc.4` after merge → expect all 3 jobs green (incl. publish) + a published pre-release with signed assets, zero warnings.

Generated with [Claude Code](https://claude.com/claude-code)