### PR TITLE
chore(release): main becomes 2.1.0-CURRENT + PR-aware release targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,14 +106,14 @@ spyc is Model-View-Update. Keep these — they're what make it reason-about-able
 - **Repaint:** event-driven dirty-frame; `needs_draw` reason codes (pane=1, event=2, other=3), `needs_full_repaint` for teardown transitions; DEC 2026 sync output wraps every frame; rows/grid cached via `list_generation`. Target 0 dps at idle.
 - **Pane I/O:** keys via `input::encode_key()`, raw bytes via `pane.send_bytes()`, paste wrapped in `\x1b[200~`…`\x1b[201~`. Prefix `^a` (`^w` alias); `^a ↓` sends a literal `^a` to the child. Panes `exec` the agent (`PtySpec.exec_replace` → `$SHELL -i -c 'exec <agent>'`, no job-control wrapper shell), so on an **agent** tab `^z` toggles a spyc-managed suspend — `Effect::SignalPane` sends `SIGSTOP`/`SIGCONT` to the pty foreground group (the agent), `TabInfo.suspended` → 💤. `SIGSTOP` not `SIGTSTP` (Claude catches `SIGTSTP` → its self-suspend handler trips the macOS false-exit `[exited 146]`); `exec` so no wrapper reclaims the tty on resume. Pure decision `pane_suspend_key_action`; a shell tab's `^z` forwards (captures/tasks keep the wrapper — no `exec`).
 - **Keep docs in sync (same commit, not a follow-up):** for user-visible / keybinding / status changes update the affected ones of `README.md`, `FEATURES.md`, `AGENTS.md` (the module index is guard-checked: `every_app_module_is_in_the_agents_index`), `ARCHITECTURE.md` (only on an architectural decision), `DESIGN.md` (only on a UI-language change), `ROADMAP.md` (strategy only — per-item work is filed as GitHub Issues), `CHANGELOG.md`, `INSTALL.md`, `docs/KEYBINDINGS.md` (the keymap reference — mirrors `?`), `src/ui/help.rs`.
-- **Bump version** in `Cargo.toml` on user-visible changes (patch = fix, minor = feature); see `CONTRIBUTING.md`.
+- **Don't bump the version in a PR.** `main` is the CURRENT stream and carries `N.M.0-CURRENT` (the next minor, unreleased) until that minor ships; the release PR is what strips the suffix. Build identity comes from the git SHA baked into `--version`. See `CONTRIBUTING.md` → Versioning.
 
 ### Commits, merges, CHANGELOG
 
 - **Commit subject = actual scope, not its caption.** A commit touching a feature + a version bump says both (`feat: gemini agent + bump cargo-deny`). The body holds the long form.
 - **Squash on merge** (`bkt pr merge <N> --strategy squash`) — `main`'s log becomes one commit per shipped shape.
-- **Version-line conflicts auto-resolve.** Because every PR bumps `version`, concurrent PRs collide on that one `Cargo.toml`/`Cargo.lock` line. The `spyc-semver` merge driver (`src/merge_driver.rs`, installed into git config on spyc launch via `.gitattributes`) keeps the higher semver on rebase; `Cargo.lock` uses `merge=ours` + a `cargo` regen. So a merge-train rebase only stops on a *real* conflict — don't hand-resolve version lines.
-- **`CHANGELOG.md` is git-cliff-generated from v1.57.0** (config `cliff.toml`): the section comes from the commit *type*, the line from `scope: subject` — so **the commit message _is_ the changelog entry** (a category-spanning PR wants multiple well-typed commits). v1.56.0 and earlier are frozen hand-written history, left verbatim. Preview with `make changelog`; release with `make release-tag VERSION=x.y.z`.
+- **Version-line conflicts are extinct on CURRENT.** A static `N.M.0-CURRENT` means no PR touches the version line, so concurrent PRs can't collide on it. The `spyc-semver` merge driver (`src/merge_driver.rs`, installed into git config on spyc launch via `.gitattributes`) therefore sits dormant here; it still earns its keep on release branches, where patch bumps resume. It parses plain `MAJOR.MINOR.PATCH` only — a conflict against a `-CURRENT` line is declined and reported as a real conflict, which is correct, since a version-line conflict on CURRENT means something unexpected happened. `Cargo.lock` keeps `merge=ours` + a `cargo` regen.
+- **`CHANGELOG.md` is git-cliff-generated from v1.57.0** (config `cliff.toml`): the section comes from the commit *type*, the line from `scope: subject` — so **the commit message _is_ the changelog entry** (a category-spanning PR wants multiple well-typed commits). v1.56.0 and earlier are frozen hand-written history, left verbatim. Preview with `make changelog`; release in two steps — `make release-prep VERSION=x.y.z` on a release branch, then `make release-tag VERSION=x.y.z` on `main` once that PR merged.
 
 ## Building
 
