### PR TITLE
feat(dist): publish to crates.io on release (cargo install)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,3 +178,33 @@ jobs:
             echo "pruning old RC release + tag: $tag"
             gh release delete "$tag" --cleanup-tag --yes
           done
+
+  crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    # Independent of the GitHub release (only needs the tag's source + the
+    # token), so a crates.io hiccup never blocks shipping the binaries. Skips
+    # cleanly when CARGO_REGISTRY_TOKEN is unset (forks) and is idempotent — a
+    # re-run of an already-published version is a no-op, not a failure. rc/beta
+    # tags publish too: crates.io keeps prereleases out of the default
+    # `cargo install` resolution, so they can't poison the stable channel.
+    steps:
+      - uses: actions/checkout@v7
+      - name: Toolchain (auto from rust-toolchain.toml)
+        run: rustc --version && cargo --version
+      - uses: Swatinem/rust-cache@v2
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN}" ]; then
+            echo "CARGO_REGISTRY_TOKEN unset — skipping crates.io publish."
+            exit 0
+          fi
+          ver="${GITHUB_REF_NAME#v}"
+          if curl -sf -H "User-Agent: spyc-release" \
+               "https://crates.io/api/v1/crates/spyc/${ver}" >/dev/null; then
+            echo "spyc ${ver} is already on crates.io — nothing to do."
+            exit 0
+          fi
+          cargo publish --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.24"
+version = "2.0.0-rc.25"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,30 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.24"
+version = "2.0.0-rc.25"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"
 repository = "https://github.com/Tripstack-Corp/spyc"
 rust-version = "1.88"
+readme = "README.md"
+keywords = ["tui", "file-manager", "terminal", "mcp", "agent"]
+categories = ["command-line-utilities", "filesystem"]
+# Trim the published crate to what's needed to build + a README: keep `src/`
+# (incl. the `include_str!`'d `src/config/default.spycrc.toml`), Cargo.{toml,lock},
+# README, LICENSE, CHANGELOG. Drop the dev/CI/media bulk (`docs/` alone is ~5 MB
+# of assets + archives) so `cargo package` stays small and `cargo install` fast.
+exclude = [
+    "/docs",
+    "/.github",
+    "/.aislop",
+    "/fuzz",
+    "/tests",
+    "/assets",
+    "/Makefile",
+    "/cliff.toml",
+    "/deny.toml",
+    "/.gitattributes",
+]
 
 [[bin]]
 name = "spyc"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -68,6 +68,28 @@ cosign verify-blob SHA256SUMS \
 
 Make sure `~/.local/bin` is on your `PATH` (see below).
 
+### Cargo (crates.io)
+
+With a Rust toolchain, `cargo install` builds spyc from
+[crates.io](https://crates.io/crates/spyc) (needs a C compiler — the Lua
+scripting engine is vendored and built from source):
+
+```sh
+cargo install spyc
+```
+
+During the 2.0 release-candidate phase there's no stable version yet, and bare
+`cargo install spyc` resolves only stable releases — pin the current
+pre-release (the latest `-rc.<N>` on
+[crates.io](https://crates.io/crates/spyc)):
+
+```sh
+cargo install spyc --version '2.0.0-rc.<N>'
+```
+
+Once 2.0.0 ships, bare `cargo install spyc` works. The pre-built binaries above
+are faster if you'd rather not compile.
+
 ### Build from source
 
 To compile spyc yourself — to hack on it or run unreleased changes —


### PR DESCRIPTION
Adds `cargo install spyc`, as Lev asked.

## What
- **release.yml `crates` job** — publishes on every `v*` tag. Token-gated (`CARGO_REGISTRY_TOKEN`, already set as a repo secret → skips cleanly on forks), idempotent (no-ops if the version's already on crates.io), independent of the GitHub release so a crates.io hiccup never blocks the binaries. rc/beta tags publish too — crates.io keeps prereleases out of default `cargo install` resolution, so no stable-channel poisoning.
- **Cargo.toml** — crates.io metadata (readme/keywords/categories) + an `exclude` trimming the package from ~5 MB of docs/media to **1.2 MB compressed**, keeping all build-needed files (incl. the `include_str!`'d `src/config/default.spycrc.toml`).
- **INSTALL.md** — `cargo install spyc` section.

## Validation
`cargo publish --dry-run`: **packages 253 files, compiles from the packaged tarball.** `make check` green (1607 tests).

## After merge
The next release tag publishes `spyc` to crates.io (first publish claims the name). Until stable 2.0.0, install with `cargo install spyc --version 2.0.0-rc.<N>`.

Arch/AUR (`pacman`) is a separate follow-up PR — it needs an AUR account + SSH key first.

Generated with [Claude Code](https://claude.com/claude-code)