### PR TITLE
chore(apt): prune superseded prerelease debs on every publish

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -17,6 +17,11 @@
 # stays green until then. Prereleases publish too — the deb version uses a
 # tilde (`2.0.0~rc.4`), which dpkg sorts BELOW the final `2.0.0`, so an rc never
 # blocks the stable upgrade (the Makefile's `DEB_VERSION` does the `-`→`~`).
+#
+# Because rc debs publish, they also accumulate: step 3 runs
+# `scripts/prune-apt-repo.sh` first, dropping prereleases whose final release
+# has shipped (and all but the 3 newest of an in-flight version) so the index
+# doesn't grow without bound. Stable versions are never pruned.
 name: apt
 
 on:
@@ -118,6 +123,11 @@ jobs:
         run: |
           set -euo pipefail
           cp dist/spyc_*.deb aptrepo/
+          # Prune BEFORE indexing, in this same step: the index and its GPG
+          # signature must describe the pruned set. Deleting debs without
+          # reindexing would leave the signed Packages advertising files that
+          # are gone, which fails apt's hash check on every client.
+          ./scripts/prune-apt-repo.sh aptrepo
           cd aptrepo
           apt-ftparchive packages . > Packages
           gzip -kf Packages

--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,15 @@ deb-arm: ## Package the built Linux aarch64 binary → dist/spyc_<version>_arm64
 .PHONY: deb
 deb: deb-x86 deb-arm ## Package both Linux .debs (binaries must already be built)
 
+# apt.yml runs this against the gh-pages checkout on every publish, so the repo
+# self-maintains. Exposed here to inspect the policy against a local checkout of
+# gh-pages without publishing: `make apt-prune-check APT_REPO=../spyc-gh-pages`.
+APT_REPO ?=
+.PHONY: apt-prune-check
+apt-prune-check: ## Dry-run the apt prerelease pruning (set APT_REPO=<gh-pages checkout>)
+	@test -n "$(APT_REPO)" || { echo "usage: make apt-prune-check APT_REPO=<dir>"; exit 1; }
+	@./scripts/prune-apt-repo.sh --dry-run "$(APT_REPO)"
+
 # Internal: build one .deb from $(SRC) for $(ARCH). Fails clearly if the binary
 # is missing — build it with the matching release-linux-* target first.
 .PHONY: _deb

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -146,6 +146,28 @@ pre-releases are pruned — stable `vN.M.P` releases are never touched. Older RC
 throwaway soak builds (~38 MB of assets each); the changelog and stable tags are the
 durable record.
 
+**RC retention in apt** mirrors it, but on a different rule, because a published
+deb is an *installable artifact* rather than a download. `apt.yml` runs
+`scripts/prune-apt-repo.sh` on every publish, before regenerating the index:
+
+- A prerelease deb is dropped **once its final release is present**. dpkg sorts
+  `2.0.0~rc.11` below `2.0.0`, so once the stable exists that deb can never be
+  selected again — it is pure index weight.
+- Otherwise the **3 newest prereleases of an in-flight version** are kept, per
+  version line, so a soak in progress stays installable.
+- **Stable versions are never pruned** — pinning an older release is legitimate.
+
+The prune runs in the same step as the reindex on purpose: `Packages` /
+`Release` / `InRelease` are GPG-signed over the file set, so deleting debs
+without regenerating and re-signing would leave the signed index advertising
+files that are gone, failing apt's hash check on every client. That is also why
+this can't be done by hand-editing `gh-pages` — the signing key only exists
+inside the `apt-publish` environment. To purge retroactively, dispatch `apt.yml`
+with any recent tag; the prune runs on the way through.
+
+Inspect the policy against a local gh-pages checkout without publishing:
+`make apt-prune-check APT_REPO=<dir>`.
+
 ## 6. Maintenance: Errata & Security (EN / SA)
 
 FreeBSD splits post-release fixes into **Errata Notices** (critical non-security)