@@ -123,7 +123,8 @@ make install      # release build + copy to ~/.local/bin
 make check        # fmt + clippy + test + deny (CI gate)
 make fuzz         # nightly + cargo-fuzz, on-demand (NOT in check)
 make changelog    # preview the pending CHANGELOG section
-make release-tag VERSION=x.y.z        # bump + prepend changelog + commit + tag
+make release-prep VERSION=x.y.z       # step 1, on a release branch: set version + changelog + commit
+make release-tag VERSION=x.y.z        # step 2, on main after that PR merged: verify + tag
 ```
 
 **Crate shape: lib + bin.** `src/lib.rs` owns every module + the `run()` entry point; `src/main.rs` is a thin shim. The split lets `fuzz/` (a standalone workspace; nightly, on-demand) link the lib. New fuzz entry points go through the `pub mod fuzz` facade in `lib.rs`, not by widening module visibility.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,14 +145,26 @@ This is a hard requirement, not a nice-to-have. Stale docs are bugs.
 ## Versioning
 
 We use [SemVer](https://semver.org/). The version lives in
-`Cargo.toml` (currently 1.x).
+`Cargo.toml`.
 
-- **Patch** (1.57.1): bug fixes, doc updates, minor polish
-- **Minor** (1.58.0): new features, new keybindings, new milestones
-- **Major** (2.0.0): breaking changes to config, state files, or
+- **Patch** (2.0.1): bug fixes, doc updates, minor polish
+- **Minor** (2.1.0): new features, new keybindings, new milestones
+- **Major** (3.0.0): breaking changes to config, state files, or
   the command surface
 
-Bump the version in your PR if your change is user-visible.
+**Don't bump the version in your PR.** `main` is the CURRENT stream
+(FreeBSD's `-CURRENT`; see `docs/RELEASE_ENGINEERING.md`) and carries the
+*next* minor with a `-CURRENT` suffix — e.g. `2.1.0-CURRENT` while 2.1 is
+in development. It stays there for the whole cycle: the release PR is
+what strips the suffix down to `2.1.0`.
+
+So a feature PR touches no version line at all. Two things follow:
+
+- You can tell a dev build from a release at a glance — `spyc --version`
+  prints `2.1.0-CURRENT (<sha>)`, and the SHA identifies the exact build,
+  which is what per-PR bumps used to be for.
+- Concurrent PRs can no longer collide on the version line (see
+  *Merge-train conflicts* below).
 
 ## Commit messages
 
@@ -175,7 +187,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>
   headline. A category-spanning PR wants multiple well-typed
   commits, not one.
 - Preview the pending section with `make changelog`; cut a release
-  with `make release-tag VERSION=x.y.z`.
+  with `make release-prep` then `make release-tag` (see
+  `docs/RELEASE_ENGINEERING.md` § The release cycle).
 - Include the `Co-Authored-By` trailer when Claude Code contributed.
 
 See `AGENTS.md` ("Commits, merges, and CHANGELOG") for the longer
@@ -183,15 +196,23 @@ rationale.
 
 ## Merge-train conflicts
 
-Because every PR bumps `version`, concurrent PRs collide on that one
-`Cargo.toml` / `Cargo.lock` line. spyc ships a git merge driver
-(`src/merge_driver.rs`) that resolves it automatically — it keeps the
+Since `main` sits on a static `-CURRENT` version, no PR touches the
+version line and concurrent PRs can't collide on it — the conflict this
+section exists for doesn't arise on CURRENT any more.
+
+spyc still ships the git merge driver (`src/merge_driver.rs`) that
+resolves it, for release branches where patch bumps resume: it keeps the
 higher semver on rebase, so a merge-train rebase only stops on a *real*
 conflict. The driver is installed into the repo's git config the first
 time you launch spyc in the repo (idempotent); to set it up without
 launching, the `.gitattributes` driver name is `spyc-semver`. After a
 driver-assisted rebase, run `cargo build` once so `Cargo.lock` (which
 uses `merge=ours`) picks up the resolved version.
+
+Note the driver parses plain `MAJOR.MINOR.PATCH` only. A conflict against
+a `-CURRENT` line is declined and surfaces as a real conflict — correct,
+because a version-line conflict on CURRENT means something unexpected
+happened and wants a human.
 
 ## CI
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,7 +4338,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.0.3"
+version = "2.1.0-CURRENT"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.0.3"
+version = "2.1.0-CURRENT"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"

--- a/Makefile
+++ b/Makefile
@@ -143,32 +143,60 @@ release-debug: ## Optimized build with debug symbols (for `sample`, `lldb`, `per
 
 # --- Changelog & release tagging (git-cliff) ---------------------------------
 # CHANGELOG.md is git-cliff-generated from v1.57.0 onward (older entries are
