### PR TITLE
ci: RUST_BACKTRACE=full so the next index-lock flake is diagnosable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,11 @@ env:
   # cache. (Matched the Bitbucket pipeline.)
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
+  # Full backtrace on any panic so a CI-only failure is diagnosable from the
+  # log alone. Aimed at the intermittent gix worktree index-lock flake
+  # (`write index: Could not acquire lock`), which doesn't reproduce on macOS —
+  # the next occurrence must show WHERE the lock acquisition unwinds.
+  RUST_BACKTRACE: full
 
 permissions:
   contents: read


### PR DESCRIPTION
The intermittent gix worktree index-lock flake (`write index: Could not acquire lock for index file` in `add_succeeds_after_a_prior_failed_attempt`) doesn't reproduce on macOS, so #117/#118/#138 each shipped blind. Set `RUST_BACKTRACE=full` at the workflow `env` level so the **next** CI occurrence prints where the lock acquisition unwinds — the data to fix the race instead of widening the retry a fourth time.

CI-only, no binary change → no version bump.

(Context: this flake just blocked #157, which is otherwise green.)

Generated with [Claude Code](https://claude.com/claude-code)