### PR TITLE
fix(listing): surface why a directory read failed, not just which one

### DIFF
--- a/src/app/find_picker.rs
+++ b/src/app/find_picker.rs
@@ -201,7 +201,7 @@ impl App {
                     let abs = root.join(&rel);
                     if let Some(parent) = abs.parent() {
                         if let Err(e) = self.state.chdir(parent) {
-                            self.state.flash_error(format!("chdir: {e}"));
+                            self.state.flash_error(format!("chdir: {e:#}"));
                         } else if let Some(idx) =
                             self.state.cur().rows.iter().position(|r| r.path == abs)
                         {

--- a/src/app/navigate.rs
+++ b/src/app/navigate.rs
@@ -54,7 +54,7 @@ impl App {
             return;
         };
         if let Err(e) = self.state.chdir(&chdir_to) {
-            self.state.flash_error(format!("chdir: {e}"));
+            self.state.flash_error(format!("chdir: {e:#}"));
             return;
         }
         if let Some(p) = focus {
@@ -207,7 +207,7 @@ impl App {
                     .map_or_else(|| path.clone(), Path::to_path_buf)
             };
             if let Err(e) = self.state.chdir(&target_dir) {
-                self.state.flash_error(format!("chdir: {e}"));
+                self.state.flash_error(format!("chdir: {e:#}"));
                 return Vec::new();
             }
             self.state.cur_mut().view = View::Dir;
@@ -229,7 +229,7 @@ impl App {
 
         if descend {
             if let Err(e) = self.state.chdir(&path) {
-                self.state.flash_error(format!("chdir: {e}"));
+                self.state.flash_error(format!("chdir: {e:#}"));
             }
             return Vec::new();
         }

--- a/src/app/pager_handler/pickers.rs
+++ b/src/app/pager_handler/pickers.rs
@@ -159,7 +159,7 @@ impl App {
         // re-anchored — it stays the overall anchor (`g h`). (`g w` jumps to
         // this column's worktree root.)
         if let Err(e) = self.state.chdir(&path) {
-            self.state.flash_error(format!("chdir: {e}"));
+            self.state.flash_error(format!("chdir: {e:#}"));
             return;
         }
         // Re-key the focused column's harpoon to the new worktree root.

--- a/src/app/state/listing.rs
+++ b/src/app/state/listing.rs
@@ -428,7 +428,11 @@ impl AppState {
                     self.flash_info(msg.to_string());
                 }
             }
-            Err(e) => self.flash_error(format!("{err_prefix}: {e}")),
+            // `{e:#}` (anyhow alternate) renders the whole source chain. Plain
+            // `{e}` shows only the outermost context, which silently dropped
+            // the real cause — e.g. a macOS privacy denial arrived as the
+            // unactionable "chdir: reading directory <path>".
+            Err(e) => self.flash_error(format!("{err_prefix}: {e:#}")),
         }
     }
 

--- a/src/app/state/navigation.rs
+++ b/src/app/state/navigation.rs
@@ -221,12 +221,12 @@ impl AppState {
         let md = std::fs::metadata(&canonical)?;
         if md.is_dir() {
             if let Err(e) = self.chdir(&canonical) {
-                self.flash_error(format!("chdir: {e}"));
+                self.flash_error(format!("chdir: {e:#}"));
                 return Ok(());
             }
         } else if let Some(parent) = canonical.parent() {
             if let Err(e) = self.chdir(parent) {
-                self.flash_error(format!("chdir: {e}"));
+                self.flash_error(format!("chdir: {e:#}"));
                 return Ok(());
             }
             self.focus_on_path(&canonical);

--- a/src/app/worktree_ops.rs
+++ b/src/app/worktree_ops.rs
@@ -311,7 +311,7 @@ impl App {
                             self.state
                                 .flash_info(format!("created worktree: {}", path.display()));
                             if let Err(e) = self.state.chdir(&path) {
-                                self.state.flash_error(format!("chdir: {e}"));
+                                self.state.flash_error(format!("chdir: {e:#}"));
                             }
                         }
                         None => {

--- a/src/fs/listing.rs
+++ b/src/fs/listing.rs
@@ -1,9 +1,44 @@
 use std::fmt;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 use super::entry::{Entry, EntryKind};
+
+/// Whether a directory-read failure is a macOS privacy (TCC) denial rather than
+/// an ordinary permission problem.
+///
+/// macOS reports a TCC denial on a protected folder (`~/Downloads`, `~/Desktop`,
+/// `~/Documents`, iCloud, removable volumes) as **`EPERM`**, while a genuine
+/// mode-based refusal is `EACCES` — and Rust maps *both* to
+/// `ErrorKind::PermissionDenied`, so only the raw errno separates them. The
+/// giveaway is that the POSIX mode already grants the owner read (`drwx------`
+/// owned by you) and the read still fails, which no `chmod` can fix: the grant
+/// lives in System Settings, not the filesystem.
+#[cfg(target_os = "macos")]
+fn is_privacy_denial(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(1) // EPERM
+}
+
+/// Attach the path to a `read_dir` failure — plus, on macOS, the one hint that
+/// makes a TCC denial actionable.
+///
+/// The bare OS message for that case is "Operation not permitted", which reads
+/// like a filesystem problem and sends you to `chmod`. Naming the real cause is
+/// the difference between an unactionable error and a two-click fix.
+fn read_dir_error(dir: &Path, e: std::io::Error) -> anyhow::Error {
+    #[cfg(target_os = "macos")]
+    if is_privacy_denial(&e) {
+        return anyhow::anyhow!(
+            "reading directory {}: {e} — macOS privacy protection, not file \
+             permissions: grant your terminal access to this folder under System \
+             Settings \u{2192} Privacy & Security \u{2192} Files and Folders (or \
+             Full Disk Access)",
+            dir.display()
+        );
+    }
+    anyhow::Error::new(e).context(format!("reading directory {}", dir.display()))
+}
 
 /// Sort order for the file listing. Dirs-first grouping is always applied;
 /// this controls the secondary sort within each group.
@@ -108,8 +143,7 @@ impl Listing {
         let dir = dir.as_ref().to_path_buf();
         let mut entries: Vec<Entry> = Vec::new();
         let mut truncated = false;
-        let rd = std::fs::read_dir(&dir)
-            .with_context(|| format!("reading directory {}", dir.display()))?;
+        let rd = std::fs::read_dir(&dir).map_err(|e| read_dir_error(&dir, e))?;
         for item in rd {
             if entries.len() >= cap {
                 truncated = true;
@@ -308,6 +342,116 @@ mod tests {
         assert_eq!(
             names(&l),
             ["Alpha", "zeta", "apple.rs", "cherry.rs", "Banana.txt"]
+        );
+    }
+
+    /// The reported bug: navigating into a directory spyc can't read produced
+    /// "chdir: reading directory <path>" and nothing else, because the flash
+    /// rendered the anyhow error with `{e}` (outermost context only). The cause
+    /// must survive into the message the user actually sees.
+    #[test]
+    fn an_unreadable_directory_reports_why_not_just_the_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let locked = tmp.path().join("locked");
+        std::fs::create_dir(&locked).unwrap();
+        // Drop all permissions so read_dir genuinely fails. (Skipped when
+        // running as root, which ignores the mode.)
+        let mut perms = std::fs::metadata(&locked).unwrap().permissions();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            perms.set_mode(0o000);
+        }
+        std::fs::set_permissions(&locked, perms).unwrap();
+
+        let result = Listing::read(&locked);
+        // Restore so the tempdir can be cleaned up regardless of outcome.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut p = std::fs::metadata(&locked).unwrap().permissions();
+            p.set_mode(0o700);
+            let _ = std::fs::set_permissions(&locked, p);
+        }
+
+        let Err(e) = result else {
+            // Running as root (CI containers sometimes do): the mode is
+            // ignored, so there is no failure to inspect.
+            return;
+        };
+        let plain = format!("{e}");
+        let full = format!("{e:#}");
+        assert!(
+            plain.contains("locked"),
+            "the path should always be named: {plain}"
+        );
+        // The regression guard: the alternate form must carry a cause beyond the
+        // context line, otherwise the user is told what failed but never why.
+        assert!(
+            full.len() > plain.len(),
+            "`{{e:#}}` must add the cause; got the same string both ways: {full}"
+        );
+        assert!(
+            full.to_lowercase().contains("permission")
+                || full.to_lowercase().contains("denied")
+                || full.to_lowercase().contains("not permitted"),
+            "the cause should name the permission failure: {full}"
+        );
+    }
+
+    /// A macOS privacy (TCC) denial arrives as EPERM even though the POSIX mode
+    /// grants the owner read, so `chmod` can never fix it. Keying the hint on
+    /// `ErrorKind::PermissionDenied` would be wrong — Rust maps both EPERM and
+    /// EACCES to it — so this pins the errno-level discrimination.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn only_eperm_is_treated_as_a_privacy_denial() {
+        use std::io::{Error, ErrorKind};
+        let eperm = Error::from_raw_os_error(1);
+        let eacces = Error::from_raw_os_error(13);
+        // Both look identical at the ErrorKind level — hence the raw errno.
+        assert_eq!(eperm.kind(), ErrorKind::PermissionDenied);
+        assert_eq!(eacces.kind(), ErrorKind::PermissionDenied);
+        assert!(super::is_privacy_denial(&eperm));
+        assert!(
+            !super::is_privacy_denial(&eacces),
+            "EACCES is an ordinary permission problem, not a TCC denial"
+        );
+    }
+
+    /// The hint has to name System Settings, since that is the only place the
+    /// grant can be made — the whole point of distinguishing this case.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn a_privacy_denial_points_at_system_settings() {
+        let e = super::read_dir_error(
+            std::path::Path::new("/Users/someone/Downloads"),
+            std::io::Error::from_raw_os_error(1),
+        );
+        let msg = format!("{e:#}");
+        assert!(
+            msg.contains("/Users/someone/Downloads"),
+            "names the path: {msg}"
+        );
+        assert!(msg.contains("Privacy"), "points at System Settings: {msg}");
+        assert!(
+            msg.contains("not file permissions") || msg.contains("privacy"),
+            "distinguishes it from a chmod problem: {msg}"
+        );
+    }
+
+    /// An ordinary failure must NOT be dressed up as a privacy problem.
+    #[test]
+    fn a_missing_directory_gets_no_privacy_hint() {
+        let e = super::read_dir_error(
+            std::path::Path::new("/nope/missing"),
+            std::io::Error::from_raw_os_error(2), // ENOENT
+        );
+        let msg = format!("{e:#}");
+        assert!(msg.contains("/nope/missing"), "names the path: {msg}");
+        assert!(
+            !msg.contains("Privacy"),
+            "ENOENT is not a privacy denial: {msg}"
         );
     }
 }


### PR DESCRIPTION
Reported: entering `~/Downloads` flashed

```
chdir: reading directory /Users/derekmarshall/Downloads
```

…and nothing more. The real cause was a macOS privacy (TCC) denial, but the message never said so — nothing to act on, and it looks like a spyc bug.

## Two defects, one visible

**1. The cause was thrown away at the last step.** `Listing::read` wraps the `io::Error` with `with_context`, so anyhow *had* the cause the whole time — but the flash rendered it with `{e}`, and anyhow’s plain `Display` prints only the outermost context. `{e:#}` renders the full chain.

Fixed in `change_dir` (one line covering every `err_prefix` caller — `chdir`, `cd`, jump-to-start / project-home / worktree-root / back) plus the eight direct `chdir: {e}` flash sites.

**2. Even with the cause shown, "Operation not permitted" misleads.** It reads like a filesystem permission problem and sends you to `chmod`, which can *never* fix a TCC denial — the grant lives in System Settings. So that case now names itself and says where to go.

## Why the check is errno-level

macOS reports a TCC denial as **EPERM**, an ordinary refusal as **EACCES**, and Rust maps **both** to `ErrorKind::PermissionDenied`. Keying the hint on `ErrorKind` would have mislabelled every genuine permission error as a privacy problem. Only the raw errno separates them.

Confirmed empirically on the reporting machine: the directory was `drwx------` owned by the user — POSIX grants the owner read — and `read_dir` still returned errno 1, selectively for `Downloads` while `Desktop` and `Documents` read fine. `com.apple.macl` was present on the directory. The grant has since been made, so the symptom no longer reproduces there; the message defect is permanent and is what this fixes.

## Tests

- Reproduction against a genuinely unreadable directory: the cause must survive into the message, asserting `{e:#}` adds what `{e}` dropped.
- EPERM vs EACCES discrimination, pinned *against* the `ErrorKind` collision so the distinction can’t silently regress.
- The hint names System Settings.
- ENOENT is **not** dressed up as a privacy problem.

`make check` green — 1638 tests, clippy, fmt, deny.

## Scope

Deliberately limited to the directory-navigation family. The same dropped-cause pattern (`format!("…{e}")` on an anyhow error) exists at ~50 other flash sites across 39 files; `{e}` → `{e:#}` is safe there too (`io::Error` ignores the alternate flag), but that is a mechanical sweep worth its own PR rather than bundling.

Generated with [Claude Code](https://claude.com/claude-code)