-# frozen hand-written history). `make changelog` PREVIEWS the pending section;
-# `make release-tag VERSION=x.y.z` cuts a release by *prepending* the new
-# version's section (never rewriting prior entries), bumping, committing, and
-# tagging. Both are LOCAL / release-time — neither is part of `make check` or CI.
+# frozen hand-written history). `make changelog` PREVIEWS the pending section.
+#
+# Releasing is TWO steps because `main` only takes PRs — a single
+# bump-commit-and-tag target would put the tag on a release-branch commit that
+# the squash-merge then orphans, leaving the tag pointing at a commit outside
+# `main`'s history:
+#
+#   1. `make release-prep VERSION=x.y.z` on a release branch — strips `main`'s
+#      `-CURRENT` suffix down to the real version, prepends the changelog
+#      section, commits. Open that as a PR and merge it.
+#   2. `make release-tag VERSION=x.y.z` on `main` after the merge — verifies the
+#      merged commit really is that version, then tags it.
+#
+# All LOCAL / release-time — none of this runs in `make check` or CI.
 
 .PHONY: changelog
 changelog: ## Preview the pending (unreleased) CHANGELOG section from commits since the last tag
 	@command -v git-cliff >/dev/null 2>&1 || { echo "git-cliff MISSING — brew install git-cliff"; exit 1; }
 	@git cliff --config cliff.toml --unreleased
 
-.PHONY: release-tag
-release-tag: ## Cut a release: VERSION=x.y.z → bump Cargo.toml, prepend changelog section, commit, tag (local; push yourself)
-	@test "$(origin VERSION)" = "command line" || { echo "usage: make release-tag VERSION=x.y.z (VERSION defaults to the Cargo.toml value, so it must be passed explicitly)"; exit 1; }
-	@echo "$(VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "VERSION must be semver x.y.z (got '$(VERSION)')"; exit 1; }
+.PHONY: release-prep
+release-prep: ## Step 1 of 2, on a release branch: VERSION=x.y.z → set version, prepend changelog, commit (then PR it)
+	@test "$(origin VERSION)" = "command line" || { echo "usage: make release-prep VERSION=x.y.z (VERSION defaults to the Cargo.toml value, so it must be passed explicitly)"; exit 1; }
+	@echo "$(VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "VERSION must be semver x.y.z (got '$(VERSION)') — a release drops any -CURRENT suffix"; exit 1; }
 	@command -v git-cliff >/dev/null 2>&1 || { echo "git-cliff MISSING — brew install git-cliff"; exit 1; }
 	@test -z "$$(git status --porcelain)" || { echo "working tree not clean — commit or stash first"; exit 1; }
