### PR TITLE
chore(deny): drop unreachable unmaintained ignores + bump v2.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,7 +4338,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/deny.toml
+++ b/deny.toml
@@ -70,15 +70,6 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    # yaml-rust 0.4.5 — unmaintained, no security advisory. Transitive
-    # via syntect, no upgrade path until syntect drops it. We don't
-    # parse YAML at runtime — only syntect's bundled .sublime-syntax
-    # files load it during build.
-    { id = "RUSTSEC-2024-0320", reason = "unmaintained transitive via syntect; build-time only" },
-    # bincode 1.3.3 — unmaintained per maintainer's choice; the team
-    # considers 1.3.3 a "complete" version. Transitive via syntect for
-    # serializing the bundled syntax cache.
-    { id = "RUSTSEC-2025-0141", reason = "unmaintained transitive via syntect; complete-as-shipped" },
     # quick-xml < 0.41.0 — XML-parse DoS advisories (RUSTSEC-2026-0194 quadratic
     # duplicate-attribute check; RUSTSEC-2026-0195 unbounded namespace-declaration
     # allocation). Two copies in the tree, neither reachable under the advisory's
@@ -105,8 +96,11 @@ ignore = [
 # transitive font/parsing dep we can't upgrade doesn't break CI. The trigger
 # was ttf-parser 0.25.1 (author declared EOL, recommends skrifa) — transitive
 # via resvg/fontdb for the mermaid SVG→PNG render only, no runtime untrusted
-# font input, and no safe upgrade in the resvg 0.46 tree. RUSTSEC-db
-# unmaintained advisories (real ids) are unaffected and still enforced above.
+# font input, and no safe upgrade in the resvg 0.46 tree. This scope covers the
+# RUSTSEC-db unmaintained advisories too, so a transitive one needs no `ignore`
+# entry — yaml-rust 0.4.5 (RUSTSEC-2024-0320) and bincode 1.3.3
+# (RUSTSEC-2025-0141) are still in the tree via syntect and go unreported here.
+# Vulnerability advisories are a different class and stay enforced tree-wide.
 unmaintained = "workspace"
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
## What

Removes the two `advisory-not-detected` warnings `cargo deny` has been
emitting, and fixes the comment that made them look necessary.

## Why they were dead — not the obvious reason

The warnings were for `RUSTSEC-2024-0320` (yaml-rust 0.4.5) and
`RUSTSEC-2025-0141` (bincode 1.3.3). Both crates are **still in the
tree**, still unmaintained, still transitive via syntect — so "the
dependency went away" is not the explanation.

The actual cause is `deny.toml`'s `unmaintained = "workspace"`, added
earlier for the ttf-parser EOL case. That scope suppresses the whole
unmaintained check for non-workspace crates, RUSTSEC-db advisories
included, so a transitive advisory is never reached and its `ignore`
entry never fires.

Verified by running the same check with `unmaintained = "all"`: both
`advisory-not-detected` warnings disappear, because under that scope the
advisories are encountered and the ignores actually silence them.

## Changes

- Drop the dead `RUSTSEC-2024-0320` / `RUSTSEC-2025-0141` entries.
- Correct the `unmaintained = "workspace"` rationale — it previously
  asserted "RUSTSEC-db unmaintained advisories (real ids) are unaffected
  and still enforced above", which is the opposite of what the scope
  does. Now names yaml-rust and bincode as the transitive ones going
  unreported, and notes vulnerability advisories are a separate class
  still enforced tree-wide.
- Version 2.0.2 -> 2.0.3, lock synced.

`RUSTSEC-2026-0194/0195` (quick-xml) are untouched — vulnerability
class, still detected, still needed.

## Trade-off worth knowing

This makes the config honest but does not change that two unmaintained
crates sit in the tree unreported. The louder alternative is
`unmaintained = "all"` plus explicit ignores for ttf-parser, rustybuzz,
yaml-rust and bincode: nothing gets silently dropped, at the cost of
churn on every new EOL declaration.

## Verification

`make check` green locally (fmt, clippy, `cargo test --locked
--all-targets`, deny). `cargo deny --all-features check` ends
`advisories ok, bans ok, licenses ok, sources ok` with zero stale-ignore
warnings.

Generated with [Claude Code](https://claude.com/claude-code)
