### PR TITLE
chore(release): 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to spyc. Entries from v1.57.0 onward are generated from the conventional-commit history by [git-cliff](https://git-cliff.org) (config in `cliff.toml`); regenerate the pending section with `make changelog` and cut a release with `make release-tag VERSION=x.y.z`. Entries at v1.56.0 and earlier are the original hand-written log, kept verbatim.
 
+## [2.0.0] - 2026-07-08
+
+spyc 2.0 — the file commander built for collaborating with your coding agents.
+The terminal file manager and the agent in its side pane now share one context
+over MCP. Highlights since the 1.x line (per-change detail is in the
+`v2.0.0-rc.*` release notes + git history):
+
+### Agent integration (MCP-native)
+
+- The embedded agent pane (claude / codex / gemini / antigravity) queries and
+  drives spyc over a PID-scoped MCP server — grounding itself in the cursor,
+  picks, filter, and git branch, and navigating / picking / filtering /
+  searching / reading files / running git in-process instead of shelling out.
+- Per-tab **activity dots**: output-timing heat-pulse overridden by semantic
+  self-report (`report_status`) via status hooks, with a latched `Blocked`
+  "needs me" signal. Consent-gated hook writes; `:why-status` / `:activity`
+  diagnostics.
+- **Desktop notifications** on Blocked/Done (notify-rust locally, OSC-9 over
+  SSH) plus a branded visual-bell border pulse.
+- Live **session-id pinning** so `spyc -r` resumes the exact agent conversation.
+
+### Worktrees & multi-agent coordination
+
+- First-class git **worktree** tools over MCP (list / create / open / remove /
+  clean + claim/release leases), safe-by-default teardown (archive to the
+  graveyard, delete the branch only if merged), and ahead/behind/merged signals.
+- A **merge/scope registry** so parallel agents declare and wait on file scopes
+  before they collide, plus the `spyc-semver` git merge driver that
+  auto-resolves the version-line conflict every concurrent PR hits.
+
+### Editor & views
+
+- **Vertical split** with a live file preview and a second commander column.
+- **Lua scripting** (`~/.config/spyc/init.lua`, `map KEY lua`) — off-thread
+  mlua with an instruction-budget kill switch and a runaway prompt; exposes
+  `spyc.map`/`command`/`on` events plus the full built-in Action API.
+- **Mermaid + image pager**: render ` ```mermaid ` blocks and images inline.
+- In-house, syntax-highlighted **git diff / show / blame** (split or unified).
+
+### Under the hood
+
+- Git is **100% in-process via gix** — no `git` subprocess in production.
+- Model-View-Update throughout; event-driven repaint targeting 0 draws/sec at
+  idle.
+- **Chord & command overhaul**: a which-key hint popup, the `Space` leader, a
+  binding-tier taxonomy, and a `:` command line.
+
+### Install
+
+- Now on **Homebrew**, **apt**, and **crates.io** (`cargo install spyc`), with
+  signed release binaries (build-provenance attestations + cosign).
+
 ## [1.61.0] - 2026-06-22
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0-rc.26"
+version = "2.0.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0-rc.26"
+version = "2.0.0"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -78,17 +78,7 @@ scripting engine is vendored and built from source):
 cargo install spyc
 ```
 
-During the 2.0 release-candidate phase there's no stable version yet, and bare
-`cargo install spyc` resolves only stable releases — pin the current
-pre-release (the latest `-rc.<N>` on
-[crates.io](https://crates.io/crates/spyc)):
-
-```sh
-cargo install spyc --version '2.0.0-rc.<N>'
-```
-
-Once 2.0.0 ships, bare `cargo install spyc` works. The pre-built binaries above
-are faster if you'd rather not compile.
+The pre-built binaries above are faster if you'd rather not compile.
 
 ### Build from source
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ toolchain — install from [crates.io](https://crates.io/crates/spyc) (also the
 easy path on Arch and any distro without a native package):
 
 ```sh
-cargo install spyc --version '2.0.0-rc.<N>'   # bare `cargo install spyc` once 2.0.0 ships
+cargo install spyc
 ```
 
 To **build from source** instead, see [BUILD.md](BUILD.md). Full setup —


### PR DESCRIPTION
The stable **2.0 launch** (§13.1 license + §13.2 IP sign-offs confirmed).

## What's in it
- **Cargo.toml** `2.0.0-rc.26` → `2.0.0`.
- **CHANGELOG.md** — a curated `## [2.0.0]` **Highlights** section (git-cliff's raw output was 265 bullets across 15 rc sub-sections; the per-rc detail already lives in the `v2.0.0-rc.*` GitHub release notes). Grouped into: Agent integration (MCP), Worktrees & multi-agent coordination, Editor & views, Under the hood, Install.
- **README + INSTALL** — dropped the `--version '2.0.0-rc.<N>'` pin; bare `cargo install spyc` resolves once 2.0.0 is on crates.io.

`make check` green (1607 tests).

## Please review the CHANGELOG highlights
It's the public 2.0 release notes — check the framing/accuracy. Tweak and I'll amend.

## On your OK
I'll squash-merge, then tag **`v2.0.0`** on the merge commit → `release.yml` publishes a **stable** (non-prerelease) GitHub release, **crates.io 2.0.0** (bare `cargo install spyc` works), and bumps brew/apt to latest. Stable releases are never pruned.

Generated with [Claude Code](https://claude.com/claude-code)