+	@test "$$(git rev-parse --abbrev-ref HEAD)" != "main" || { echo "refusing to prepare a release on main — main takes PRs only; branch first (e.g. chore/release-$(VERSION))"; exit 1; }
 	@git rev-parse "v$(VERSION)" >/dev/null 2>&1 && { echo "tag v$(VERSION) already exists"; exit 1; } || true
-	@echo "→ bumping to v$(VERSION) and prepending its changelog section…"
+	@echo "→ setting version to $(VERSION) and prepending its changelog section…"
 	@tmp=$$(mktemp); sed 's/^version = ".*"/version = "$(VERSION)"/' Cargo.toml > $$tmp && mv $$tmp Cargo.toml
 	cargo update -p $(BINARY)
 	git cliff --config cliff.toml --unreleased --tag v$(VERSION) --prepend CHANGELOG.md
 	git add Cargo.toml Cargo.lock CHANGELOG.md
 	git commit -m "chore(release): v$(VERSION)"
+	@echo "✓ prepared v$(VERSION) on $$(git rev-parse --abbrev-ref HEAD). Next:"
+	@echo "    git push -u origin HEAD && gh pr create --title 'chore(release): v$(VERSION)'"
+	@echo "    # after it merges, on main: make release-tag VERSION=$(VERSION)"
+
+.PHONY: release-tag
+release-tag: ## Step 2 of 2, on main after the release PR merged: VERSION=x.y.z → verify + tag (push yourself)
+	@test "$(origin VERSION)" = "command line" || { echo "usage: make release-tag VERSION=x.y.z (VERSION defaults to the Cargo.toml value, so it must be passed explicitly)"; exit 1; }
+	@echo "$(VERSION)" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "VERSION must be semver x.y.z (got '$(VERSION)')"; exit 1; }
+	@test -z "$$(git status --porcelain)" || { echo "working tree not clean — commit or stash first"; exit 1; }
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || { echo "refusing to tag off main (on $$(git rev-parse --abbrev-ref HEAD)) — the tag must land on main's merged release commit"; exit 1; }
+	@git rev-parse "v$(VERSION)" >/dev/null 2>&1 && { echo "tag v$(VERSION) already exists"; exit 1; } || true
+	@# The release PR is what sets the version, so a mismatch here means it has
+	@# not merged yet (or main is still on its -CURRENT suffix).
+	@test "$(VERSION)" = "$$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')" || { echo "Cargo.toml says '$$(grep '^version' Cargo.toml | head -1 | sed 's/.*\"\(.*\)\".*/\1/')', not '$(VERSION)' — run release-prep on a branch and merge that PR first"; exit 1; }
+	@grep -q '^## \[$(VERSION)\]' CHANGELOG.md || { echo "CHANGELOG.md has no [$(VERSION)] section — merge the release-prep PR first"; exit 1; }
+	@git fetch -q origin main && test "$$(git rev-parse HEAD)" = "$$(git rev-parse origin/main)" || { echo "HEAD is not origin/main — pull first so the tag lands on the merged commit"; exit 1; }
 	git tag v$(VERSION)
