### PR TITLE
docs(agent): correct the transcript-miss behavior and agy's transcript path

### DIFF
--- a/docs/drafts/AUTO_APPROVAL_PLAN.md
+++ b/docs/drafts/AUTO_APPROVAL_PLAN.md
@@ -110,10 +110,18 @@ parsed today; tool-use schema needs confirming.
 ### Gemini CLI — out of scope
 
 Dropped. Google deprecated the Gemini CLI in favour of Antigravity, and spyc
-removed its `AgentProfile` accordingly. Anything this plan ships for a
-third agent targets **agy** instead: its transcript is
-`~/.gemini/antigravity-cli/history.jsonl` (one JSON line per turn, keyed by
-`conversationId` + `workspace`), parsed today in `find_agy_sessions`.
+removed its `AgentProfile` accordingly. Anything this plan ships for a third
+agent targets **agy** instead. Two separate files, easy to confuse:
+
+* **The transcript** (what a tool-use log would come from) —
+  `~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/transcript.jsonl`,
+  one JSON step per line (`step_index` / `source` / `type` / `content`), rendered
+  today by `state::agy_transcript`.
+* **`~/.gemini/antigravity-cli/history.jsonl`** — NOT a transcript: agy's
+  typed-prompt log, one line per message the user sent, and it only carries a
+  `conversationId` for messages sent inside an already-`--conversation`-resumed
+  process. Parsed by `find_agy_sessions` as a best-effort session guess; do not
+  treat it as a conversation index.
 
 ### Unified abstraction
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -84,9 +84,11 @@ pub struct TranscriptSpec {
     pub config_key: Option<&'static str>,
     /// Default when the config key is unset.
     pub default_enabled: bool,
-    /// When no transcript is found: `Some(msg)` flashes `msg` and stops
-    /// (codex — its history isn't in the terminal grid); `None` falls
-    /// through to vt100 terminal capture (claude / agy).
+    /// Flash text when no transcript is found. Either way `^a v` flashes and
+    /// closes back to the pane (`pane_scroll`'s `TranscriptStream`): `Some(msg)`
+    /// uses `msg`, `None` uses a generic "`<agent>`: no transcript found for this
+    /// session". There is no fall-through to vt100 terminal capture — that only
+    /// runs when the agent has no transcript spec at all, or the view is disabled.
     pub miss_message: Option<&'static str>,
 }
 

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -53,8 +53,9 @@
 # artifacts), the terminal capture is verbatim.
 #
 # `agy_transcript_scrollback` (default true): same as above, but for
-# Antigravity (`agy`) panes. Reads from `history.jsonl` and renders
-# cleanly without terminal artifacts.
+# Antigravity (`agy`) panes. Reads that conversation's own transcript
+# (`~/.gemini/antigravity-cli/brain/<conversation-id>/.../transcript.jsonl`)
+# and renders cleanly without terminal artifacts.
 [pane]
 # default_command = "claude"
 # new_tab_cwd = "worktree_root"

--- a/src/state/agy_transcript.rs
+++ b/src/state/agy_transcript.rs
@@ -18,9 +18,11 @@ use crate::ui::theme::Theme;
 /// within the same second — which is every `-r` restore.
 ///
 /// A pinned id with no transcript on disk yet returns `None` rather than
-/// proximity-matching: we know which conversation this pane is running, so
-/// falling through to `^a v`'s terminal capture is right and showing a *different*
-/// conversation's history is not. The `command` field of the query is unused.
+/// proximity-matching: `None` makes `^a v` flash "no transcript found" and close,
+/// which is the right answer for a conversation we've positively identified but
+/// have nothing on disk for. Showing a *different* conversation's history — what
+/// proximity-matching would do here — is worse than showing none.
+/// The `command` field of the query is unused.
 pub fn resolve_active_jsonl(q: crate::agent::TranscriptQuery) -> Option<PathBuf> {
     resolve_under_home(Path::new(&std::env::var_os("HOME")?), q)
 }
@@ -175,8 +177,8 @@ mod tests {
         );
 
         // A pin whose transcript isn't on disk yet resolves to nothing rather than
-        // proximity-matching some other conversation — `^a v` then falls through to
-        // terminal capture.
+        // proximity-matching some other conversation — `^a v` then flashes
+        // "no transcript found" and closes.
         assert_eq!(
             resolve_under_home(
                 home.path(),


### PR DESCRIPTION
Found while re-auditing today's #201–#203. **No behavior change** — three doc/comment claims that state the wrong thing.

## 1. `TranscriptSpec::miss_message` — the fall-through doesn't exist

The field doc claimed `None` "falls through to vt100 terminal capture". Verified against the code: `pane_scroll`'s `TranscriptStream` turns an empty resolve into `DrainOutcome::CloseInfo(miss)`, so **both** `Some(msg)` and `None` flash and close back to the pane — `None` only supplies a generic *"`<agent>`: no transcript found for this session"* instead of a custom string. The vt100 path is reachable only when `decide_scroll_source` picks it (no transcript spec at all, or the view disabled), never as a miss fallback. `pane_scroll.rs` even says so inline — *"the old synchronous vt100-on-miss fallthrough is retired"* — so the field doc has been stale since that rewrite.

Why it matters beyond tidiness: **that stale doc misled me into repeating the claim in #202**, both in `resolve_active_jsonl`'s doc and in its test comment. The *decision* in #202 is unchanged and still correct — returning `None` for a conversation we've positively identified but have nothing on disk for beats proximity-matching a different conversation's history — only my stated consequence was wrong.

## 2. `default.spycrc.toml` named the wrong file

It told users `agy_transcript_scrollback` "reads from `history.jsonl`". It reads `brain/<conversation-id>/.system_generated/logs/transcript.jsonl`. `history.jsonl` is the typed-prompt log that #203 just established is *not* a conversation index — so this is user-facing config docs pointing at exactly the file that caused the resume bug.

## 3. My own #201 draft-plan edit made the same substitution

`docs/drafts/AUTO_APPROVAL_PLAN.md` now spells out both files and what each is for, so a future reader planning tool-use logging doesn't reach for the prompt log.

---

`make check` green.

Generated with [Claude Code](https://claude.com/claude-code)