### PR TITLE
chore(release): v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to spyc. Entries from v1.57.0 onward are generated from the conventional-commit history by [git-cliff](https://git-cliff.org) (config in `cliff.toml`); regenerate the pending section with `make changelog` and cut a release with `make release-tag VERSION=x.y.z`. Entries at v1.56.0 and earlier are the original hand-written log, kept verbatim.
 
+## [2.0.2] - 2026-07-17
+
+### Bug Fixes
+- **watch**: Drop read-only access events to kill the inotify open-storm (#169)
+- **pane**: Only bracket-wrap pane pastes when the child enabled the mode (#170)
+
+### Build & Tooling
+- **deps**: Bump the cargo-minor-patch group with 5 updates (#165)
+
 ## [2.0.0] - 2026-07-08
 
 spyc 2.0 — the file commander built for collaborating with your coding agents.


### PR DESCRIPTION
Cut **v2.0.2**. Cargo.toml is already at 2.0.2 (per-PR bumps); this prepends the git-cliff CHANGELOG section.

Sweeps up everything since v2.0.0:
- fix(watch): drop read-only access events to kill the inotify open-storm (#169)
- fix(pane): only bracket-wrap pane pastes when the child enabled the mode (#170)
- chore(deps): bump the cargo-minor-patch group with 5 updates (#165)
- ci(release): crates.io Trusted Publishing / OIDC (#164) — excluded from user-facing notes by cliff.toml

Merging this then tagging `v2.0.2` on main fires the release fan-out (GitHub Release + crates.io + Homebrew + apt).

Generated with [Claude Code](https://claude.com/claude-code)