-	@echo "✓ committed + tagged v$(VERSION). Push per your flow, e.g.:"
-	@echo "    git push origin HEAD && git push origin v$(VERSION)"
+	@echo "✓ tagged v$(VERSION) at $$(git rev-parse --short HEAD). Push it to publish:"
+	@echo "    git push origin v$(VERSION)"
+	@echo "  then open a PR setting main's version to the next minor + '-CURRENT'."
 
 # --- macOS ---
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -12,7 +12,8 @@ header = """
 All notable changes to spyc. Entries from v1.57.0 onward are generated from the \
 conventional-commit history by [git-cliff](https://git-cliff.org) (config in \
 `cliff.toml`); regenerate the pending section with `make changelog` and cut a \
-release with `make release-tag VERSION=x.y.z`. Entries at v1.56.0 and earlier are \
+release with `make release-prep` then `make release-tag` (see \
+`docs/RELEASE_ENGINEERING.md`). Entries at v1.56.0 and earlier are \
 the original hand-written log, kept verbatim.
 
 """

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -57,6 +57,22 @@ SemVer, with FreeBSD's patch-level mapping made explicit:
 
 - `MAJOR.MINOR.PATCH` — `MAJOR.MINOR` names the release branch (`releng/2.0`),
   `PATCH` is FreeBSD's `-pK` errata/security level (`v2.0.0` → `v2.0.1` → …).
+- **What `main` carries between releases: `N.M.0-CURRENT`** — the *next* minor,
+  suffixed to mark it as the rolling CURRENT stream (`2.1.0-CURRENT` while 2.1
+  is in development). It is **static** for the whole cycle: no PR bumps it, and
+  the release PR is what strips the suffix to `N.M.0`. Three consequences:
+  - A dev build is self-identifying: `spyc --version` prints
+    `2.1.0-CURRENT (<sha>)`. The SHA gives exact build identity, which is what
+    the former bump-every-PR rule provided.
+  - Version-line merge conflicts stop happening, since nothing edits that line.
+    The `spyc-semver` driver goes dormant on CURRENT (it parses plain triples
+    and declines a `-CURRENT` line) and still serves release branches.
+  - Nothing publishes a CURRENT version: only `v*` tags trigger `release.yml`,
+    and CURRENT is never tagged. Were one ever packaged, `make deb`'s
+    `DEB_VERSION` tilde-forms it to `2.1.0~CURRENT`, which dpkg sorts *below*
+    the real `2.1.0` — the same ordering rule the `2.0.0~rc.N` debs rely on.
+  - After a minor ships, a follow-up PR opens the next cycle by setting `main`
+    to the following `-CURRENT`.
 - **Prereleases:** `vN.M.0-beta.1`, `vN.M.0-rc.1` — published as GitHub
   *pre-releases* (the "Latest" badge stays on the last stable).
 - **Breaking changes** bump MAJOR and (Stage 2) start a new `stable/N`.
@@ -98,15 +114,24 @@ tag RELEASEs directly off `main` until a second major needs `stable/`.
 
 **Stage 1 (single line, what we launch with):**
 
-1. Development accrues on `main`; CI green on every PR.
+1. Development accrues on `main`, which sits at `N.M.0-CURRENT` (§3); CI green
+   on every PR.
 2. **Cut RC:** tag `vN.M.0-rc.1` on `main`. `release.yml` builds + publishes a
    GitHub *pre-release* with full artifacts. Soak (e.g., 3–7 days / dogfood).
 3. Fix blockers on `main`; re-tag `-rc.2` as needed.
