### PR TITLE
docs: install/build split + Homebrew and apt channels

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -1,0 +1,144 @@
+# Publish spyc's signed apt repository on a stable release.
+#
+# On a non-prerelease GitHub Release (or manual dispatch) this:
+#   1. downloads the release's Linux tarballs,
+#   2. builds .deb packages via the Makefile (`make deb-x86` / `deb-arm`),
+#   3. regenerates the flat apt index (apt-ftparchive) and GPG-signs `Release`,
+#   4. publishes the tree to `Tripstack-Corp/spyc-apt` (served via GitHub Pages
+#      at https://tripstack-corp.github.io/spyc-apt), keeping older versions.
+#
+# Users then: `apt install spyc` (see INSTALL.md). RELEASE_ENGINEERING.md §8
+# has the one-time operator setup (create spyc-apt, enable Pages, add secrets).
+#
+# The publish job SELF-SKIPS when its secrets are absent, so this stays green
+# until that setup is done. Prereleases are skipped so package versions stay a
+# clean `X.Y.Z` (apt orders `~rc` before the final; we sidestep it entirely).
+name: apt
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v2.0.0)"
+        required: true
+
+concurrency:
+  group: apt-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build .debs + publish signed apt repo
+    # Skip prereleases; manual dispatch always runs.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
+    runs-on: ubuntu-latest
+    env:
+      APT_REPO_TOKEN: ${{ secrets.APT_REPO_TOKEN }}
+      APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
+      APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Gate on secrets (self-skip until configured)
+        id: guard
+        run: |
+          if [ -z "$APT_REPO_TOKEN" ] || [ -z "$APT_GPG_PRIVATE_KEY" ]; then
+            echo "::notice::apt secrets not configured — skipping publish"
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve tag + version
+        if: steps.guard.outputs.enabled == 'true'
+        id: ver
+        run: |
+          TAG="${{ github.event.release.tag_name || inputs.tag }}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout spyc (for the Makefile)
+        if: steps.guard.outputs.enabled == 'true'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.ver.outputs.tag }}
+
+      - name: Install apt tooling
+        if: steps.guard.outputs.enabled == 'true'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends dpkg-dev apt-utils gnupg
+
+      - name: Download release Linux tarballs
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          gh release download "${{ steps.ver.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern 'spyc-*-linux-*.tar.gz'
+
+      - name: Unpack binaries into the paths the Makefile expects
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p target/x86_64-unknown-linux-musl/release \
+                   target/aarch64-unknown-linux-musl/release
+          tar xzf spyc-*-linux-x86_64.tar.gz spyc
+          mv spyc target/x86_64-unknown-linux-musl/release/spyc
+          tar xzf spyc-*-linux-aarch64.tar.gz spyc
+          mv spyc target/aarch64-unknown-linux-musl/release/spyc
+
+      - name: Build .debs
+        if: steps.guard.outputs.enabled == 'true'
+        run: make deb VERSION="${{ steps.ver.outputs.version }}"
+
+      - name: Import GPG signing key
+        if: steps.guard.outputs.enabled == 'true'
+        id: gpg
+        run: |
+          echo "$APT_GPG_PRIVATE_KEY" | gpg --batch --import
+          KEYID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+          echo "keyid=$KEYID" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout the apt repo (spyc-apt)
+        if: steps.guard.outputs.enabled == 'true'
+        uses: actions/checkout@v7
+        with:
+          repository: Tripstack-Corp/spyc-apt
+          token: ${{ env.APT_REPO_TOKEN }}
+          path: aptrepo
+
+      - name: Regenerate + sign the flat apt index
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          cp dist/spyc_*.deb aptrepo/
+          cd aptrepo
+          apt-ftparchive packages . > Packages
+          gzip -kf Packages
+          apt-ftparchive \
+            -o APT::FTPArchive::Release::Origin=spyc \
+            -o APT::FTPArchive::Release::Label=spyc \
+            -o APT::FTPArchive::Release::Suite=stable \
+            -o APT::FTPArchive::Release::Architectures="amd64 arm64" \
+            -o APT::FTPArchive::Release::Components=main \
+            release . > Release
+          rm -f InRelease Release.gpg
+          gpg --batch --yes --pinentry-mode loopback --passphrase "$APT_GPG_PASSPHRASE" \
+            --local-user "${{ steps.gpg.outputs.keyid }}" --clearsign -o InRelease Release
+          gpg --batch --yes --pinentry-mode loopback --passphrase "$APT_GPG_PASSPHRASE" \
+            --local-user "${{ steps.gpg.outputs.keyid }}" -abs -o Release.gpg Release
+          gpg --armor --export "${{ steps.gpg.outputs.keyid }}" > KEY.gpg
+          # GitHub Pages skips files/dirs starting with '_' and needs no Jekyll.
+          touch .nojekyll
+
+      - name: Commit + push to spyc-apt
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          cd aptrepo
+          git config user.name "spyc-release-bot"
+          git config user.email "noreply@tripstack.com"
+          git add -A
+          git commit -m "apt: publish spyc ${{ steps.ver.outputs.version }}" || {
+            echo "nothing to publish"; exit 0;
+          }
+          git push

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,120 @@
+# Building spyc from source
+
+Most users don't need this — install a pre-built binary with Homebrew,
+`apt`, or a Release tarball (see [INSTALL.md](INSTALL.md)). Build from
+source if you want to hack on spyc, run the tip of `main`, or target a
+platform we don't ship binaries for.
+
+For the contributor workflow (branching, the quality gate, commit
+conventions), see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Rust toolchain
+
+spyc is written in Rust. Install the toolchain via rustup:
+
+```sh
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Minimum supported Rust version: **1.88** (for `if let` chains).
+
+The repo pins an exact toolchain in `rust-toolchain.toml` (currently
+**1.96.0**), so rustup auto-installs and selects it on first build —
+no manual `rustup default` needed. Bump that file to move the project
+to a newer release.
+
+## Build and install
+
+```sh
+git clone https://github.com/Tripstack-Corp/spyc.git
+cd spyc
+make install          # builds release + copies to ~/.local/bin (no sudo)
+```
+
+Make sure `~/.local/bin` is on your `PATH`. Most Linux distros include
+it by default; on macOS add this to `~/.zshrc` (or `~/.bash_profile`):
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+To install system-wide instead, override `PREFIX` and use sudo:
+
+```sh
+sudo make install PREFIX=/usr/local
+```
+
+Or build and copy manually:
+
+```sh
+cargo build --release
+install -m 755 target/release/spyc ~/.local/bin/
+```
+
+`make doctor` checks that the toolchain and cross-compile prerequisites
+are present before you start.
+
+## Development build
+
+For iterating on the code, a debug build is faster:
+
+```sh
+make            # or: cargo build     — debug build
+make run        # cargo run
+make check      # fmt + clippy + test + deny (the CI gate)
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full quality gate,
+`make lint-linux` for OS-gated code, and the code conventions.
+
+## Cross-compilation
+
+To build for a platform other than your own — or to reproduce the
+release artifacts locally — you need a cross-linker. spyc uses Zig via
+`cargo-zigbuild`:
+
+```sh
+brew install zig
+cargo install cargo-zigbuild
+rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
+rustup target add x86_64-apple-darwin aarch64-apple-darwin
+```
+
+Then use the Makefile targets:
+
+```sh
+make dist                    # all platforms → dist/
+make release-macos-universal # macOS universal (arm64 + x86_64)
+make release-linux-x86       # Linux x86_64 (static, musl)
+make release-linux-arm       # Linux aarch64 (static, musl)
+make dist-checksums          # SHA-256 over the dist/ artifacts
+make dist-sign               # GPG-sign the checksums (set GPG_KEY=<id>)
+```
+
+Linux binaries are statically linked against musl, so they run on any
+distro without a libc dependency.
+
+## Debian package
+
+`make deb` wraps a built Linux binary into a `.deb` (requires
+`dpkg-deb`, so run it on Linux or `brew install dpkg` on macOS). Build
+the target binary first, then package it:
+
+```sh
+make release-linux-x86 && make deb-x86    # → dist/spyc_<version>_amd64.deb
+make release-linux-arm && make deb-arm    # → dist/spyc_<version>_arm64.deb
+make deb                                  # both (binaries must already exist)
+```
+
+These are the same packages the release pipeline publishes to the
+`apt` repository — see
+[docs/RELEASE_ENGINEERING.md](docs/RELEASE_ENGINEERING.md) for how the
+hosted apt repo is built and signed.
+
+## Crate shape
+
+spyc is a **lib + bin** crate: `src/lib.rs` owns every module and the
+`run()` entry point; `src/main.rs` is a thin shim. The split lets
+`fuzz/` (a standalone nightly workspace) link the library. New fuzz
+entry points go through the `pub mod fuzz` facade in `lib.rs` rather
+than widening module visibility.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,9 @@ cargo build    # dev build
 cargo test     # run all tests
 ```
 
-See `INSTALL.md` for font and terminal setup.
+See [BUILD.md](BUILD.md) for the full toolchain, build, and
+cross-compilation reference, and [INSTALL.md](INSTALL.md) for terminal
+and font setup.
 
 ## Pull request workflow
 
@@ -204,12 +206,12 @@ your local `make check`.
 ```sh
 make doctor           # verify toolchain
 make release          # current platform
