### PR TITLE
ci: declare least-privilege workflow permissions (CodeQL)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,6 +16,9 @@ on:
     - cron: "0 6 * * 1"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 jobs:
   deps:
     name: Dependency drift report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint + supply-chain (fmt, clippy, deny)

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -26,6 +26,10 @@ concurrency:
   group: homebrew-tap
   cancel-in-progress: false
 
+# Least-privilege GITHUB_TOKEN; the App token (not this) does the tap write.
+permissions:
+  contents: read
+
 jobs:
   bump:
     name: Bump the Homebrew tap formula

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,10 @@ env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
 
+# Least-privilege default; the publish job widens it (contents/id-token/…).
+permissions:
+  contents: read
+
 jobs:
   macos:
     name: Build macOS universal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.14"
+version = "2.0.0-rc.15"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.14"
+version = "2.0.0-rc.15"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Closes the 7 open CodeQL code-scanning alerts — all the same rule, `actions/missing-workflow-permissions` (medium): jobs in `release.yml` (×2), `ci.yml` (×3), `audit.yml`, and `homebrew.yml` ran with no explicit `permissions:` block, so they'd inherit the token's ambient scope.

Adds a top-level `permissions: contents: read` to each. The repo's default workflow token is already **read-only**, so this is behavior-neutral — it just makes least-privilege explicit (what CodeQL wants). `release.yml`'s publish job keeps its per-job override (`contents`/`id-token`/`attestations`/`actions: write`); `apt.yml` already declared `contents: write`.

`make check` green; all four workflows parse.

Generated with [Claude Code](https://claude.com/claude-code)