### PR TITLE
ci: publish apt repo to gh-pages (org-owned GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -2,16 +2,19 @@
 #
 # On a non-prerelease GitHub Release (or manual dispatch) this:
 #   1. downloads the release's Linux tarballs,
-#   2. builds .deb packages via the Makefile (`make deb-x86` / `deb-arm`),
+#   2. builds .deb packages via the Makefile (`make deb`),
 #   3. regenerates the flat apt index (apt-ftparchive) and GPG-signs `Release`,
-#   4. publishes the tree to `Tripstack-Corp/spyc-apt` (served via GitHub Pages
-#      at https://tripstack-corp.github.io/spyc-apt), keeping older versions.
+#   4. commits the tree to THIS repo's `gh-pages` branch, served via GitHub
+#      Pages at https://tripstack-corp.github.io/spyc (keeping older versions).
 #
-# Users then: `apt install spyc` (see INSTALL.md). RELEASE_ENGINEERING.md §8
-# has the one-time operator setup (create spyc-apt, enable Pages, add secrets).
+# Users then: `apt install spyc` (see INSTALL.md). The apt repo lives on this
+# repo's own gh-pages branch, so the push uses no personal token — the built-in,
+# org-owned GITHUB_TOKEN (contents:write) publishes it.
 #
-# The publish job SELF-SKIPS when its secrets are absent, so this stays green
-# until that setup is done. Prereleases are skipped so package versions stay a
+# The signing key lives in the `apt-publish` protected Environment (only this
+# job, on a `v*` tag or `main`, can read it); operator setup is in
+# RELEASE_ENGINEERING.md §8. The job self-skips when the key is absent, so it
+# stays green until then. Prereleases are skipped so package versions stay a
 # clean `X.Y.Z` (apt orders `~rc` before the final; we sidestep it entirely).
 name: apt
 
@@ -28,23 +31,27 @@ concurrency:
   group: apt-publish
   cancel-in-progress: false
 
+permissions:
+  contents: write # push the apt index to the gh-pages branch
+
 jobs:
   publish:
     name: Build .debs + publish signed apt repo
     # Skip prereleases; manual dispatch always runs.
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
+    # Scopes the signing-key secrets to this job (and to `v*` / `main` refs).
+    environment: apt-publish
     env:
-      APT_REPO_TOKEN: ${{ secrets.APT_REPO_TOKEN }}
       APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
       APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Gate on secrets (self-skip until configured)
+      - name: Gate on signing key (self-skip until configured)
         id: guard
         run: |
-          if [ -z "$APT_REPO_TOKEN" ] || [ -z "$APT_GPG_PRIVATE_KEY" ]; then
-            echo "::notice::apt secrets not configured — skipping publish"
+          if [ -z "$APT_GPG_PRIVATE_KEY" ]; then
+            echo "::notice::apt signing key not configured — skipping publish"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=true" >> "$GITHUB_OUTPUT"
@@ -98,12 +105,11 @@ jobs:
           KEYID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
           echo "keyid=$KEYID" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout the apt repo (spyc-apt)
+      - name: Checkout the gh-pages branch (the apt repo)
         if: steps.guard.outputs.enabled == 'true'
         uses: actions/checkout@v7
         with:
-          repository: Tripstack-Corp/spyc-apt
-          token: ${{ env.APT_REPO_TOKEN }}
+          ref: gh-pages
           path: aptrepo
 
       - name: Regenerate + sign the flat apt index
@@ -130,7 +136,7 @@ jobs:
           # GitHub Pages skips files/dirs starting with '_' and needs no Jekyll.
           touch .nojekyll
 
-      - name: Commit + push to spyc-apt
+      - name: Commit + push to gh-pages
         if: steps.guard.outputs.enabled == 'true'
         run: |
           set -euo pipefail
@@ -141,4 +147,4 @@ jobs:
           git commit -m "apt: publish spyc ${{ steps.ver.outputs.version }}" || {
             echo "nothing to publish"; exit 0;
           }
-          git push
+          git push origin gh-pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.5"
+version = "2.0.0-rc.6"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,9 +28,9 @@ upgrade through your package manager like any other package:
 
 ```sh
 sudo install -d -m 0755 /etc/apt/keyrings
-curl -fsSL https://tripstack-corp.github.io/spyc-apt/KEY.gpg \
+curl -fsSL https://tripstack-corp.github.io/spyc/KEY.gpg \
   | sudo tee /etc/apt/keyrings/spyc.asc >/dev/null
-echo "deb [signed-by=/etc/apt/keyrings/spyc.asc] https://tripstack-corp.github.io/spyc-apt ./" \
+echo "deb [signed-by=/etc/apt/keyrings/spyc.asc] https://tripstack-corp.github.io/spyc ./" \
   | sudo tee /etc/apt/sources.list.d/spyc.list >/dev/null
 sudo apt update
 sudo apt install spyc

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ brew install Tripstack-Corp/tap/spyc
 
 # Debian / Ubuntu — apt (signed repo)
 sudo install -d -m 0755 /etc/apt/keyrings
-curl -fsSL https://tripstack-corp.github.io/spyc-apt/KEY.gpg | sudo tee /etc/apt/keyrings/spyc.asc >/dev/null
-echo "deb [signed-by=/etc/apt/keyrings/spyc.asc] https://tripstack-corp.github.io/spyc-apt ./" | sudo tee /etc/apt/sources.list.d/spyc.list >/dev/null
+curl -fsSL https://tripstack-corp.github.io/spyc/KEY.gpg | sudo tee /etc/apt/keyrings/spyc.asc >/dev/null
+echo "deb [signed-by=/etc/apt/keyrings/spyc.asc] https://tripstack-corp.github.io/spyc ./" | sudo tee /etc/apt/sources.list.d/spyc.list >/dev/null
 sudo apt update && sudo apt install spyc
 ```
 

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -227,32 +227,35 @@ are the source of truth — Actions *call them* so local and CI never drift.
   formula bump. Needs a `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT with
   `contents:write` on the tap repo).
 
-### `apt.yml` — signed apt repo publish (on release published) — **IMPLEMENTED**
+### `apt.yml` — signed apt repo publish (on release published) — **LIVE**
 - On a non-prerelease publish: download the release's Linux tarballs, build
-  `.deb`s (`make deb-x86` / `deb-arm`), regenerate the apt index
-  (`apt-ftparchive`), sign the `Release` file with the repo GPG key, and publish
-  the tree to `Tripstack-Corp/spyc-apt`'s GitHub Pages site
-  (`https://tripstack-corp.github.io/spyc-apt`) so users can `apt install spyc` /
-  `apt upgrade`. The publish job self-skips when its secrets are absent, so it
-  stays green until the operator setup below is done.
-- **Operator setup (one-time):**
-  1. Create the public repo `Tripstack-Corp/spyc-apt` and enable **GitHub Pages**
-     serving from its default branch, `/` root (the workflow commits the repo
-     tree straight to that branch).
-  2. Generate a dedicated signing key (`gpg --quick-gen-key "spyc apt <email>"`);
-     export the ASCII-armored private key + note its passphrase.
-  3. On the **spyc** repo add secrets: `APT_GPG_PRIVATE_KEY`, `APT_GPG_PASSPHRASE`,
-     and `APT_REPO_TOKEN` (fine-grained PAT, `contents:write` on `spyc-apt`).
-  4. The workflow publishes the ASCII-armored public key as `KEY.gpg` at the repo
-     root — it's what users pin via `signed-by`.
+  `.deb`s (`make deb`), regenerate the apt index (`apt-ftparchive`), sign the
+  `Release` file with the signing key, and commit the tree to this repo's
+  **`gh-pages`** branch — served via GitHub Pages at
+  `https://tripstack-corp.github.io/spyc`, so users `apt install spyc` /
+  `apt upgrade`. Because the apt repo lives on this repo's own branch, the push
+  uses the built-in **`GITHUB_TOKEN`** (org-owned, `contents:write`) — no
+  personal/cross-repo token. The job self-skips when the signing key is absent.
+- **Signing key** — a dedicated RSA-4096 key signs `Release`; its public half is
+  published as `KEY.gpg` (what users pin via `signed-by`). The private key +
+  passphrase live in the **`apt-publish` protected Environment** (secrets
+  `APT_GPG_PRIVATE_KEY` + `APT_GPG_PASSPHRASE`), scoped so only this job — on a
+  `v*` tag or `main` — can read them.
+- **Operator setup — DONE** (kept for reference / rebuild):
+  1. `gh-pages` on `spyc` holds the apt tree; Pages serves it from `/` root.
+  2. The `apt-publish` Environment (deployment policy: `v*` tag + `main` branch)
+     holds the two `APT_GPG_*` secrets.
+  3. The signing key is backed up off-repo (owner's password manager) with a
+     revocation certificate.
 - **Prerelease note:** publishing is gated to non-prerelease tags so package
   versions stay clean `X.Y.Z` (a `2.0.0~rc.4`-style `~` epoch would otherwise be
   needed for correct apt ordering).
 
 **Cross-cutting:** `concurrency` groups to cancel superseded runs (already wired
-in `ci.yml`); secrets = `GPG_KEY`/`GPG_PASSPHRASE` (if GPG signing),
-`HOMEBREW_TAP_TOKEN`, and the apt trio (`APT_GPG_PRIVATE_KEY`,
-`APT_GPG_PASSPHRASE`, `APT_REPO_TOKEN`); cosign uses OIDC (no stored key).
+in `ci.yml`); repo secrets = `GPG_KEY`/`GPG_PASSPHRASE` (if GPG signing) and
+`HOMEBREW_TAP_TOKEN`; the `apt-publish` environment holds `APT_GPG_PRIVATE_KEY` +
+`APT_GPG_PASSPHRASE`. The apt push uses the built-in `GITHUB_TOKEN` and cosign
+uses OIDC — no other stored tokens.
 
 ## 9. Artifacts, signing & distribution
 


### PR DESCRIPTION
## Summary
- Repoint `apt.yml` to publish the apt tree to **this repo's `gh-pages` branch** using the built-in **`GITHUB_TOKEN`** — no personal/cross-repo token (deploy keys are org-disabled; PATs are person-owned).
- Signing key lives in a **protected `apt-publish` Environment** (secrets scoped to `v*` tags + `main`), not repo-wide.
- Retire `spyc-apt` (archived, redirect README); apt URL → `https://tripstack-corp.github.io/spyc`.
- Update README/INSTALL/RELEASE_ENGINEERING accordingly.
- Bump `2.0.0-rc.6`.

## Infra already provisioned (outside this PR)
- `gh-pages` branch seeded (`KEY.gpg` + landing page); Pages live at `https://tripstack-corp.github.io/spyc/`.
- `apt-publish` environment created; `APT_GPG_PRIVATE_KEY` + `APT_GPG_PASSPHRASE` set there; repo-level copies removed.
- Signing key backed up off-repo + revocation certificate generated.

## Test plan
- YAML validated; no `spyc-apt`/`APT_REPO_TOKEN` refs remain.
- After merge: `workflow_dispatch` `apt.yml` against `v2.0.0-rc.4` to exercise build→sign→publish end-to-end, then clean up the rc package.

Generated with [Claude Code](https://claude.com/claude-code)