-make deploy-fika      # Linux x86_64 → fika-vm
 make dist             # all platforms → dist/
 ```
 
 The Makefile touches `src/main.rs` before zigbuild to avoid stale
-cross-compile caches.
+cross-compile caches. See [BUILD.md](BUILD.md) for the full set of
+cross-compile and packaging targets (`.deb`, checksums, signing).
 
 ## Project structure
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.5"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,84 @@
 # Installing spyc
 
+Pre-built, signed binaries are the easy path — Homebrew, `apt`, or a
+Release tarball, no Rust toolchain required. To compile spyc yourself
+(to hack on it or run unreleased changes), see [BUILD.md](BUILD.md).
+
+## Install
+
+### Homebrew (macOS and Linux)
+
+```sh
+brew install Tripstack-Corp/tap/spyc
+```
+
+Installs the latest signed release for your platform (macOS universal,
+Linux x86_64 / aarch64) and upgrades with `brew upgrade spyc`. Homebrew
+works on Linux too (Linuxbrew), if you'd rather not use `apt`. To build
+the tip of `main` from source through the tap instead:
+
+```sh
+brew install --HEAD Tripstack-Corp/tap/spyc
+```
+
+### Debian / Ubuntu (apt)
+
+spyc publishes a signed apt repository. Add it once, then install and
+upgrade through your package manager like any other package:
+
+```sh
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://tripstack-corp.github.io/spyc-apt/KEY.gpg \
+  | sudo tee /etc/apt/keyrings/spyc.asc >/dev/null
+echo "deb [signed-by=/etc/apt/keyrings/spyc.asc] https://tripstack-corp.github.io/spyc-apt ./" \
+  | sudo tee /etc/apt/sources.list.d/spyc.list >/dev/null
+sudo apt update
+sudo apt install spyc
+```
+
+`sudo apt upgrade` picks up new releases from then on. Both `amd64` and
+`arm64` are published.
+
+### Pre-built binary (any platform)
+
+Download a tarball from the
+[Releases page](https://github.com/Tripstack-Corp/spyc/releases), verify
+it, and put the binary on your `PATH`:
+
+```sh
+# pick the asset for your platform:
+#   spyc-<tag>-macos-universal.tar.gz   arm64 + x86_64
+#   spyc-<tag>-linux-x86_64.tar.gz      static, musl
+#   spyc-<tag>-linux-aarch64.tar.gz     static, musl
+tar xzf spyc-<tag>-<platform>.tar.gz
+install -m 755 spyc ~/.local/bin/
+```
+
+Every release ships a `SHA256SUMS` file plus keyless signatures — verify
+before installing:
+
+```sh
+sha256sum -c SHA256SUMS --ignore-missing        # checksum
+gh attestation verify spyc-<tag>-<platform>.tar.gz --repo Tripstack-Corp/spyc
+cosign verify-blob SHA256SUMS \
+  --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/Tripstack-Corp/spyc/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Make sure `~/.local/bin` is on your `PATH` (see below).
+
+### Build from source
+
+To compile spyc yourself — to hack on it or run unreleased changes —
+see **[BUILD.md](BUILD.md)** for the Rust toolchain, `make install`, and
+cross-compilation. Make sure `~/.local/bin` is on your `PATH`; on macOS
+add this to `~/.zshrc` (or `~/.bash_profile`):
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+```
+
 ## Terminal
 
 spyc is designed for modern terminals with true-color (24-bit) and
@@ -46,49 +125,6 @@ If you don't install a Nerd Font, spyc still works — the powerline
 separators will render as missing-glyph boxes. Toggle to mono mode
 with **C** for a plain-text fallback that uses no special glyphs.
 
-## Rust toolchain
-
-spyc is written in Rust. Install the toolchain via rustup:
-
-```sh
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
-Minimum supported Rust version: **1.88** (for `if let` chains).
-
-The repo pins an exact toolchain in `rust-toolchain.toml` (currently
-**1.96.0**), so rustup auto-installs and selects it on first build —
-no manual `rustup default` needed. Bump that file to move the project
-to a newer release.
-
-## Build and install
-
-```sh
-git clone https://github.com/Tripstack-Corp/spyc.git
-cd spyc
-make install          # builds release + copies to ~/.local/bin (no sudo)
-```
-
-Make sure `~/.local/bin` is on your `PATH`. Most Linux distros include
-it by default; on macOS add this to `~/.zshrc` (or `~/.bash_profile`):
-
-```sh
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-To install system-wide instead, override `PREFIX` and use sudo:
-
-```sh
-sudo make install PREFIX=/usr/local
-```
-
-Or build and copy manually:
-
-```sh
-cargo build --release
-install -m 755 target/release/spyc ~/.local/bin/
-```
-
 ## Clipboard helper (Linux only)
 
 The yank-to-clipboard features (`yf`, `yp`, `yP`, `ya`, and pager-side
@@ -103,28 +139,6 @@ spyc auto-detects the session — `wl-copy` when `$WAYLAND_DISPLAY` is
 set, otherwise `xclip` → `xsel`. With none installed, yanks flash
 `yank failed: no clipboard helper available — install xclip, xsel,
 or wl-copy`.
-
-## Cross-compilation (optional)
-
-To build for Linux or create a macOS universal binary, you'll need a
-few extra tools:
-
-```sh
-brew install zig
-cargo install cargo-zigbuild
-rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
-rustup target add x86_64-apple-darwin aarch64-apple-darwin
-```
-
-Then use the Makefile targets:
-
-```sh
-make dist                    # all platforms → dist/
-make release-macos-universal # macOS universal (arm64 + x86_64)
-make release-linux-x86       # Linux x86_64 (static, musl)
-make release-linux-arm       # Linux aarch64 (static, musl)
-make deploy-fika             # scp to a remote host
-```
 
 ## Claude Code (pane default)
 

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ release-macos-universal: release-macos-arm release-macos-x86 ## macOS Universal 
 
 # `ulimit -n 8192`: zig's linker opens an fd per object file (250+ for spyc),
 # so the final link dies with `ProcessFdQuotaExceeded` under macOS's 256-fd
-# default soft limit — which bites when `make deploy-fika` is invoked from a
+# default soft limit — which bites when a musl build is invoked from a
 # context that didn't raise it (e.g. spyc's own `!` shell). Raise it on the
 # same shell line as the build so it applies to that subshell.
 .PHONY: release-linux-x86
@@ -250,6 +250,45 @@ dist-sign: dist-checksums ## GPG-sign the checksums file (set GPG_KEY=<id> to ch
 		gpg --detach-sign --armor $(if $(GPG_KEY),--local-user $(GPG_KEY),) checksums-sha256.txt
 	@echo "✓ signature written to $(DIST_DIR)/checksums-sha256.txt.asc"
 
+# ---------- Debian packages --------------------------------------------------
+
+# Wrap an already-built static-musl binary in a .deb. `dpkg-deb` is Linux-only
+# (on macOS: `brew install dpkg`). Build the target binary first
+# (`make release-linux-x86` / `release-linux-arm`) — these targets PACKAGE an
+# existing binary rather than rebuild, so the release pipeline reuses the
+# artifacts it already produced. Output → dist/spyc_<version>_<arch>.deb.
+DEB_MAINTAINER ?= Derek Marshall <derek.marshall@tripstack.com>
+
+.PHONY: deb-x86
+deb-x86: ## Package the built Linux x86_64 binary → dist/spyc_<version>_amd64.deb
+	@$(MAKE) --no-print-directory _deb ARCH=amd64 \
+		SRC=target/x86_64-unknown-linux-musl/release/$(BINARY)
+
+.PHONY: deb-arm
+deb-arm: ## Package the built Linux aarch64 binary → dist/spyc_<version>_arm64.deb
+	@$(MAKE) --no-print-directory _deb ARCH=arm64 \
+		SRC=target/aarch64-unknown-linux-musl/release/$(BINARY)
+
+.PHONY: deb
+deb: deb-x86 deb-arm ## Package both Linux .debs (binaries must already be built)
+
+# Internal: build one .deb from $(SRC) for $(ARCH). Fails clearly if the binary
+# is missing — build it with the matching release-linux-* target first.
+.PHONY: _deb
+_deb:
+	@command -v dpkg-deb >/dev/null 2>&1 || { echo "dpkg-deb not found (Linux, or 'brew install dpkg')"; exit 1; }
+	@test -f "$(SRC)" || { echo "missing $(SRC) — run the matching 'make release-linux-*' first"; exit 1; }
+	@rm -rf "$(DIST_DIR)/deb-$(ARCH)"
+	@mkdir -p "$(DIST_DIR)/deb-$(ARCH)/DEBIAN" "$(DIST_DIR)/deb-$(ARCH)/usr/bin"
+	@install -m 0755 "$(SRC)" "$(DIST_DIR)/deb-$(ARCH)/usr/bin/$(BINARY)"
+	@printf 'Package: %s\nVersion: %s\nArchitecture: %s\nMaintainer: %s\nSection: utils\nPriority: optional\nHomepage: https://github.com/Tripstack-Corp/spyc\nDescription: Keyboard-driven, MCP-native terminal file commander\n' \
+		"$(BINARY)" "$(VERSION)" "$(ARCH)" "$(DEB_MAINTAINER)" \
+		> "$(DIST_DIR)/deb-$(ARCH)/DEBIAN/control"
+	dpkg-deb --build --root-owner-group "$(DIST_DIR)/deb-$(ARCH)" \
+		"$(DIST_DIR)/$(BINARY)_$(VERSION)_$(ARCH).deb"
+	@rm -rf "$(DIST_DIR)/deb-$(ARCH)"
+	@ls -lh "$(DIST_DIR)/$(BINARY)_$(VERSION)_$(ARCH).deb"
+
 # ---------- Install ----------------------------------------------------------
 
 PREFIX ?= $(HOME)/.local
@@ -294,15 +333,6 @@ install-hooks: ## Install pre-commit hook (runs `make check` before each commit)
 	@install -m 755 scripts/git-hooks/pre-commit .git/hooks/pre-commit
 	@echo "✓ installed .git/hooks/pre-commit — runs 'make check' on each commit"
 	@echo "  bypass with 'git commit --no-verify' (don't make a habit)"
-
-# --- Remote deploy ---
-
-FIKA_HOST := drek@10.130.1.36
-
-.PHONY: deploy-fika
-deploy-fika: release-linux-x86 ## Build Linux x86_64 and scp to fika-vm
-	scp target/x86_64-unknown-linux-musl/release/$(BINARY) $(FIKA_HOST):~/bin/$(BINARY)
-	@echo "deployed: $(FIKA_HOST):~/bin/$(BINARY)"
 
 # ---------- Doctor (preflight checks) ----------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ coding agents.
 
 ### Prerequisites
 
-- **Rust** 1.88+ -- `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 - **Nerd Font** recommended for the powerline status bar; press `C`
   inside spyc to toggle a mono fallback if you don't have one.
   Install one with: `brew install --cask font-meslo-lg-nerd-font`
