### PR TITLE
fix(pane): show the status-hooks consent as a centered pop-up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.23"
+version = "2.0.0-rc.24"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.23"
+version = "2.0.0-rc.24"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/src/app/pane_tabs.rs
+++ b/src/app/pane_tabs.rs
@@ -191,7 +191,7 @@ impl App {
                         agent: kind,
                     },
                     format!(
-                        "Let spyc show this agent's live status? Writes hooks to {} (removed on exit). [y]es / [n]o ",
+                        "Show this agent's live status on its tab? spyc will write status hooks to {} (removed when the pane exits).",
                         support.config_label
                     ),
                 ));

--- a/src/app/render/inner.rs
+++ b/src/app/render/inner.rs
@@ -305,6 +305,12 @@ impl App {
             widgets::Paragraph,
         };
         if let Mode::Prompting(p) = &self.state.mode {
+            // HookConsent is shown as a centered pop-up (`render_hook_consent_popup`),
+            // not this one-line bar — leave the prompt row blank so the ask reads
+            // as a modal, not a status line lost beneath the pane.
+            if matches!(p.kind, crate::app::PromptKind::HookConsent { .. }) {
+                return;
+            }
             PromptLine {
                 prefix: &p.prefix,
                 buffer: &p.buffer,

--- a/src/app/render/mod.rs
+++ b/src/app/render/mod.rs
@@ -431,6 +431,11 @@ impl App {
         // ring, above the chrome + HUD (an attention flash), below the mermaid
         // image. A no-op unless a flash is live (only armed on a transition).
         self.render_visual_bell(frame, frame_area);
+        // First-launch status-hooks consent — a centered modal pop-up drawn over
+        // everything (chrome + HUD), so an auto-fired ask can't be mistaken for a
+        // frozen pane while the user's eyes are on the agent. No-op unless the
+        // `HookConsent` prompt is active.
+        self.render_hook_consent_popup(frame, h_divider_row, v_divider_col);
         // Full-screen mermaid image overlay (the `i` key) — drawn last so it
         // sits on top of everything, including the HUD.
         self.render_mermaid_overlay(frame, frame_area);
@@ -874,6 +879,42 @@ mod render_tests {
         let mut app = demo_app(&files());
         app.state.mode = Mode::Prompting(Prompt::shell(PromptKind::Command, ":"));
         insta::assert_snapshot!(render_to_string(&mut app, 80, 24));
+    }
+
+    #[test]
+    fn hook_consent_draws_a_centered_popup_not_the_prompt_line() {
+        let mut app = demo_app(&files());
+        app.state.mode = Mode::Prompting(Prompt::simple(
+            PromptKind::HookConsent {
+                root: PathBuf::from("/projects/demo"),
+                cwd: PathBuf::from("/projects/demo"),
+                agent: crate::state::sessions::AgentKind::Claude,
+            },
+            "Show this agent's live status on its tab? spyc will write status \
+             hooks to .claude/settings.json (removed when the pane exits)."
+                .to_string(),
+        ));
+        let out = render_to_string(&mut app, 80, 24);
+        // The pop-up drew: the question, the prominent y/n footer, and a border.
+        assert!(
+            out.contains("live status"),
+            "consent question shown:\n{out}"
+        );
+        assert!(
+            out.contains("[y]") && out.contains("[n]"),
+            "y/n keys shown in the popup:\n{out}"
+        );
+        assert!(
+            out.contains('┌') && out.contains('│'),
+            "a bordered box drew:\n{out}"
+        );
+        // It's a CENTERED modal, NOT the one-line prompt bar: the question must
+        // not sit on the final (chrome) row — that's the confusing old behavior.
+        let last = out.lines().last().unwrap_or_default();
+        assert!(
+            !last.contains("live status"),
+            "question must not be on the prompt-line row:\n{out}"
+        );
     }
 
     #[test]

--- a/src/app/render/overlays.rs
+++ b/src/app/render/overlays.rs
@@ -5,7 +5,7 @@
 
 use ratatui::Frame;
 
-use crate::app::{App, format_uptime};
+use crate::app::{App, Mode, PromptKind, format_uptime};
 
 impl App {
     /// P3-1 visual bell: paint spyc's spice-heat gradient border pulse over the
@@ -173,6 +173,83 @@ impl App {
             Paragraph::new(Span::styled(footer_text, footer_style)),
             footer_rect,
         );
+    }
+
+    /// Render the first-launch status-hooks consent (`PromptKind::HookConsent`)
+    /// as a centered modal pop-up. It fires automatically when an agent pane
+    /// launches — while the user's eyes are on the pane — so the old one-line
+    /// prompt bar read as "spyc isn't taking my input". A bordered box in the
+    /// middle of the screen with a prominent `y`/`n` footer makes the ask
+    /// unmissable. Only `y`/`n` dismiss it (the confirm handler enforces that);
+    /// drawn on top of everything from `render`. `h_divider_row`/`v_divider_col`
+    /// nudge the border off a structural divider (see [`Self::render_harpoon_menu`]).
+    pub(super) fn render_hook_consent_popup(
+        &self,
+        frame: &mut Frame,
+        h_divider_row: Option<u16>,
+        v_divider_col: Option<u16>,
+    ) {
+        use ratatui::{
+            layout::Rect,
+            style::{Modifier, Style},
+            text::{Line, Span},
+            widgets::{Block, Borders, Clear, Paragraph},
+        };
+        let Mode::Prompting(prompt) = &self.state.mode else {
+            return;
+        };
+        if !matches!(prompt.kind, PromptKind::HookConsent { .. }) {
+            return;
+        }
+
+        let area = frame.area();
+        let width = area.width.clamp(40, 68);
+        // Body wraps to the inner width (box minus two border columns + a
+        // one-column pad each side).
+        let text_w = usize::from(width).saturating_sub(4).max(1);
+        let body = wrap_label(&prompt.prefix, text_w);
+        // 2 borders + body rows + 1 blank spacer + 1 footer.
+        let height = (2 + body.len() as u16 + 2).min(area.height);
+        let cx = area.x + (area.width.saturating_sub(width)) / 2;
+        let cy = area.y + (area.height.saturating_sub(height)) / 2;
+        let x = place_clear_of_line(cx, width, v_divider_col, area.x, area.right());
+        let y = place_clear_of_line(cy, height, h_divider_row, area.y, area.bottom());
+        let rect = Rect {
+            x,
+            y,
+            width,
+            height,
+        };
+        frame.render_widget(Clear, rect);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(" spyc — agent status ")
+            .border_style(
+                Style::default()
+                    .fg(self.view.theme.popup_border)
+                    .add_modifier(Modifier::BOLD),
+            );
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
+
+        let body_style = Style::default().fg(self.view.theme.status_path);
+        let mut lines: Vec<Line> = body
+            .into_iter()
+            .map(|l| Line::from(Span::styled(format!(" {l}"), body_style)))
+            .collect();
+        lines.push(Line::from("")); // spacer
+        let key = Style::default()
+            .fg(self.view.theme.prompt_prefix)
+            .add_modifier(Modifier::BOLD);
+        let word = Style::default().fg(self.view.theme.status_suffix);
+        lines.push(Line::from(vec![
+            Span::styled(" [y] ", key),
+            Span::styled("yes     ", word),
+            Span::styled("[n] ", key),
+            Span::styled("no", word),
+        ]));
+        frame.render_widget(Paragraph::new(lines), inner);
     }
 
     /// Render the activity (`A`) monitor overlay (top-right corner). Called


### PR DESCRIPTION
## Problem
The first-launch "show this agent's live status?" consent fires **automatically** when an agent pane launches — while your eyes are on the pane. As a one-line bar above the divider it read as spyc freezing; two users got stuck not realizing it wanted input.

## Fix
Render it as a **centered bordered modal pop-up** over everything (from the top-level `render`, so it shows regardless of `render_inner` branch), with a prominent `[y] yes  [n] no` footer. The one-line prompt bar is suppressed for this prompt. Only y/n dismiss it (handler unchanged). Reuses the harpoon/which-key centered-box + `wrap_label`/`place_clear_of_line` helpers.

```
      ┌ spyc — agent status ─────────────────────────────────────────────┐
      │ Show this agent's live status on its tab? spyc will write status │
      │ hooks to .claude/settings.json (removed when the pane exits).    │
      │                                                                  │
      │ [y] yes     [n] no                                               │
      └──────────────────────────────────────────────────────────────────┘
```

Render test asserts the box + question + y/n draw and that the question isn't on the prompt-line row. `make check` green (1607 tests). rc.24.

Generated with [Claude Code](https://claude.com/claude-code)