### PR TITLE
docs(readme): note cargo install (covers Arch) in the Install section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.25"
+version = "2.0.0-rc.26"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.25"
+version = "2.0.0-rc.26"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -96,9 +96,16 @@ sudo apt update && sudo apt install spyc
 ```
 
 Or grab a tarball from
-[Releases](https://github.com/Tripstack-Corp/spyc/releases). To **build
-from source** instead, see [BUILD.md](BUILD.md). Full setup — terminal,
-font, clipboard, MCP, and verification — is in [INSTALL.md](INSTALL.md).
+[Releases](https://github.com/Tripstack-Corp/spyc/releases), or — with a Rust
+toolchain — install from [crates.io](https://crates.io/crates/spyc) (also the
+easy path on Arch and any distro without a native package):
+
+```sh
+cargo install spyc --version '2.0.0-rc.<N>'   # bare `cargo install spyc` once 2.0.0 ships
+```
+
+To **build from source** instead, see [BUILD.md](BUILD.md). Full setup —
+terminal, font, clipboard, MCP, and verification — is in [INSTALL.md](INSTALL.md).
 
 ### Launch
 


### PR DESCRIPTION
Follow-up to #161 — mirrors the INSTALL.md `cargo install` section into the README quick-start, and notes that `cargo install` is the easy path on **Arch** and any distro without a native package (so no AUR is needed to unblock Lev).

Docs + version bump only.

Generated with [Claude Code](https://claude.com/claude-code)