### PR TITLE
fix(git): widen worktree index-lock retry to kill the CI flake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.14"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.13"
+version = "2.0.0-rc.14"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -287,21 +287,24 @@ fn checkout_and_write(
 ///
 /// gix acquires `<admin>/index.lock` with `Fail::Immediately` — no internal
 /// wait — so a contender that holds the lock for even a moment (a concurrent
-/// gix operation in production, or the heavily-parallel test runner) makes the
-/// very first `write` fail instantly with `AcquireLock` rather than blocking.
-/// A short bounded backoff (5 attempts, ~0.3s total) lets a passing holder
-/// release, while a genuinely stuck lock still fails fast instead of hanging.
+/// gix operation in production, or the heavily-parallel test runner) makes a
+/// `write` fail instantly with `AcquireLock` rather than blocking. A bounded
+/// exponential backoff (10 attempts, capped at 300ms/step, ~1.8s total) rides
+/// out that transient contention on a loaded CI filesystem, while a genuinely
+/// stuck lock still fails in bounded time instead of hanging (it is NOT
+/// stomped — see `write_index_gives_up_on_a_stuck_lock_instead_of_hanging`).
 /// Re-issuing `write` is safe: it re-serializes the same in-memory index and
 /// re-acquires from scratch, so no partial state carries across attempts.
 fn write_index_with_lock_retry(index: &mut gix::index::File) -> std::io::Result<()> {
-    const ATTEMPTS: u32 = 5;
+    const ATTEMPTS: u32 = 10;
+    const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_millis(300);
     let mut backoff = std::time::Duration::from_millis(20);
     for attempt in 1..=ATTEMPTS {
         match index.write(gix::index::write::Options::default()) {
             Ok(()) => return Ok(()),
             Err(gix::index::file::write::Error::AcquireLock(_)) if attempt < ATTEMPTS => {
                 std::thread::sleep(backoff);
-                backoff *= 2;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
             }
             Err(e) => return Err(std::io::Error::other(format!("write index: {e}"))),
         }


### PR DESCRIPTION
## The flake
`git::worktree::tests::remove_clean_worktree_leaves_nothing` intermittently fails on CI:
```
add: "write index: Could not acquire lock for index file"
```
gix acquires `<admin>/index.lock` with `Fail::Immediately` (no internal wait), and `write_index_with_lock_retry`'s backoff (5 attempts / ~0.3s) was too short to ride out transient contention on a heavily-parallel, loaded CI filesystem. Not reproducible on macOS.

## The fix
Widen the retry to **10 attempts / ~1.8s** (exponential backoff capped at 300ms/step) — a 6× larger window that rides out the transient lock, while staying **bounded** so a genuinely stuck lock still fails fast instead of hanging.

Deliberately **not** stomping the lock: the "give up on a truly-stuck lock, never skip the write" contract (`write_index_gives_up_on_a_stuck_lock_instead_of_hanging`) is unchanged and still passes — a permanent lock fails after the window, a momentary one no longer flakes. Complements the existing `cfg(test)` serialize-mutex (inter-test) guard.

Local (macOS) can't reproduce the flake, so the real proof is CI over time; `make check` + all 18 `git::worktree` tests green.

Generated with [Claude Code](https://claude.com/claude-code)