@@ -95,14 +94,27 @@ coding agents.
   `ya`, pager yanks) needs `wl-copy` (Wayland) or `xclip` / `xsel`
   (X11). macOS uses the built-in `pbcopy`. See
   [INSTALL.md](INSTALL.md#clipboard-helper-linux-only) for details.
+- **Rust** 1.88+ -- only if you build from source (see [BUILD.md](BUILD.md)).
 
 ### Install
 
+Pre-built, signed binaries — no Rust toolchain needed:
+
 ```sh
-git clone https://github.com/Tripstack-Corp/spyc.git
-cd spyc
-make install          # builds release + copies to ~/.local/bin (no sudo)
+# macOS & Linux — Homebrew
+brew install Tripstack-Corp/tap/spyc
+
+# Debian / Ubuntu — apt (signed repo)
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://tripstack-corp.github.io/spyc-apt/KEY.gpg | sudo tee /etc/apt/keyrings/spyc.asc >/dev/null
+echo "deb [signed-by=/etc/apt/keyrings/spyc.asc] https://tripstack-corp.github.io/spyc-apt ./" | sudo tee /etc/apt/sources.list.d/spyc.list >/dev/null
+sudo apt update && sudo apt install spyc
 ```
+
+Or grab a tarball from
+[Releases](https://github.com/Tripstack-Corp/spyc/releases). To **build
+from source** instead, see [BUILD.md](BUILD.md). Full setup — terminal,
+font, clipboard, MCP, and verification — is in [INSTALL.md](INSTALL.md).
 
 ### Launch
 
@@ -491,7 +503,8 @@ See [INSTALL.md](INSTALL.md) for detailed setup instructions.
 
 - [FEATURES.md](FEATURES.md) -- complete feature reference
 - [CONFIGURATION.md](CONFIGURATION.md) -- config reference: `.spycrc.toml`, notifications, keymap DSL, Lua
-- [INSTALL.md](INSTALL.md) -- terminal, font, build, and cross-compilation setup
+- [INSTALL.md](INSTALL.md) -- install (Homebrew, apt, binary), terminal, font, clipboard, and MCP setup
+- [BUILD.md](BUILD.md) -- build from source: Rust toolchain, `make install`, cross-compilation
 - [ARCHITECTURE.md](ARCHITECTURE.md) -- concurrency model, MVU target shape, persistence, MCP transport
 - [docs/AGENT_ORCHESTRATION.md](docs/AGENT_ORCHESTRATION.md) -- how the activity dots, notifications, session-resume, and scope registry fit together
 - [DESIGN.md](DESIGN.md) -- UI design language: components, surfaces, palette, extension checklist

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -156,11 +156,13 @@ are the source of truth — Actions *call them* so local and CI never drift.
 
 > **Dev-platform: RESOLVED (2026-07-02) — full move to GitHub.** All dev + CI run
 > on GitHub Actions; `bitbucket-pipelines.yml` is retired (archived under
-> `docs/archive/`). **`ci.yml` and `audit.yml` are implemented** — direct ports
-> of the retired pipeline, and **`release.yml` is implemented** (keyless signing,
-> no secrets). `snapshot.yml` and `homebrew.yml` remain to build; they gate on
-> the remaining distribution decisions (the Homebrew tap, nightly cadence), so
-> they land with that work.
+> `docs/archive/`). **`ci.yml`, `audit.yml`, and `release.yml` are implemented**
+> (the last with keyless signing, no secrets). The **Homebrew tap is live** —
+> `Tripstack-Corp/homebrew-tap` carries a `Formula/spyc.rb` that installs the
+> signed release tarballs (macOS universal + Linux x86_64/aarch64) and supports
+> `--HEAD` source builds. **`apt.yml` is implemented** — it builds `.deb`
+> packages and publishes a signed apt repository to GitHub Pages (see below).
+> `snapshot.yml` (nightly cadence) remains to build.
 
 ### `ci.yml` — quality gate (PR + push to `main`) — **IMPLEMENTED**
 - Direct port of the retired `bitbucket-pipelines.yml`: `lint` (fmt + clippy +
@@ -218,14 +220,39 @@ are the source of truth — Actions *call them* so local and CI never drift.
   retired Bitbucket `weekly-deps` pipeline. The old Bitbucket→Slack failure
   notification does *not* carry over — add a GitHub-issue/Slack step if wanted.
 
-### `homebrew.yml` — tap bump (on release published)
-- On a non-prerelease publish, compute the new artifacts' SHAs and open a PR (or
-  push) to `Tripstack-Corp/homebrew-tap` updating the `spyc` formula/cask.
-  Needs a `HOMEBREW_TAP_TOKEN` secret.
+### `homebrew.yml` — tap bump (on release published) — **TAP LIVE**
+- `Tripstack-Corp/homebrew-tap` is live with `Formula/spyc.rb` (pins the release
+  version, its per-platform tarball URLs + SHA256s, and a `--HEAD` source build).
+  On a non-prerelease publish this workflow recomputes the SHAs and pushes the
+  formula bump. Needs a `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT with
+  `contents:write` on the tap repo).
+
+### `apt.yml` — signed apt repo publish (on release published) — **IMPLEMENTED**
+- On a non-prerelease publish: download the release's Linux tarballs, build
+  `.deb`s (`make deb-x86` / `deb-arm`), regenerate the apt index
+  (`apt-ftparchive`), sign the `Release` file with the repo GPG key, and publish
+  the tree to `Tripstack-Corp/spyc-apt`'s GitHub Pages site
+  (`https://tripstack-corp.github.io/spyc-apt`) so users can `apt install spyc` /
+  `apt upgrade`. The publish job self-skips when its secrets are absent, so it
+  stays green until the operator setup below is done.
+- **Operator setup (one-time):**
+  1. Create the public repo `Tripstack-Corp/spyc-apt` and enable **GitHub Pages**
+     serving from its default branch, `/` root (the workflow commits the repo
+     tree straight to that branch).
+  2. Generate a dedicated signing key (`gpg --quick-gen-key "spyc apt <email>"`);
+     export the ASCII-armored private key + note its passphrase.
+  3. On the **spyc** repo add secrets: `APT_GPG_PRIVATE_KEY`, `APT_GPG_PASSPHRASE`,
+     and `APT_REPO_TOKEN` (fine-grained PAT, `contents:write` on `spyc-apt`).
+  4. The workflow publishes the ASCII-armored public key as `KEY.gpg` at the repo
+     root — it's what users pin via `signed-by`.
+- **Prerelease note:** publishing is gated to non-prerelease tags so package
+  versions stay clean `X.Y.Z` (a `2.0.0~rc.4`-style `~` epoch would otherwise be
+  needed for correct apt ordering).
 
 **Cross-cutting:** `concurrency` groups to cancel superseded runs (already wired
-in `ci.yml`); secrets = `GPG_KEY`/`GPG_PASSPHRASE` (if GPG signing) and
-`HOMEBREW_TAP_TOKEN`; cosign uses OIDC (no stored key).
+in `ci.yml`); secrets = `GPG_KEY`/`GPG_PASSPHRASE` (if GPG signing),
+`HOMEBREW_TAP_TOKEN`, and the apt trio (`APT_GPG_PRIVATE_KEY`,
+`APT_GPG_PASSPHRASE`, `APT_REPO_TOKEN`); cosign uses OIDC (no stored key).
 
 ## 9. Artifacts, signing & distribution
 
