### PR TITLE
chore: remove accidental test_gix.rs

### DIFF
--- a/test_gix.rs
+++ b/test_gix.rs
@@ -1,6 +1,0 @@
-fn main() {
-    let repo = gix::open("/Users/drek/src/spyc.worktrees/agy-mcp-support").unwrap();
-    let common_dir = std::fs::canonicalize(repo.common_dir()).unwrap();
-    let main_repo = gix::open(&common_dir).unwrap();
-    println!("{:?}", main_repo.work_dir().unwrap());
-}


### PR DESCRIPTION
Removes test_gix.rs which was accidentally committed during merge conflict resolution.