### PR TITLE
ci(apt): track the rc stream via tilde-versioned debs

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -1,6 +1,6 @@
-# Publish spyc's signed apt repository on a stable release.
+# Publish spyc's signed apt repository on a release (rc or stable).
 #
-# On a non-prerelease GitHub Release (or manual dispatch) this:
+# On any published GitHub Release (or manual dispatch) this:
 #   1. downloads the release's Linux tarballs,
 #   2. builds .deb packages via the Makefile (`make deb`),
 #   3. regenerates the flat apt index (apt-ftparchive) and GPG-signs `Release`,
@@ -14,8 +14,9 @@
 # The signing key lives in the `apt-publish` protected Environment (only this
 # job, on a `v*` tag or `main`, can read it); operator setup is in
 # RELEASE_ENGINEERING.md §8. The job self-skips when the key is absent, so it
-# stays green until then. Prereleases are skipped so package versions stay a
-# clean `X.Y.Z` (apt orders `~rc` before the final; we sidestep it entirely).
+# stays green until then. Prereleases publish too — the deb version uses a
+# tilde (`2.0.0~rc.4`), which dpkg sorts BELOW the final `2.0.0`, so an rc never
+# blocks the stable upgrade (the Makefile's `DEB_VERSION` does the `-`→`~`).
 name: apt
 
 on:
@@ -37,8 +38,6 @@ permissions:
 jobs:
   publish:
     name: Build .debs + publish signed apt repo
-    # Skip prereleases; manual dispatch always runs.
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
     # Scopes the signing-key secrets to this job (and to `v*` / `main` refs).
     environment: apt-publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.11"
+version = "2.0.0-rc.12"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,12 @@ dist-sign: dist-checksums ## GPG-sign the checksums file (set GPG_KEY=<id> to ch
 # artifacts it already produced. Output → dist/spyc_<version>_<arch>.deb.
 DEB_MAINTAINER ?= Derek Marshall <derek.marshall@tripstack.com>
 
+# dpkg orders `2.0.0-rc.4` ABOVE the final `2.0.0` (a `-` starts the Debian
+# revision, and having one outranks having none). The tilde form `2.0.0~rc.4`
+# sorts a prerelease correctly BELOW `2.0.0`, so rc debs never block the stable
+# upgrade. `-` → `~` (a no-op for a final `X.Y.Z`, which has no `-`).
+DEB_VERSION := $(subst -,~,$(VERSION))
+
 .PHONY: deb-x86
 deb-x86: ## Package the built Linux x86_64 binary → dist/spyc_<version>_amd64.deb
 	@$(MAKE) --no-print-directory _deb ARCH=amd64 \
@@ -282,12 +288,12 @@ _deb:
 	@mkdir -p "$(DIST_DIR)/deb-$(ARCH)/DEBIAN" "$(DIST_DIR)/deb-$(ARCH)/usr/bin"
 	@install -m 0755 "$(SRC)" "$(DIST_DIR)/deb-$(ARCH)/usr/bin/$(BINARY)"
 	@printf 'Package: %s\nVersion: %s\nArchitecture: %s\nMaintainer: %s\nSection: utils\nPriority: optional\nHomepage: https://github.com/Tripstack-Corp/spyc\nDescription: Keyboard-driven, MCP-native terminal file commander\n' \
-		"$(BINARY)" "$(VERSION)" "$(ARCH)" "$(DEB_MAINTAINER)" \
+		"$(BINARY)" "$(DEB_VERSION)" "$(ARCH)" "$(DEB_MAINTAINER)" \
 		> "$(DIST_DIR)/deb-$(ARCH)/DEBIAN/control"
 	dpkg-deb --build --root-owner-group "$(DIST_DIR)/deb-$(ARCH)" \
-		"$(DIST_DIR)/$(BINARY)_$(VERSION)_$(ARCH).deb"
+		"$(DIST_DIR)/$(BINARY)_$(DEB_VERSION)_$(ARCH).deb"
 	@rm -rf "$(DIST_DIR)/deb-$(ARCH)"
-	@ls -lh "$(DIST_DIR)/$(BINARY)_$(VERSION)_$(ARCH).deb"
+	@ls -lh "$(DIST_DIR)/$(BINARY)_$(DEB_VERSION)_$(ARCH).deb"
 
 # ---------- Install ----------------------------------------------------------
 

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -230,7 +230,8 @@ are the source of truth — Actions *call them* so local and CI never drift.
   short-lived token via `actions/create-github-app-token`.
 
 ### `apt.yml` — signed apt repo publish (on release published) — **LIVE**
-- On a non-prerelease publish: download the release's Linux tarballs, build
+- On any publish (prereleases included — apt tracks the rc stream): download the
+  release's Linux tarballs, build
   `.deb`s (`make deb`), regenerate the apt index (`apt-ftparchive`), sign the
   `Release` file with the signing key, and commit the tree to this repo's
   **`gh-pages`** branch — served via GitHub Pages at
@@ -249,9 +250,10 @@ are the source of truth — Actions *call them* so local and CI never drift.
      holds the two `APT_GPG_*` secrets.
   3. The signing key is backed up off-repo (owner's password manager) with a
      revocation certificate.
-- **Prerelease note:** publishing is gated to non-prerelease tags so package
-  versions stay clean `X.Y.Z` (a `2.0.0~rc.4`-style `~` epoch would otherwise be
-  needed for correct apt ordering).
+- **Prerelease ordering:** rc tags publish too. The deb version is tilde-formed
+  (`make deb`'s `DEB_VERSION` does `-`→`~`, e.g. `2.0.0~rc.4`) because dpkg sorts
+  `2.0.0-rc.4` ABOVE the final `2.0.0` — the `~` form sorts a prerelease BELOW
+  it, so an rc deb never blocks the stable upgrade.
 
 **Cross-cutting:** `concurrency` groups to cancel superseded runs (already wired
 in `ci.yml`); the `apt-publish` environment holds `APT_GPG_PRIVATE_KEY` +


### PR DESCRIPTION
Make the apt channel track prereleases like the Homebrew tap does (per owner request — the "apt stable-only until 2.0.0" was an unratified inference).

## The problem
apt is a *pool* of versions and the client installs the highest-sorting one. dpkg sorts `2.0.0-rc.4` **above** the final `2.0.0` (a `-` starts the Debian revision; having one outranks having none), so naive rc debs would win over — and block the upgrade to — the real release. That's why apt was gated to non-prereleases.

## The fix
- `make deb` now builds a **tilde** deb version: `DEB_VERSION := $(subst -,~,$(VERSION))` → `2.0.0~rc.11`. dpkg sorts `~` **below** the final `2.0.0` and monotonically across rcs, so an rc never blocks the stable upgrade. No-op for a final `X.Y.Z`.
- `apt.yml` drops the `prerelease == false` job gate, so it publishes on rc tags too (still self-skips without the signing key).
- Docs updated.

## Verified
- `make -n _deb VERSION=2.0.0-rc.11` → `spyc_2.0.0~rc.11_amd64.deb`; `VERSION=2.0.0` → unchanged.
- `make check` green.
- (dpkg ordering is standard Debian behavior — the `-rc` > final trap is what bit the earlier rc.4 apt test.)

After merge I'll dispatch `apt.yml` for the current rc tag to publish the first real deb and confirm the repo serves it.

Generated with [Claude Code](https://claude.com/claude-code)