@@ -250,15 +277,14 @@ in `ci.yml`); secrets = `GPG_KEY`/`GPG_PASSPHRASE` (if GPG signing) and
 
 **Distribution channels:**
 - **GitHub Releases** — primary; the binaries + checksums + signatures live here.
-- **Homebrew tap** — `brew install Tripstack-Corp/tap/spyc` (the backlog already
-  flags "investigate a brew tap"). `homebrew.yml` keeps it current.
+- **Homebrew tap** — `brew install Tripstack-Corp/tap/spyc` (**live**; works on
+  macOS and Linux/Linuxbrew). `homebrew.yml` keeps the formula current.
+- **apt repository** — `apt install spyc` on Debian/Ubuntu from the signed
+  GitHub-Pages repo (`apt.yml`; amd64 + arm64).
 - **`cargo-binstall`** — add the `[package.metadata.binstall]` hints to
   `Cargo.toml` so `cargo binstall spyc` pulls the GitHub artifact (no compile).
 - **crates.io** — optional `cargo install spyc` (§13.5); reserve the name
   regardless.
-- **Install script** — an optional `curl --proto '=https' -sSf <url> | sh`
-  bootstrap (detect OS/arch → fetch the matching release asset → verify checksum
-  → drop in `~/.local/bin`), hosted in-repo. FreeBSD-ish "one command" install.
 
 ## 10. GitHub org & repo presentation (Tripstack-Corp)
 


