### PR TITLE
fix(ci): apt.yml uses main's Makefile for .deb packaging

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -67,9 +67,11 @@ jobs:
 
       - name: Checkout spyc (for the Makefile)
         if: steps.guard.outputs.enabled == 'true'
+        # main, not the release tag: the .deb target just wraps the prebuilt
+        # binary (release-agnostic), and older tags predate `make deb`.
         uses: actions/checkout@v7
         with:
-          ref: ${{ steps.ver.outputs.tag }}
+          ref: main
 
       - name: Install apt tooling
         if: steps.guard.outputs.enabled == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.7"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.7"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary
The `apt.yml` "Checkout spyc (for the Makefile)" step pinned the **release tag**, but `.deb` packaging (`make deb`) just wraps the prebuilt binary — it's release-agnostic, and tags older than #129 don't have the target at all. A test dispatch against `v2.0.0-rc.4` failed with `No rule to make target 'deb'`. Check out `main` instead.

Bump `2.0.0-rc.7`.

## Test plan
- Found by a live `workflow_dispatch` of `apt.yml` against `v2.0.0-rc.4` (everything up to `make deb` passed, incl. protected-env secret resolution).
- Re-dispatch after merge to confirm the full build→sign→publish→gh-pages path.

Generated with [Claude Code](https://claude.com/claude-code)