-4. **Release:** `make release-tag VERSION=N.M.0` (bumps `Cargo.toml`, prepends
-   the git-cliff changelog section, commits, tags `vN.M.0`). Push the tag →
-   `release.yml` publishes the RELEASE.
-5. **Patch:** for a post-release fix, `make release-tag VERSION=N.M.(P+1)` →
-   tag → release. (Stage 2: cherry-pick onto `releng/N.M` first.)
+4. **Release — two steps, because `main` only takes PRs.** A single
+   bump-commit-and-tag would put the tag on a release-branch commit that the
+   squash-merge then orphans, leaving it outside `main`'s history:
+   1. On a `chore/release-N.M.P` branch: `make release-prep VERSION=N.M.P` —
+      strips the `-CURRENT` suffix to the real version, prepends the git-cliff
+      section, commits. Open it as a PR and merge it.
+   2. On `main` once merged: `make release-tag VERSION=N.M.P` — verifies the
+      merged commit really is that version, that the changelog has its section,
+      and that `HEAD` is `origin/main`, then tags. Push the tag →
+      `release.yml` publishes the RELEASE.
+   Then open a follow-up PR setting `main` to the next `-CURRENT`.
+5. **Patch:** same two steps with `VERSION=N.M.(P+1)`. (Stage 2: cherry-pick
+   onto `releng/N.M` first.)
 
 **Stage 2 (parallel majors):** add a freeze on a `releng/N.M` branch forked
 from `stable/N`, run `-beta.X` → `-rc.X` → `vN.M.0` on that branch, and keep


### PR DESCRIPTION
Opens the 2.1 cycle, and fixes the release tooling to match how releases
are actually cut.

## `main` becomes `2.1.0-CURRENT`

`docs/RELEASE_ENGINEERING.md` §2 already maps FreeBSD's `-CURRENT` onto
`main`; what was never written down is what version `main` carries
*between* releases. Now it carries the next unreleased minor with a
`-CURRENT` suffix, **static for the whole cycle** — no PR bumps it, and
the release PR strips the suffix to `2.1.0`.

Build identity still works: `--version` prints `2.1.0-CURRENT (<sha>)`,
and the SHA identifies the exact build, which is what the retired
bump-every-PR rule was providing.

## `release-tag` split in two

The old target bumped, committed **and tagged** in one go — which assumes
pushing straight to `main`. But `main` takes PRs only, so on the real flow
the tag lands on the release-*branch* commit that the squash-merge then
orphans, leaving the tag outside `main`'s history. v2.0.2 and v2.0.3 were
both hand-worked around this.

| Step | Where | Does |
|---|---|---|
| `make release-prep VERSION=x.y.z` | release branch | set version (dropping `-CURRENT`), prepend changelog, commit |
| `make release-tag VERSION=x.y.z` | `main`, post-merge | verify + tag |

`release-prep` refuses to run on `main` and refuses a VERSION that still
carries a suffix. `release-tag` refuses unless `Cargo.toml` really is that
version, `CHANGELOG.md` has its `## [x.y.z]` section, and `HEAD` is
`origin/main` — so it can't tag a CURRENT commit or an unmerged one.

## Verified, not assumed

- Makefile parses the suffix; `DEB_VERSION` tilde-forms it to
  `2.1.0~CURRENT`, which dpkg sorts **below** the real `2.1.0` — the same
  ordering the live `2.0.0~rc.N` debs depend on. Moot in practice: only
  `v*` tags trigger `release.yml`, and CURRENT is never tagged.
- Crate compiles and the full gate passes as `spyc v2.1.0-CURRENT`.
- Exercised the new guards: prerelease VERSION rejected, dirty tree
  rejected, missing VERSION rejected.

## Merge driver

`spyc-semver` goes dormant on CURRENT — nothing edits the version line, so
the conflicts it exists to resolve stop occurring. It parses plain
`MAJOR.MINOR.PATCH` and declines a `-CURRENT` line, which is the right
behavior: a version-line conflict on CURRENT means something unexpected
and wants a human. It still serves release branches, where patch bumps
resume.

## Docs (same commit)

`RELEASE_ENGINEERING.md` §3 (CURRENT convention) and §5 (two-step cycle);
`AGENTS.md` + `CONTRIBUTING.md` retire the bump rule and restate the
merge-train section; `cliff.toml`'s changelog header stops naming the
one-step flow.

`make check` green (fmt, clippy, `cargo test --locked --all-targets`, deny).

Generated with [Claude Code](https://claude.com/claude-code)