### PR DESCRIPTION
## Summary
- Split build-from-source out of `INSTALL.md` into a new **`BUILD.md`**; `INSTALL.md` is now the install umbrella (Homebrew, apt, pre-built binary, source pointer).
- `README.md` install section leads with **Homebrew** + **apt** (no Rust toolchain needed), points to `BUILD.md` for source and `INSTALL.md` for full setup; Rust demoted to a source-only prerequisite.
- `CONTRIBUTING.md` points at `BUILD.md`; removed the internal **`deploy-fika`** Makefile target (+ `FIKA_HOST`).
- **apt support (hosted signed repo):** new `make deb`/`deb-x86`/`deb-arm` targets (dpkg-deb) + `.github/workflows/apt.yml` that builds `.debs` from the release tarballs, signs a flat apt index, and publishes to the `spyc-apt` GitHub Pages repo. Self-skips until secrets exist; non-prerelease only.
- `RELEASE_ENGINEERING.md` de-staled (Homebrew tap is live) + apt operator setup documented.
- Bump `2.0.0-rc.5`.

## Owner steps before `apt install spyc` serves
1. Create public repo `Tripstack-Corp/spyc-apt`, enable Pages (default branch, `/` root).
2. Add secrets on this repo: `APT_GPG_PRIVATE_KEY`, `APT_GPG_PASSPHRASE`, `APT_REPO_TOKEN`.
3. First non-prerelease tag (or manual `apt` dispatch) populates it.

## Test plan
- Docs render on GitHub; all `BUILD.md`/`INSTALL.md` cross-links resolve.
- `make -n deb-x86` parses; `deploy-fika` target removed.
- `apt.yml` + `release.yml` YAML validated.
- **Linux:** `make release-linux-x86 && make deb-x86` produces an installable `dist/spyc_<ver>_amd64.deb`.

Generated with [Claude Code](https://claude.com/claude-code)