### PR TITLE
fix(pane): only bracket-wrap pane pastes when the child enabled the mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,7 +4309,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/src/app/key_dispatch/mod.rs
+++ b/src/app/key_dispatch/mod.rs
@@ -42,6 +42,19 @@ fn bracketed_paste(text: &str) -> Vec<u8> {
     buf
 }
 
+/// Encode a paste for a pane child. Wrap in bracketed-paste markers only when
+/// the child has the mode on (`child_bracketed`) — otherwise send raw, the way
+/// the `Capture` sink already does: a shell that never enabled DECSET 2004
+/// (a remote `/bin/sh` over ssh, `csh`) takes the literal `\e[200~`/`\e[201~`
+/// bytes as input and runs a multi-line paste line-by-line.
+fn paste_bytes_for_pane(text: &str, child_bracketed: bool) -> Vec<u8> {
+    if child_bracketed {
+        bracketed_paste(text)
+    } else {
+        text.as_bytes().to_vec()
+    }
+}
+
 /// What a key destined for the bottom pane should do, w.r.t. `^z` job control.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PaneKeyAction {
@@ -579,15 +592,23 @@ impl App {
             }
             route::InputSink::BottomPane => {
                 // The user is interacting with the bottom pane — focus it (as a
-                // keystroke there would), track the text for `yP`, and forward
-                // bracketed so claude/codex/shell sees one paste block.
+                // keystroke there would) and track the text for `yP`. Wrap in
+                // bracketed-paste markers only when the child actually enabled
+                // the mode (claude/codex/a shell with it on); a plain shell over
+                // ssh that never did would otherwise take the literal `\e[200~`
+                // bytes as input. Mirrors the raw `Capture` forward above.
                 if !self.state.pane_focused() {
                     self.set_pane_focus(true);
                 }
                 self.state.pane.pane_prompt_buf.push_str(&text);
+                let child_bracketed = self
+                    .runtime
+                    .pane_tabs
+                    .as_ref()
+                    .is_some_and(|t| t.active().bracketed_paste_enabled());
                 vec![Effect::SendToPane {
                     target: PaneTarget::Active,
-                    input: PaneInput::Bytes(bracketed_paste(&text)),
+                    input: PaneInput::Bytes(paste_bytes_for_pane(&text, child_bracketed)),
                     on_ok: None,
                     err_prefix: None,
                 }]
@@ -723,11 +744,35 @@ mod prompts;
 
 #[cfg(test)]
 mod paste_tests {
-    use super::bracketed_paste;
+    use super::{bracketed_paste, paste_bytes_for_pane};
 
     #[test]
     fn wraps_plain_text() {
         assert_eq!(bracketed_paste("hello"), b"\x1b[200~hello\x1b[201~");
+    }
+
+    /// A child with the mode on (claude/codex/shell that enabled DECSET 2004)
+    /// gets the wrapped block; a child without it gets the bytes raw so the
+    /// literal markers aren't injected as input.
+    #[test]
+    fn pane_paste_wraps_only_when_child_enabled_the_mode() {
+        assert_eq!(
+            paste_bytes_for_pane("ls -la", true),
+            b"\x1b[200~ls -la\x1b[201~"
+        );
+        assert_eq!(paste_bytes_for_pane("ls -la", false), b"ls -la");
+    }
+
+    /// The regression: multi-line paste into a shell that never enabled the
+    /// mode must not carry any `\e[200~`/`\e[201~` bytes (they'd land as the
+    /// stray input seen when pasting into a remote `/bin/sh` over ssh).
+    #[test]
+    fn raw_pane_paste_has_no_bracket_markers() {
+        let out = paste_bytes_for_pane("line one\nline two\n", false);
+        assert_eq!(out, b"line one\nline two\n");
+        let s = String::from_utf8(out).unwrap();
+        assert!(!s.contains("\x1b[200~"));
+        assert!(!s.contains("\x1b[201~"));
     }
 
     #[test]

--- a/src/pane/mod.rs
+++ b/src/pane/mod.rs
@@ -439,6 +439,14 @@ impl Pane {
         self.with_screen(vt100::Screen::alternate_screen)
     }
 
+    /// Has the child enabled bracketed-paste mode (DECSET 2004)? Gates paste
+    /// wrapping: claude/codex/a shell with the mode on want the `\e[200~`…`\e[201~`
+    /// markers; a plain shell that never turned it on (e.g. a remote `/bin/sh`
+    /// over ssh) would take those bytes as literal input.
+    pub fn bracketed_paste_enabled(&self) -> bool {
+        self.with_screen(vt100::Screen::bracketed_paste)
+    }
+
     /// Return visible screen content as individual lines (plain text,
     /// no ANSI escapes). When the pane is in scroll mode, this is
     /// exactly the viewport the user is looking at — *not* the live


### PR DESCRIPTION
## Problem

Pasting into a pane hosting a plain shell over ssh garbles the input. The reported symptom (FreeBSD host over ssh): pasted `ifconfig` output shows up at the prompt as commands running line-by-line —

```
freebsd@beastie:~ $ =ec079b<RXCSUM,TXCSUM,VLAN_MTU,...,HWSTATS>
freebsd@beastie:~ $ =ec079b<RXCSUM,TXCSUM,VLAN_MTU,...,HWSTATS>
freebsd@beastie:~ $ i=ec079b<...>k
```

— and iTerm2 raises its "paste bracketing was left on" banner.

## Cause

`handle_paste`'s `BottomPane` sink wrapped every paste in bracketed-paste markers (`\e[200~`…`\e[201~`) **unconditionally**, assuming the child understood bracketed paste (DECSET `?2004h`). That's true for claude/codex and a shell that turned the mode on, but **not** for a remote `/bin/sh`, `csh`, etc. Those children:

1. take the literal `\e[200~`/`\e[201~` bytes as input (the stray `=` / `i` / `k` fragments), and
2. execute a multi-line paste line-by-line (each `\n` → Enter).

The `Capture` sink right above already handles the identical situation by forwarding raw — this brings `BottomPane` in line.

## Fix

Gate the wrapping on the child's real mode, read from the vt100 screen (`Pane::bracketed_paste_enabled()`, mirroring the existing `is_alternate_screen()`); send raw otherwise. The decision is extracted as the pure `paste_bytes_for_pane(text, child_bracketed)` and unit-tested (both branches + a multi-line no-marker regression test).

Note: a genuinely multi-line paste into a shell without the mode on will still submit line-by-line — that's the shell's real behavior. What this removes is the literal-marker injection.

## Test plan
- `make check` green (fmt + clippy + test + deny)
- New tests in `app::key_dispatch::paste_tests`
- Manual: paste multi-line text into a pane running `ssh host` → a plain shell; no `\e[200~` artifacts; claude/codex pane still receives one block.

Patch bump 2.0.0 → 2.0.1.