### PR TITLE
ci(release): prune old RC pre-releases to newest 3 on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,3 +160,21 @@ jobs:
         run: |
           gh workflow run homebrew.yml -f tag="${GITHUB_REF_NAME}"
           gh workflow run apt.yml      -f tag="${GITHUB_REF_NAME}"
+      - name: Prune old RC pre-releases (keep newest 3)
+        # RC pre-releases each carry ~38 MB of assets and pile up on the tags
+        # page. Keep only the 3 most recent `*-rc*` pre-releases; delete older
+        # ones together with their git tags (`--cleanup-tag`), which also removes
+        # their assets. Stable releases (isPrerelease=false) and non-rc tags are
+        # never selected — final `vX.Y.Z` releases and `v1.50.0` are untouched.
+        # Runs last, so the tag just published is always among the kept 3.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mapfile -t old < <(gh release list --limit 100 \
+            --json tagName,isPrerelease,createdAt \
+            --jq 'map(select(.isPrerelease and (.tagName|test("-rc"))))
+                  | sort_by(.createdAt) | reverse | .[3:] | .[].tagName')
+          for tag in "${old[@]}"; do
+            echo "pruning old RC release + tag: $tag"
+            gh release delete "$tag" --cleanup-tag --yes
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.20"
+version = "2.0.0-rc.21"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.20"
+version = "2.0.0-rc.21"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -115,6 +115,12 @@ from `stable/N`, run `-beta.X` → `-rc.X` → `vN.M.0` on that branch, and keep
 Each tag matching `v*` triggers `release.yml` (§8); `-beta`/`-rc` tags are
 auto-marked pre-release by pattern.
 
+**RC retention:** `release.yml` keeps only the **3 most recent `-rc` pre-releases**,
+deleting older ones (release + git tag + assets) on every publish. Only `-rc`
+pre-releases are pruned — stable `vN.M.P` releases are never touched. Older RCs are
+throwaway soak builds (~38 MB of assets each); the changelog and stable tags are the
+durable record.
+
 ## 6. Maintenance: Errata & Security (EN / SA)
 
 FreeBSD splits post-release fixes into **Errata Notices** (critical non-security)


### PR DESCRIPTION
Adds a final step to `release.yml`'s publish job that keeps only the **3 most recent `-rc` pre-releases**, deleting older ones (release + git tag + assets via `--cleanup-tag`) on every publish.

- **rc-only**: selects `isPrerelease and (tagName matches -rc)` — stable `vX.Y.Z` releases and `v1.50.0` are never touched.
- **assets**: deleting the release + tag removes its ~38 MB of assets.
- Runs last, so the just-published tag is always among the kept 3.
- Dry-ran the selection logic against the live repo; documented in RELEASE_ENGINEERING.md §5.

Bumps to rc.21. Next `v2.0.0-rc.21` tag will build + auto-prune the backlog (keeps rc.21/18/17).

Generated with [Claude Code](https://claude.com/claude-code)