### PR TITLE
ci(homebrew): mint the tap token from an org GitHub App, not a PAT

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -7,8 +7,9 @@
 # nothing else changes. Prereleases are NOT skipped: the tap tracks the current
 # rc stream (unlike apt.yml, which stays on stable X.Y.Z).
 #
-# Needs HOMEBREW_TAP_TOKEN (fine-grained PAT, contents:write on the tap repo)
-# in the `homebrew-tap` environment. Self-skips when absent so it stays green
+# Auth is an org-owned GitHub App (contents:write on the tap repo, no personal
+# PAT): HOMEBREW_APP_ID + HOMEBREW_APP_KEY in the `homebrew-tap` environment
+# mint a short-lived token per run. Self-skips when absent so it stays green
 # until configured (RELEASE_ENGINEERING.md §8).
 name: homebrew
 
@@ -31,18 +32,29 @@ jobs:
     runs-on: ubuntu-latest
     environment: homebrew-tap
     env:
-      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      HOMEBREW_APP_ID: ${{ secrets.HOMEBREW_APP_ID }}
+      HOMEBREW_APP_KEY: ${{ secrets.HOMEBREW_APP_KEY }}
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Gate on tap token (self-skip until configured)
+      - name: Gate on App credentials (self-skip until configured)
         id: guard
         run: |
-          if [ -z "$HOMEBREW_TAP_TOKEN" ]; then
-            echo "::notice::HOMEBREW_TAP_TOKEN not configured — skipping tap bump"
+          if [ -z "$HOMEBREW_APP_ID" ] || [ -z "$HOMEBREW_APP_KEY" ]; then
+            echo "::notice::homebrew App credentials not configured — skipping tap bump"
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Mint a tap token from the GitHub App
+        if: steps.guard.outputs.enabled == 'true'
+        id: apptoken
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HOMEBREW_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_APP_KEY }}
+          owner: Tripstack-Corp
+          repositories: homebrew-tap
 
       - name: Resolve tag + version
         if: steps.guard.outputs.enabled == 'true'
@@ -63,7 +75,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: Tripstack-Corp/homebrew-tap
-          token: ${{ env.HOMEBREW_TAP_TOKEN }}
+          token: ${{ steps.apptoken.outputs.token }}
           path: tap
 
       - name: Rewrite Formula/spyc.rb

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.9"
+version = "2.0.0-rc.10"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -223,9 +223,11 @@ are the source of truth — Actions *call them* so local and CI never drift.
 ### `homebrew.yml` — tap bump (on release published) — **TAP LIVE**
 - `Tripstack-Corp/homebrew-tap` is live with `Formula/spyc.rb` (pins the release
   version, its per-platform tarball URLs + SHA256s, and a `--HEAD` source build).
-  On a non-prerelease publish this workflow recomputes the SHAs and pushes the
-  formula bump. Needs a `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT with
-  `contents:write` on the tap repo).
+  On any publish (prereleases included — the tap tracks the current rc stream)
+  this workflow recomputes the SHAs and pushes the formula bump. Auth is an
+  org-owned GitHub App (contents:write on the tap repo, no personal PAT):
+  `HOMEBREW_APP_ID` + `HOMEBREW_APP_KEY` in the `homebrew-tap` environment mint a
+  short-lived token via `actions/create-github-app-token`.
 
 ### `apt.yml` — signed apt repo publish (on release published) — **LIVE**
 - On a non-prerelease publish: download the release's Linux tarballs, build
@@ -252,10 +254,10 @@ are the source of truth — Actions *call them* so local and CI never drift.
   needed for correct apt ordering).
 
 **Cross-cutting:** `concurrency` groups to cancel superseded runs (already wired
-in `ci.yml`); repo secrets = `GPG_KEY`/`GPG_PASSPHRASE` (if GPG signing) and
-`HOMEBREW_TAP_TOKEN`; the `apt-publish` environment holds `APT_GPG_PRIVATE_KEY` +
-`APT_GPG_PASSPHRASE`. The apt push uses the built-in `GITHUB_TOKEN` and cosign
-uses OIDC — no other stored tokens.
+in `ci.yml`); the `apt-publish` environment holds `APT_GPG_PRIVATE_KEY` +
+`APT_GPG_PASSPHRASE`, the `homebrew-tap` environment holds `HOMEBREW_APP_ID` +
+`HOMEBREW_APP_KEY` (org GitHub App). The apt push uses the built-in
+`GITHUB_TOKEN` and cosign uses OIDC — no personal tokens stored.
 
 ## 9. Artifacts, signing & distribution
 
@@ -360,8 +362,9 @@ existing repo, not seeding a clean slate. Ordered to stand the whole thing up:
 5. Add/refresh community-health files (LICENSE, SECURITY.md Supported-Versions
    table, CONTRIBUTING, add CODE_OF_CONDUCT, issue/PR templates, CODEOWNERS).
 6. Repo About: description, homepage, topics; upload the social-preview card.
-7. Configure secrets (`GPG_KEY`/`GPG_PASSPHRASE` if GPG; `HOMEBREW_TAP_TOKEN`) +
-   Actions permissions (`id-token: write` for attestations).
+7. Configure secrets (`GPG_KEY`/`GPG_PASSPHRASE` if GPG; `HOMEBREW_APP_ID` +
+   `HOMEBREW_APP_KEY` for the tap-bump App) + Actions permissions
+   (`id-token: write` for attestations).
 8. Branch protection on `main` (+ `stable/*`, `releng/*` for Stage 2); required
    checks; squash-merge default.
 9. Enable Security: private vuln reporting, secret scanning, (optional)


### PR DESCRIPTION
Follow-up to #133. Switches the tap-bump auth from a personal fine-grained PAT to an **org-owned GitHub App**, so the credential isn't tied to an individual account and there's no expiry churn.

- `actions/create-github-app-token@v1` mints a short-lived, tap-scoped token from `HOMEBREW_APP_ID` + `HOMEBREW_APP_KEY` (stored in the `homebrew-tap` environment, scoped to `main` + `v*` like `apt-publish`).
- Guard self-skips until both App secrets are set, so it stays green in the meantime.
- Docs (`RELEASE_ENGINEERING.md`) updated: App auth + the tap tracks the rc stream (prereleases not skipped).

**Operator step:** create an org App (Tripstack-Corp) with `Contents: read/write`, install it on `homebrew-tap`, and add its App ID + private key as the two secrets. Until then the job self-skips.

Generated with [Claude Code](https://claude.com/claude-code)