### PR TITLE
docs: recommend single-branch clone to avoid large downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ Cargo.lock.bak
 # aislop local trend log (written on every `make aislop`); the baseline
 # (.aislop/baseline.json) IS committed, this churn log is not.
 .aislop/history.jsonl
+
+# Antigravity agent environment files
+.agents/

--- a/BUILD.md
+++ b/BUILD.md
@@ -26,7 +26,8 @@ to a newer release.
 ## Build and install
 
 ```sh
-git clone https://github.com/Tripstack-Corp/spyc.git
+# Use single-branch to avoid downloading the heavy gh-pages branch
+git clone --single-branch --branch main https://github.com/Tripstack-Corp/spyc.git
 cd spyc
 make install          # builds release + copies to ~/.local/bin (no sudo)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ workflow, standards, and conventions for the project.
 ## Getting started
 
 ```sh
-git clone git@github.com:Tripstack-Corp/spyc.git
+# Use single-branch to avoid downloading the heavy gh-pages branch
+git clone --single-branch --branch main git@github.com:Tripstack-Corp/spyc.git
 cd spyc
 make doctor    # check prerequisites (rustc, cargo, zig, etc.)
 cargo build    # dev build

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ It is also, by definition, unreleased: rolling, and it may break. There are no
 prebuilt binaries — CURRENT is source-only, so you need a Rust toolchain.
 
 ```sh
-git clone https://github.com/Tripstack-Corp/spyc.git
+# Use single-branch to avoid downloading the heavy gh-pages branch
+git clone --single-branch --branch main https://github.com/Tripstack-Corp/spyc.git
 cd spyc
 make install        # release build → ~/.local/bin/spyc
 ```


### PR DESCRIPTION
Recommends single-branch clones to avoid downloading the heavy gh-pages branch. Also ignores .agents in .gitignore.