--- a/scripts/prune-apt-repo.sh
+++ b/scripts/prune-apt-repo.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Prune superseded prerelease .debs from spyc's flat apt repo.
+#
+# apt tracks the rc stream (see RELEASE_ENGINEERING.md §8), so every `-rc` tag
+# publishes a deb. Those accumulate forever otherwise: the 2.0.x line alone left
+# nine rc versions x two arches in the published index long after 2.0.0 shipped.
+#
+# Policy:
+#   * A prerelease (tilde in the version, e.g. `2.0.0~rc.11`) is DELETED once its
+#     final release is present. dpkg sorts `2.0.0~rc.11` BELOW `2.0.0`, so such a
+#     deb can never be selected again — it is pure index weight.
+#   * Otherwise the KEEP most recent prereleases of an in-flight version are kept
+#     and older ones deleted. Mirrors release.yml's "3 most recent -rc
+#     pre-releases" retention so the two channels agree.
+#   * Stable releases are NEVER pruned — users legitimately pin an old version.
+#
+# Run this AFTER copying the newly built debs in and BEFORE regenerating the
+# index, so `Packages` / `Release` / `InRelease` are rebuilt and re-signed over
+# the pruned set. Deleting debs without reindexing leaves the signed index
+# advertising files that no longer exist, which fails apt's hash check.
+#
+# Usage: prune-apt-repo.sh [--dry-run] [--keep N] <repo-dir>
+set -euo pipefail
+
+KEEP=3
+DRY_RUN=0
+REPO=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --keep) KEEP="${2:?--keep needs a number}"; shift 2 ;;
+        -h|--help) sed -n '2,25p' "$0"; exit 0 ;;
+        -*) echo "unknown flag: $1" >&2; exit 2 ;;
+        *) REPO="$1"; shift ;;
+    esac
+done
+
+[ -n "$REPO" ] || { echo "usage: $(basename "$0") [--dry-run] [--keep N] <repo-dir>" >&2; exit 2; }
+[ -d "$REPO" ] || { echo "not a directory: $REPO" >&2; exit 2; }
+case "$KEEP" in ''|*[!0-9]*) echo "--keep must be a number (got '$KEEP')" >&2; exit 2 ;; esac
+
+cd "$REPO"
+
+# Every version present, and which of them are stable. Filenames are
+# `spyc_<version>_<arch>.deb`; the version field never contains `_`.
+versions=$(ls spyc_*_*.deb 2>/dev/null | sed -n 's/^spyc_\(.*\)_[^_]*\.deb$/\1/p' | sort -u || true)
+if [ -z "$versions" ]; then
+    echo "prune: no debs in $REPO — nothing to do"
+    exit 0
+fi
+
+stable=$(printf '%s\n' "$versions" | grep -v '~' || true)
+prereleases=$(printf '%s\n' "$versions" | grep '~' || true)
+
+if [ -z "$prereleases" ]; then
+    echo "prune: no prerelease debs — nothing to do"
+    exit 0
+fi
+
+doomed=""
+
+# 1. Prereleases whose final release has shipped.
+for ver in $prereleases; do
+    base="${ver%%~*}"
+    if printf '%s\n' "$stable" | grep -qxF "$base"; then
+        doomed="$doomed $ver"
+    fi
+done
+
+# 2. Of what remains (versions still in flight), keep the KEEP newest per base.
+#    `sort -V` orders `rc.9` before `rc.11` (digit runs compare numerically),
+#    which is what matters within a single base version.
+in_flight=""
+for ver in $prereleases; do
+    if [[ " $doomed " == *" $ver "* ]]; then
+        continue
+    fi
+    in_flight="$in_flight $ver"
+done
+
+for base in $(printf '%s\n' $in_flight | sed 's/~.*//' | sort -u); do
+    same_base=$(printf '%s\n' $in_flight | grep -F "${base}~" | sort -V)
+    total=$(printf '%s\n' "$same_base" | grep -c . || true)
+    # Drop all but the newest KEEP. `head -n -N` is GNU-only, so compute the
+    # count instead and keep this runnable on macOS as well as the CI runner.
+    excess=$((total - KEEP))
+    [ "$excess" -gt 0 ] || continue
+    for ver in $(printf '%s\n' "$same_base" | head -n "$excess"); do
+        doomed="$doomed $ver"
+    done
+done
+
+if [ -z "${doomed// /}" ]; then
+    echo "prune: nothing superseded (kept $(printf '%s\n' "$versions" | wc -l | tr -d ' ') version(s))"
+    exit 0
+fi
+
+removed=0
+for ver in $doomed; do
+    for f in spyc_"$ver"_*.deb; do
+        [ -e "$f" ] || continue
+        if [ "$DRY_RUN" -eq 1 ]; then
+            echo "prune: would remove $f"
+        else
+            rm -f -- "$f"
+            echo "prune: removed $f"
+        fi
+        removed=$((removed + 1))
+    done
+done
+
+verb=$([ "$DRY_RUN" -eq 1 ] && echo "would remove" || echo "removed")
+echo "prune: $verb $removed file(s); kept $(ls spyc_*_*.deb 2>/dev/null | wc -l | tr -d ' ')"


### PR DESCRIPTION
apt tracks the rc stream, so every `-rc` tag publishes a deb — and they accumulate forever. The published index still carries **nine `2.0.0~rc.*` versions × two arches (18 files)** months after 2.0.0 shipped. dpkg sorts a tilde version *below* the final, so none of them can ever be selected again; they are pure index weight.

## Policy

`scripts/prune-apt-repo.sh`, run by `apt.yml` on every publish:

- A prerelease is dropped **once its final release is present**.
- Otherwise the **3 newest prereleases of an in-flight version** are kept, per version line, so a soak in progress stays installable. Mirrors `release.yml`'s 3-most-recent-rc retention so the two channels agree.
- **Stable versions are never pruned** — pinning an old release is legitimate.

## Why it runs where it does

The prune sits in the **same step** as the reindex, immediately before it, and that ordering is load-bearing: `Packages` / `Release` / `InRelease` are GPG-signed over the file set. Deleting debs without regenerating and re-signing would leave the signed index advertising files that are gone — failing apt's hash check on **every client**.

That is also why this could not be a manual `gh-pages` edit: the signing key exists only inside the `apt-publish` environment, so nothing outside the workflow can produce a valid index. Dispatching `apt.yml` with any recent tag purges retroactively.

## Verification

Tested against a fixture reproducing the live repo exactly (all 24 debs): removes **precisely the 18** superseded files, keeps 2.0.0 / 2.0.2 / 2.0.3. Also covered:

| Case | Result |
|---|---|
| 2.1 in flight, 5 rcs, no stable | keeps newest 3 |
| `rc.8/9/10/11` | keeps 9, 10, 11 — version-aware ordering, the case a lexical sort gets wrong |
| two in-flight lines | tracked independently |
| stable-only repo | no-op |
| empty repo / re-run | no-op, idempotent |

Also verified the workflow’s exact invocation shape (`./scripts/prune-apt-repo.sh aptrepo` from the repo root), that the script is committed **executable** (100755 — otherwise the step dies on permission denied), and that `apt.yml` still parses as YAML.

`make check` green (1634 tests). `make apt-prune-check APT_REPO=<dir>` dry-runs the policy against a local gh-pages checkout.

## After merge

Dispatch `apt.yml` with `tag: v2.0.3` to perform the one-time purge — that rebuilds the 2.0.3 debs, prunes the 18 stale ones, then reindexes and re-signs in one atomic commit.

Generated with [Claude Code](https://claude.com/claude-code)