### PR TITLE
fix(git): hold last-known markers during async re-walk (status-bar flicker)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.18"
+version = "2.0.0-rc.19"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.18"
+version = "2.0.0-rc.19"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -338,7 +338,7 @@ impl App {
         app.state.left.git.info = app.state.compute_git_info_fast(state::Side::Left);
         let _ = app
             .state
-            .git_file_statuses_cached(state::Side::Left, &initial_cwd);
+            .git_file_statuses_cached(state::Side::Left, &initial_cwd, false);
         // The bootstrap cache-miss queued a request into the Model's
         // outbox (git_worker_available is now true); flush it onto the
         // worker channel so the first per-file markers land as early as

--- a/src/app/state/git.rs
+++ b/src/app/state/git.rs
@@ -84,11 +84,14 @@ impl AppState {
         if !force_rewalk && key.is_some() && key == self.col(side).git_cache.git_poll_cache {
             return false;
         }
-        // mtime moved — invalidate the raw-status cache before going through
-        // `git_file_statuses_cached`, which re-spawns and refills it on this dir.
-        self.col_mut(side).git_cache.git_status_cache = None;
+        // A re-walk is warranted (mtime moved, or `force_rewalk` — a working-tree
+        // edit the mtime key can't see). `git_file_statuses_cached` hands it to
+        // the background worker and returns the CURRENT (stale-but-same-repo)
+        // markers rather than blanking the cache, so the dirty star + gutter hold
+        // steady until `apply_git_worker_result` swaps in the fresh walk. Nulling
+        // here is what made the status bar flicker under worktree churn.
         let listing_dir = self.col(side).listing.dir.clone();
-        let new_git_files = self.git_file_statuses_cached(side, &listing_dir);
+        let new_git_files = self.git_file_statuses_cached(side, &listing_dir, force_rewalk);
         let new_git_info = self.compute_git_info_fast(side);
         // Stash on success so the next idle poll skips the subprocesses.
         self.col_mut(side).git_cache.git_poll_cache = key;
@@ -109,10 +112,19 @@ impl AppState {
     ///
     /// Caller must have already called [`Self::update_repo_root`] for `side` so
     /// its `current_repo_root` reflects the new dir.
+    ///
+    /// `force` requests a fresh walk even when the mtime cache would be reused —
+    /// a working-tree edit moves no `.git/index`/`HEAD` mtime, so the poll and
+    /// the listing refresh flag it to converge a stale ` M`/clean marker. When a
+    /// walk is needed and the worker is live, it runs off-thread and this returns
+    /// the CURRENT cache's markers (stale but same-repo), NOT an empty map, and
+    /// does not clear the cache — [`Self::apply_git_worker_result`] swaps in the
+    /// fresh entries when the walk lands.
     pub fn git_file_statuses_cached(
         &mut self,
         side: Side,
         canonical: &Path,
+        force: bool,
     ) -> std::collections::HashMap<String, crate::ui::list_view::GitFileStatus> {
         let Some(repo_root) = self.col(side).git_cache.current_repo_root.clone() else {
             // Not in a repo — nothing to do, no cache to maintain.
@@ -130,12 +142,16 @@ impl AppState {
                     && mtimes
                         .is_some_and(|(idx, head)| idx == c.index_mtime && head == c.head_mtime)
             });
-        if !reuse {
-            // Cache miss — the `git status` spawn walks the entire index
-            // (200-500 ms on a ~110k-file repo) and would block the UI thread.
-            // Hand it to the background worker (stamped with this column's
+        if force || !reuse {
+            // A walk is needed. The `git status` spawn walks the entire index
+            // (200-500 ms on a ~110k-file repo) and would block the UI thread,
+            // so hand it to the background worker (stamped with this column's
             // `side` + generation so the result routes back to the right column
-            // and stale results are discarded) and return an empty map for now.
+            // and stale results are discarded) and fall through to return the
+            // CURRENT cache below — the display holds steady until the walk lands
+            // (`apply_git_worker_result`). Returning an empty map / nulling here
+            // flickers the dirty star + gutter for the ~1 poll the walk takes
+            // under worktree churn.
             if self.col(side).git_cache.git_worker_available {
                 let generation = self.col(side).git_cache.git_generation.wrapping_add(1);
                 let c = self.col_mut(side);
@@ -146,24 +162,28 @@ impl AppState {
                     side,
                 });
                 c.git_cache.last_git_request_at = Some(std::time::Instant::now());
-                return std::collections::HashMap::new();
-            }
-            // No worker (tests, App::new bootstrap) — fall through to the
-            // synchronous walk path below.
-            self.col_mut(side).git_cache.git_status_cache = None;
-            if let Some(entries) = crate::git::status::repo_status(&repo_root)
-                && let Some((index_mtime, head_mtime)) = mtimes
-            {
-                self.col_mut(side).git_cache.git_status_cache = Some(GitStatusCache {
-                    repo_root: repo_root.clone(),
-                    index_mtime,
-                    head_mtime,
-                    entries,
-                });
+            } else {
+                // No worker (tests, App::new bootstrap) — walk synchronously and
+                // refill in-band; the fresh entries are immediate, no async
+                // window to flicker.
+                self.col_mut(side).git_cache.git_status_cache = None;
+                if let Some(entries) = crate::git::status::repo_status(&repo_root)
+                    && let Some((index_mtime, head_mtime)) = mtimes
+                {
+                    self.col_mut(side).git_cache.git_status_cache = Some(GitStatusCache {
+                        repo_root: repo_root.clone(),
+                        index_mtime,
+                        head_mtime,
+                        entries,
+                    });
+                }
             }
         }
-        // Re-filter the cached repo-wide entries to this listing dir's prefix —
-        // no repo re-walk needed (the cache survives chdir within the repo).
+        // Re-filter the cached repo-wide entries to this listing dir's prefix — no
+        // repo re-walk needed (the cache survives chdir within the repo). On the
+        // async path this is the previous (stale-but-same-repo) snapshot; with no
+        // cache yet (first walk / just switched repos) it's empty — the correct
+        // "nothing to show yet".
         let Some(cache) = self.col(side).git_cache.git_status_cache.as_ref() else {
             return std::collections::HashMap::new();
         };

--- a/src/app/state/listing.rs
+++ b/src/app/state/listing.rs
@@ -262,7 +262,6 @@ impl AppState {
             .last_git_invalidation
             .is_none_or(|t| t.elapsed() >= throttle);
         if should_invalidate {
-            self.col_mut(side).git_cache.git_status_cache = None;
             self.col_mut(side).git_cache.last_git_invalidation = Some(std::time::Instant::now());
             // This walk reflects the current worktree, so any earlier
             // deferred re-walk is now satisfied.
@@ -276,7 +275,11 @@ impl AppState {
             self.col_mut(side).git_cache.pending_worktree_rewalk = true;
         }
         let dir = self.col(side).listing.dir.clone();
-        let new_git_files = self.git_file_statuses_cached(side, &dir);
+        // `force` a fresh walk when not throttled — a working-tree edit moves no
+        // mtime, so the reuse check alone would skip it. The walk runs off-thread
+        // and returns the current (stale-but-same-repo) markers, so the gutter
+        // holds steady until the fresh result lands rather than blanking.
+        let new_git_files = self.git_file_statuses_cached(side, &dir, should_invalidate);
         let new_git_info = self.compute_git_info_fast(side);
         let mut new_keys: Vec<&str> = new_git_files.keys().map(String::as_str).collect();
         new_keys.sort_unstable();
@@ -333,7 +336,7 @@ impl AppState {
         // Refill the raw-status cache (if needed) before computing
         // branch/dirty — `compute_git_info_fast` reads `dirty` off
         // the cached raw output, so it must be current.
-        let files = self.git_file_statuses_cached(side, &canonical);
+        let files = self.git_file_statuses_cached(side, &canonical, false);
         let info = self.compute_git_info_fast(side);
         self.col_mut(side).git.set(info, files);
         // Cache key from the cached repo root — no subprocess. The

--- a/src/app/state/tests/mod.rs
+++ b/src/app/state/tests/mod.rs
@@ -776,11 +776,11 @@ fn git_worker_available_enqueues_request_instead_of_spawning() {
     s.left.git_cache.pending_git_requests.clear();
     let gen_before = s.left.git_cache.git_generation;
 
-    let map = s.git_file_statuses_cached(crate::app::state::Side::Left, &root);
+    let map = s.git_file_statuses_cached(crate::app::state::Side::Left, &root, false);
 
     assert!(
         map.is_empty(),
-        "worker path returns an empty map this frame (markers arrive async)"
+        "no cache yet → the worker path returns an empty map this frame (markers arrive async)"
     );
     assert_eq!(
         s.left.git_cache.pending_git_requests.len(),
@@ -805,6 +805,90 @@ fn git_worker_available_enqueues_request_instead_of_spawning() {
     assert!(
         s.left.git_cache.last_git_request_at.is_some(),
         "request-sent timestamp stamped for the activity overlay"
+    );
+}
+
+/// Regression (status-bar flicker): the git poll used to null the status cache
+/// before handing the re-walk to the async worker, blanking the dirty star +
+/// gutter markers for the ~1 poll the walk took — which reads as a flicker under
+/// worktree churn (a running build fires a working-tree event every poll). A
+/// forced re-walk with a live worker must ENQUEUE the fresh walk yet keep
+/// showing the current (stale-but-same-repo) markers until it lands.
+#[test]
+fn forced_rewalk_keeps_stale_markers_and_star_instead_of_blanking() {
+    use crate::app::state::Side;
+    let tmp = tempfile::tempdir().unwrap();
+    let root = std::fs::canonicalize(tmp.path()).unwrap_or_else(|_| tmp.path().to_path_buf());
+    let run_git = |args: &[&str]| {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(&root)
+            .env("GIT_AUTHOR_NAME", "t")
+            .env("GIT_AUTHOR_EMAIL", "t@x")
+            .env("GIT_COMMITTER_NAME", "t")
+            .env("GIT_COMMITTER_EMAIL", "t@x")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .status()
+            .expect("spawn git");
+        assert!(status.success(), "git {args:?} failed");
+    };
+    run_git(&["init", "-q", "--initial-branch=main"]);
+    std::fs::write(root.join("file.txt"), "v1\n").unwrap();
+    run_git(&["add", "file.txt"]);
+    run_git(&["commit", "-q", "-m", "v1"]);
+
+    let mut s = test_state();
+    s.left.listing.dir = root.clone();
+    s.update_repo_root(Side::Left, &root);
+    s.left.git_cache.git_worker_available = true;
+
+    // Seed a populated cache stamped with the CURRENT mtimes, so the reuse check
+    // would normally skip the walk — `force` must re-walk anyway. This is exactly
+    // the poll's `force_rewalk` case: a working-tree edit moves no
+    // `.git/index`/`HEAD` mtime, so only the flag forces a fresh walk.
+    let (idx, head) = s
+        .compute_git_mtime_key_fast(Side::Left)
+        .expect("repo mtimes");
+    s.left.git_cache.git_status_cache = Some(crate::app::state::GitStatusCache {
+        repo_root: root.clone(),
+        index_mtime: idx,
+        head_mtime: head,
+        entries: vec![crate::git::status::StatusEntry {
+            rela_path: "file.txt".to_string(),
+            staged: None,
+            unstaged: Some(crate::ui::list_view::GitChange::Modified),
+            untracked: false,
+        }],
+    });
+    s.left.git_cache.pending_git_requests.clear();
+    let gen_before = s.left.git_cache.git_generation;
+
+    let map = s.git_file_statuses_cached(Side::Left, &root, true);
+
+    // The markers survive the async window — NOT blanked (the flicker fix).
+    assert!(
+        map.contains_key("file.txt"),
+        "forced re-walk must keep the current markers, not blank them"
+    );
+    // ...and the fresh walk is still enqueued off-thread.
+    assert_eq!(
+        s.left.git_cache.pending_git_requests.len(),
+        1,
+        "forced re-walk still enqueues the async walk"
+    );
+    assert_eq!(
+        s.left.git_cache.git_generation,
+        gen_before.wrapping_add(1),
+        "generation bumped once for the enqueued walk"
+    );
+    // The dirty star holds steady too — `compute_git_info_fast` reads the
+    // retained (non-nulled) cache, so it stays `main*` rather than flipping to
+    // `main` for the frame the async walk is in flight.
+    assert_eq!(
+        s.compute_git_info_fast(Side::Left).as_deref(),
+        Some("main*"),
+        "the dirty star holds steady across the forced re-walk"
     );
 }
 


### PR DESCRIPTION
## Problem

The status bar flickered `main*` ⇄ `main` under worktree churn — the git dirty star (and file-list gutter markers) blanked for ~15 ms on every git-status re-walk, then snapped back. The tightly-packed powerline reflows every segment to the right of the vanishing `*`, so the whole right side of the bar jitters.

## Root cause

The 1 Hz git poll (`refresh_git_state_for`) and the listing refresh (`refresh_listing`) nulled `git_status_cache` **before** handing the re-walk to the async worker, then committed the worker's empty placeholder. `compute_git_info_fast` reads the now-null cache → `dirty = false` → `main`; when `apply_git_worker_result` lands it refills → `main*`. A running build fires a working-tree fs-event every poll, so the poll re-walks (and blanks) every tick → continuous flicker.

Diagnosis ruled out the repo and gix: `git status` was rock-stable (4 entries, 30 ms), `repo_status` / `repo_status_stable` returned 4 across 40 iterations (~15 ms each, no flap), and `.git/index` mtime wasn't churning. The blank was purely the null-then-async-refill window.

## Fix

Decouple "force a fresh async walk" from "blank the display": `git_file_statuses_cached` gains a `force` flag, enqueues the worker walk, and **falls through to return the current (stale-but-same-repo) cache** instead of an empty map — without nulling it. `apply_git_worker_result` swaps in the fresh entries when the walk lands.

A working-tree edit (which moves no `.git/index` mtime) still forces a fresh walk, so `~` / ` M` marker freshness is intact. Safe because `update_repo_root` nulls the cache on a repo switch and `compute_git_info_fast` filters on `repo_root` — a stale cache can never surface another repo's state.

## Test

`forced_rewalk_keeps_stale_markers_and_star_instead_of_blanking` seeds a populated cache with matching mtimes, forces a re-walk with a live worker, and asserts the markers + `main*` survive **and** the fresh walk still enqueues. `make check` green.

Generated with [Claude Code](https://claude.com/claude-code)
