### PR TITLE
fix(watch): drop read-only access events to kill the inotify open-storm

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -70,6 +70,23 @@ same pattern: spawn a worker, push a typed message into a channel,
 drop stale messages by generation. See `ROADMAP.md`'s "Background
 directory loading" entry.
 
+## Watcher event filtering (read-only access events)
+
+<!-- SPYC-TRAP: fs-watch-readonly-access -->
+The watch worker's notify callback drops read-only access events —
+`Access(Open(_))`, `Access(Read)`, `Access(Close(Read))` — before they
+reach the loop (`app/watch.rs`, `is_readonly_access`). Load-bearing on
+Linux: notify's inotify mask includes `IN_OPEN` / `IN_CLOSE_NOWRITE`, so
+every file *open* fires an event. spyc's own git-status + gitignore-excludes
+machinery opens every `.gitignore` in the tree to build the ignore stack;
+under the recursive listing watch those opens fire `Access(Open)` events,
+which drive a refresh that opens them again — a self-sustaining storm
+(~21 k events/s in a small repo, enough to starve the input path). macOS
+FSEvents never reports opens, so it's invisible in local dev — the reason
+this went unnoticed until a WSL user hit it. `Access(Close(Write))` (a real
+write completion) and every Create / Modify / Remove event still pass
+through. Removing the filter silently reintroduces the storm on Linux/WSL.
+
 ## Update model: Elm-architecture (MVU)
 
 spyc follows the Elm/Model-View-Update pattern. The structural migration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/src/app/watch.rs
+++ b/src/app/watch.rs
@@ -15,9 +15,34 @@
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::Sender;
 
-use notify::{RecursiveMode, Watcher};
+use notify::event::{AccessKind, AccessMode};
+use notify::{EventKind, RecursiveMode, Watcher};
 
 use super::Message;
+
+/// True for a pure read/open watcher event — one that never changes a file's
+/// content or the directory structure, so a file manager has nothing to react
+/// to. Dropped at the callback so it never reaches the loop.
+///
+/// This is load-bearing on Linux: `notify`'s inotify mask includes `IN_OPEN`
+/// (→ `Access(Open)`) and `IN_CLOSE_NOWRITE` (→ `Access(Close(Read))`). spyc's
+/// own git-status / gitignore-excludes machinery opens every `.gitignore` in
+/// the tree to build the ignore stack; under the recursive watch each open
+/// fires an `Access(Open)` event, which drives a refresh that opens them
+/// again — a self-sustaining storm (observed at ~21 k events/s in a small
+/// repo). macOS FSEvents never reports opens, so it's invisible in dev.
+/// `Access(Close(Write))` (a real write completion) and every Create / Modify
+/// / Remove event pass through.
+// SPYC-TRAP(fs-watch-readonly-access): dropping open/read events breaks a
+// self-sustaining inotify storm invisible on macOS (FSEvents has no opens).
+const fn is_readonly_access(kind: EventKind) -> bool {
+    matches!(
+        kind,
+        EventKind::Access(
+            AccessKind::Open(_) | AccessKind::Read | AccessKind::Close(AccessMode::Read)
+        )
+    )
+}
 
 /// Watch-topology change requested by the event loop. The worker owns the
 /// actual watch state; the main loop just describes the target topology.
@@ -62,7 +87,9 @@ pub fn spawn_watch_worker(
     // prior Ok-only drain contract).
     let watcher_tx = msg_tx.clone();
     let mut watcher = notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
-        if let Ok(ev) = res {
+        if let Ok(ev) = res
+            && !is_readonly_access(ev.kind)
+        {
             let _ = watcher_tx.send(Message::FsEvent(ev));
         }
     })
@@ -226,8 +253,40 @@ fn preview_parent_to_watch(preview: Option<&Path>, new_dir: &Path) -> Option<Pat
 
 #[cfg(test)]
 mod tests {
-    use super::preview_parent_to_watch;
+    use super::{is_readonly_access, preview_parent_to_watch};
+    use notify::EventKind;
+    use notify::event::{AccessKind, AccessMode, CreateKind, DataChange, MetadataKind, ModifyKind};
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn readonly_access_events_are_dropped() {
+        // The inotify `IN_OPEN` / `IN_CLOSE_NOWRITE` storm: pure reads.
+        assert!(is_readonly_access(EventKind::Access(AccessKind::Open(
+            AccessMode::Any
+        ))));
+        assert!(is_readonly_access(EventKind::Access(AccessKind::Read)));
+        assert!(is_readonly_access(EventKind::Access(AccessKind::Close(
+            AccessMode::Read
+        ))));
+    }
+
+    #[test]
+    fn mutating_events_pass_through() {
+        // `Access(Close(Write))` is a real write completion — it must survive.
+        assert!(!is_readonly_access(EventKind::Access(AccessKind::Close(
+            AccessMode::Write
+        ))));
+        assert!(!is_readonly_access(EventKind::Create(CreateKind::File)));
+        assert!(!is_readonly_access(EventKind::Modify(ModifyKind::Data(
+            DataChange::Any
+        ))));
+        assert!(!is_readonly_access(EventKind::Modify(
+            ModifyKind::Metadata(MetadataKind::Any)
+        )));
+        assert!(!is_readonly_access(EventKind::Modify(ModifyKind::Name(
+            notify::event::RenameMode::Both
+        ))));
+    }
 
     #[test]
     fn no_preview_means_no_watch() {


### PR DESCRIPTION
## The bug

spyc lags badly the moment you enter a git repo on **Linux/WSL** (fine outside one). The HUD shows the smoking gun: **`fs:21484/s`** — 21k filesystem-watch events/sec hammering the main loop.

## Root cause

`notify` 8.2.0's inotify mask includes `IN_OPEN` / `IN_CLOSE_NOWRITE` (`inotify.rs:427`), so on Linux **every file `open()` fires an `Access(Open)` event**. spyc's own git-status + `drop_gitignored_fs_events` machinery opens *every `.gitignore` in the tree* to build the ignore stack. Under the recursive listing watch, each open fires an event → drives a refresh → which opens all the `.gitignore`s again → **self-sustaining storm**.

Debug-log evidence from a WSL user (small book repo, idle, no agent):
- **85,885** `Access(Open(Any))` events vs a handful of real Create/Modify
- every storming path is a `.gitignore`
- mount is `noatime` (ruled out atime)

It's invisible in local dev because macOS FSEvents (the Parallels dev box) never reports opens. `/mnt/c` also felt fine only because DrvFs/9p delivers no inotify events at all.

## The fix

Drop read-only access events — `Access(Open(_))`, `Access(Read)`, `Access(Close(Read))` — at the watcher callback, before they enter the channel. `Access(Close(Write))` (a real write completion) and all Create/Modify/Remove events pass through untouched. An open/read never changes content or structure, so a file manager has nothing to react to.

Guarded by a `SPYC-TRAP(fs-watch-readonly-access)` anchor since the failure mode is silent off Linux.

## Verification

- `make check` green (fmt + clippy + test + deny); new unit tests for the filter predicate.
- ⚠️ **Needs live verification on WSL/Linux** — the storm can't be reproduced on macOS. Do not merge until confirmed that `fs:/s` drops to near-zero and input lag is gone inside a git repo.

Generated with [Claude Code](https://claude.com/claude-code)