### PR TITLE
ci(release): dispatch homebrew + apt channel bumps after publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
       contents: write # create the release + upload assets
       id-token: write # OIDC for attestations + cosign keyless signing
       attestations: write # build-provenance attestations
+      actions: write # dispatch homebrew.yml / apt.yml (below)
     steps:
       - uses: actions/checkout@v7
         with:
@@ -143,3 +144,15 @@ jobs:
             dist/spyc-*.tar.gz \
             dist/SHA256SUMS \
             dist/SHA256SUMS.cosign.bundle
+      - name: Bump downstream channels (homebrew tap + apt)
+        # A release created with GITHUB_TOKEN does NOT fire `on: release`
+        # workflows (GitHub blocks token events from cascading), so dispatch
+        # homebrew.yml / apt.yml explicitly — `workflow_dispatch` is the one
+        # event GITHUB_TOKEN can trigger. Runs after the release above so both
+        # can download its assets. (Their `on: release` triggers still cover a
+        # manual/UI publish.)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run homebrew.yml -f tag="${GITHUB_REF_NAME}"
+          gh workflow run apt.yml      -f tag="${GITHUB_REF_NAME}"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -193,9 +193,12 @@ are the source of truth — Actions *call them* so local and CI never drift.
   written highlights block (the 1Password/Slack "changelog for humans" style the
   backlog calls for).
 - **Publish:** create the GitHub Release, attach `spyc-vN.M.P-<target>.tar.gz` ×4,
-  `SHA256SUMS`, signatures. Trigger `homebrew.yml`.
+  `SHA256SUMS`, signatures. Then **dispatch** `homebrew.yml` + `apt.yml`: a
+  GITHUB_TOKEN-created release does NOT fire their `on: release` triggers (GitHub
+  blocks token events from cascading), so release.yml runs them via
+  `gh workflow run` — the one event a GITHUB_TOKEN can trigger.
 - **Permissions:** `contents: write`, `id-token: write` (attestations),
-  `attestations: write`.
+  `attestations: write`, `actions: write` (dispatch the channel bumps).
 - **As built (deviations from the sketch above):** the `macos`/`linux` build
   jobs run per-runner and call the platform Makefile targets directly (rather
   than `make dist` / `make dist-checksums`, which build *all* platforms on one


### PR DESCRIPTION
Makes every release auto-bump both distribution channels.

## Why
`homebrew.yml` and `apt.yml` trigger `on: release: published`, but that event **never fires** for a release created by `release.yml` — GitHub blocks `GITHUB_TOKEN`-created events from cascading into other workflows (anti-recursion). So both channels only ever bumped via manual dispatch (which is also why apt was only dispatch-tested).

## Fix
`release.yml`'s publish job, after `gh release create`, dispatches both:
```
gh workflow run homebrew.yml -f tag="$GITHUB_REF_NAME"
gh workflow run apt.yml      -f tag="$GITHUB_REF_NAME"
```
`workflow_dispatch` is the one event `GITHUB_TOKEN` *can* trigger, so no new secret is needed. Adds `actions: write` to the job. The dispatch runs after the release + assets exist, so both downstream jobs can download them. Their `on: release` triggers stay as a manual/UI-publish fallback.

Verified: rc.11 bumped both channels via manual dispatch already; this just makes it automatic. `make check` green.

Generated with [Claude Code](https://claude.com/claude-code)