### PR TITLE
fix(ui): keep the side-by-side diff separator on one column for tab-indented files

### DIFF
--- a/src/app/git_view_session.rs
+++ b/src/app/git_view_session.rs
@@ -138,12 +138,13 @@ fn render_model(
     theme: &Theme,
     layout: DiffLayout,
     width: usize,
+    tab_width: usize,
 ) -> Rendered {
     match content {
         GitViewContent::Diff(m, hl) => {
             let eff = effective_layout(layout, width);
             Rendered {
-                lines: diff_render::render_diff_highlighted(m, hl, theme, eff, width),
+                lines: diff_render::render_diff_highlighted(m, hl, theme, eff, width, tab_width),
                 line_numbers: false,
                 wrap: matches!(eff, DiffLayout::Unified),
             }
@@ -151,7 +152,9 @@ fn render_model(
         GitViewContent::Show(b) => {
             let eff = effective_layout(layout, width);
             Rendered {
-                lines: diff_render::render_show_highlighted(&b.0, &b.1, &b.2, theme, eff, width),
+                lines: diff_render::render_show_highlighted(
+                    &b.0, &b.1, &b.2, theme, eff, width, tab_width,
+                ),
                 line_numbers: false,
                 wrap: matches!(eff, DiffLayout::Unified),
             }
@@ -216,7 +219,7 @@ impl GitViewStream {
     /// fixed-width side-by-side rows wrap into stray tinted bars.
     fn render_into(&self, view: &mut PagerView, ctx: &RenderCtx) {
         let width = git_view_body_width(ctx.full_width);
-        let rendered = render_model(&self.content, &ctx.theme, self.layout, width);
+        let rendered = render_model(&self.content, &ctx.theme, self.layout, width, ctx.tab_width);
         view.lines = rendered.lines;
         view.show_line_numbers = rendered.line_numbers;
         view.wrap = rendered.wrap;
@@ -369,6 +372,7 @@ impl App {
         let ctx = RenderCtx {
             theme: self.view.theme.clone(),
             full_width,
+            tab_width: self.state.config.pager.tab_width,
         };
         if let Some(view) = self.view.pager.as_mut() {
             stream.render_into(view, &ctx);

--- a/src/app/pager_stream.rs
+++ b/src/app/pager_stream.rs
@@ -59,6 +59,11 @@ pub struct RenderCtx {
     pub theme: Theme,
     /// Whether the backing pager is full-width — affects diff body width.
     pub full_width: bool,
+    /// Columns a `\t` occupies once the pager expands it (`[pager] tab_width`).
+    /// The side-by-side diff builds fixed-width cells, so it has to measure tabs
+    /// the way the pager will finally *render* them — see
+    /// [`crate::ui::diff_render::render_diff_highlighted`].
+    pub tab_width: usize,
 }
 
 /// An in-pager command routed to a retained stream (via
@@ -272,6 +277,7 @@ impl App {
         let ctx = RenderCtx {
             theme: self.view.theme.clone(),
             full_width,
+            tab_width: self.state.config.pager.tab_width,
         };
         // Field-level `&mut` on one view slot + the disjoint `runtime` borrow
         // both end when `drain` returns the owned DrainOutcome.
@@ -367,6 +373,7 @@ impl App {
         let ctx = RenderCtx {
             theme: self.view.theme.clone(),
             full_width,
+            tab_width: self.state.config.pager.tab_width,
         };
         let view = if in_scroll {
             self.view.scroll_pager.as_mut()

--- a/src/ui/diff_render/mod.rs
+++ b/src/ui/diff_render/mod.rs
@@ -54,6 +54,29 @@ const LNUM_W: usize = 4;
 /// source line.
 const MAX_WRAP_ROWS_PER_CELL: usize = 512;
 
+/// Display columns `s` occupies once the pager has expanded its tabs.
+///
+/// `unicode_width` scores a `\t` as ONE column, but the pager rewrites every
+/// `\t` to `tab_width` spaces before drawing (`pager::render::expand_tabs`). The
+/// side-by-side layout pads each cell to an exact width, so measuring with
+/// `display_width` alone under-counts a tab-indented line by
+/// `tab_width - 1` per tab — the cell then renders wider than its budget and
+/// shoves the `│` separator (and the whole right column) right by that much.
+/// Since indent depth varies line to line, so does the shove: the columns come
+/// out visibly ragged on any tab-indented file (gofmt, Makefiles, plenty of C).
+fn tabbed_width(s: &str, tab_width: usize) -> usize {
+    let tabs = s.bytes().filter(|b| *b == b'\t').count();
+    display_width(s) + tabs * tab_width.max(1).saturating_sub(1)
+}
+
+/// Per-character counterpart to [`tabbed_width`], for the wrap scan.
+fn char_cols(ch: char, tab_width: usize) -> usize {
+    if ch == '\t' {
+        return tab_width.max(1);
+    }
+    UnicodeWidthChar::width(ch).unwrap_or(0)
+}
+
 /// A diff's syntax highlight, computed once and reused across every
 /// layout/width re-render. syntect (in [`highlight_side`]) is by far the most
 /// expensive part of rendering a diff, and it depends only on the model — not
@@ -103,6 +126,11 @@ fn highlight_file(file: &FileDiff) -> FileHighlight {
 /// production always splits the two so the highlight is computed once off-thread
 /// and the layout (width/`layout`-dependent) re-runs cheaply (see
 /// [`crate::app::git_view_session`]).
+/// `[pager] tab_width`'s default, used by the test-only render helpers so the
+/// existing cases don't all have to name it.
+#[cfg(test)]
+const TEST_TAB_WIDTH: usize = 4;
+
 #[cfg(test)]
 pub fn render_diff(
     model: &DiffModel,
@@ -110,7 +138,27 @@ pub fn render_diff(
     layout: DiffLayout,
     width: usize,
 ) -> Vec<Line<'static>> {
-    render_diff_highlighted(model, &highlight_diff(model), theme, layout, width)
+    render_diff_tw(model, theme, layout, width, TEST_TAB_WIDTH)
+}
+
+/// [`render_diff`] with an explicit `tab_width` — for the alignment cases where
+/// tab expansion is the thing under test.
+#[cfg(test)]
+pub fn render_diff_tw(
+    model: &DiffModel,
+    theme: &Theme,
+    layout: DiffLayout,
+    width: usize,
+    tab_width: usize,
+) -> Vec<Line<'static>> {
+    render_diff_highlighted(
+        model,
+        &highlight_diff(model),
+        theme,
+        layout,
+        width,
+        tab_width,
+    )
 }
 
 /// Lay out a diff at `width`/`layout` using a precomputed [`DiffHighlight`].
@@ -122,6 +170,7 @@ pub fn render_diff_highlighted(
     theme: &Theme,
     layout: DiffLayout,
     width: usize,
+    tab_width: usize,
 ) -> Vec<Line<'static>> {
     let mut out = Vec::new();
     if model.files.is_empty() {
@@ -135,7 +184,9 @@ pub fn render_diff_highlighted(
         let fhl = hl.files.get(i);
         match layout {
             DiffLayout::Unified => render_file_unified(file, fhl, theme, &mut out),
-            DiffLayout::SideBySide => render_file_split(file, fhl, theme, width, &mut out),
+            DiffLayout::SideBySide => {
+                render_file_split(file, fhl, theme, width, tab_width, &mut out);
+            }
         }
     }
     if model.truncated {
@@ -160,7 +211,15 @@ pub fn render_show(
     layout: DiffLayout,
     width: usize,
 ) -> Vec<Line<'static>> {
-    render_show_highlighted(meta, model, &highlight_diff(model), theme, layout, width)
+    render_show_highlighted(
+        meta,
+        model,
+        &highlight_diff(model),
+        theme,
+        layout,
+        width,
+        TEST_TAB_WIDTH,
+    )
 }
 
 /// Lay out `git show <rev>` using a precomputed [`DiffHighlight`].
@@ -171,9 +230,12 @@ pub fn render_show_highlighted(
     theme: &Theme,
     layout: DiffLayout,
     width: usize,
+    tab_width: usize,
 ) -> Vec<Line<'static>> {
     let mut out = commit_header(meta, theme);
-    out.extend(render_diff_highlighted(model, hl, theme, layout, width));
+    out.extend(render_diff_highlighted(
+        model, hl, theme, layout, width, tab_width,
+    ));
     out
 }
 
@@ -295,6 +357,7 @@ fn render_file_split(
     hl: Option<&FileHighlight>,
     theme: &Theme,
     width: usize,
+    tab_width: usize,
     out: &mut Vec<Line<'static>>,
 ) {
     let Some(prep) = prepare_file(file, hl, theme, out) else {
@@ -323,6 +386,7 @@ fn render_file_split(
                     styled_content(pick(old_ref, oi, &lines[i].text, theme, None), None, None),
                     col_w,
                     lnum_w,
+                    tab_width,
                 );
                 let right_rows = split_cell_rows(
                     theme,
@@ -331,6 +395,7 @@ fn render_file_split(
                     styled_content(pick(new_ref, ni, &lines[i].text, theme, None), None, None),
                     col_w,
                     lnum_w,
+                    tab_width,
                 );
                 push_split_rows(out, left_rows, right_rows, col_w, theme);
                 old_no += 1;
@@ -372,6 +437,7 @@ fn render_file_split(
                         content,
                         col_w,
                         lnum_w,
+                        tab_width,
                     );
                     old_no += 1;
                     oi += 1;
@@ -393,6 +459,7 @@ fn render_file_split(
                         content,
                         col_w,
                         lnum_w,
+                        tab_width,
                     );
                     new_no += 1;
                     ni += 1;
@@ -438,6 +505,7 @@ fn split_cell_rows(
     content: Vec<Span<'static>>,
     col_w: usize,
     lnum_w: usize,
+    tab_width: usize,
 ) -> Vec<Vec<Span<'static>>> {
     let (marker, row_bg, gutter_style) = match origin {
         LineOrigin::Context => (' ', None, Style::default()),
@@ -453,7 +521,7 @@ fn split_cell_rows(
     let content_w = col_w.saturating_sub(prefix_w);
     let pad_style = row_bg.map_or_else(Style::default, |c| Style::default().bg(c));
 
-    wrap_spans(&content, content_w)
+    wrap_spans(&content, content_w, tab_width)
         .into_iter()
         .enumerate()
         .map(|(i, row_spans)| {
@@ -472,7 +540,7 @@ fn split_cell_rows(
             }
             let used: usize = row_spans
                 .iter()
-                .map(|s| display_width(s.content.as_ref()))
+                .map(|s| tabbed_width(s.content.as_ref(), tab_width))
                 .sum();
             spans.extend(row_spans);
             if used < content_w {
@@ -636,7 +704,7 @@ fn pick(
 /// Split `spans` into visual rows of at most `width` display columns each,
 /// preserving span styles across row boundaries. Returns at least one row
 /// (an empty row when `spans` is empty or `width` is zero).
-fn wrap_spans(spans: &[Span<'static>], width: usize) -> Vec<Vec<Span<'static>>> {
+fn wrap_spans(spans: &[Span<'static>], width: usize, tab_width: usize) -> Vec<Vec<Span<'static>>> {
     if width == 0 {
         return vec![spans.to_vec()];
     }
@@ -654,7 +722,7 @@ fn wrap_spans(spans: &[Span<'static>], width: usize) -> Vec<Vec<Span<'static>>> 
             let mut consumed_bytes = 0usize;
             let mut visual = 0usize;
             for (idx, ch) in rest.char_indices() {
-                let w = UnicodeWidthChar::width(ch).unwrap_or(0);
+                let w = char_cols(ch, tab_width);
                 if visual + w > remaining {
                     break;
                 }
@@ -667,7 +735,7 @@ fn wrap_spans(spans: &[Span<'static>], width: usize) -> Vec<Vec<Span<'static>>> 
                 && let Some(first) = rest.chars().next()
             {
                 consumed_bytes = first.len_utf8();
-                visual = UnicodeWidthChar::width(first).unwrap_or(1);
+                visual = char_cols(first, tab_width).max(1);
             }
             let chunk = rest[..consumed_bytes].to_string();
             rest = &rest[consumed_bytes..];

--- a/src/ui/diff_render/tests.rs
+++ b/src/ui/diff_render/tests.rs
@@ -540,7 +540,7 @@ fn wrap_spans_splits_at_width_boundary() {
     use ratatui::text::Span;
     let spans = vec![Span::raw("hello world")];
     // Width 5: "hello" | " worl" | "d"
-    let rows = super::wrap_spans(&spans, 5);
+    let rows = super::wrap_spans(&spans, 5, 4);
     assert_eq!(rows.len(), 3, "expected 3 rows, got {rows:?}");
     assert_eq!(rows[0][0].content.as_ref(), "hello");
     assert_eq!(rows[1][0].content.as_ref(), " worl");
@@ -592,7 +592,7 @@ fn cached_highlight_render_matches_inline_render() {
     for layout in [DiffLayout::Unified, DiffLayout::SideBySide] {
         for width in [40usize, 80, 137] {
             let inline = render_diff(&model, &theme, layout, width);
-            let cached = super::render_diff_highlighted(&model, &hl, &theme, layout, width);
+            let cached = super::render_diff_highlighted(&model, &hl, &theme, layout, width, 4);
             assert_eq!(
                 styled_fingerprint(&inline),
                 styled_fingerprint(&cached),
@@ -633,8 +633,8 @@ fn cached_highlight_relayout_reflows_at_new_width() {
             .max()
             .unwrap_or(0)
     };
-    let narrow = super::render_diff_highlighted(&model, &hl, &theme, DiffLayout::SideBySide, 80);
-    let wide = super::render_diff_highlighted(&model, &hl, &theme, DiffLayout::SideBySide, 160);
+    let narrow = super::render_diff_highlighted(&model, &hl, &theme, DiffLayout::SideBySide, 80, 4);
+    let wide = super::render_diff_highlighted(&model, &hl, &theme, DiffLayout::SideBySide, 160, 4);
     // Rows are sized to the body width, so a wider render produces wider rows…
     assert!(
         widest(&wide) > widest(&narrow),
@@ -649,4 +649,131 @@ fn cached_highlight_relayout_reflows_at_new_width() {
         narrow.len(),
         wide.len()
     );
+}
+
+// ── side-by-side column alignment ──────────────────────────────────
+
+/// Separator column of every row that has one, measured as the user finally
+/// sees it — i.e. after the pager has expanded tabs to `tab_width`
+/// (`pager::render::expand_tabs`, which runs on this renderer's output).
+fn separator_columns(lines: &[Line], tab_width: usize) -> Vec<(usize, usize, String)> {
+    lines
+        .iter()
+        .enumerate()
+        .filter_map(|(i, line)| {
+            let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            let expanded = flat.replace('\t', &" ".repeat(tab_width));
+            let byte_idx = expanded.find('│')?;
+            Some((i, crate::ui::display_width(&expanded[..byte_idx]), expanded))
+        })
+        .collect()
+}
+
+/// Every side-by-side row must put `│` at the SAME display column. That's the
+/// entire contract of the layout — a separator that wanders line to line makes
+/// the two columns un-scannable, and the diff reads as untrustworthy even when
+/// the pairing underneath is correct.
+///
+/// Tab-indented source is what broke it, and it's not niche: gofmt uses tabs,
+/// so does every Makefile and a lot of C. `unicode_width` scores `\t` as ONE
+/// column, but the pager expands it to `tab_width` before drawing — so a cell
+/// padded on the raw measurement rendered `tab_width - 1` columns too wide per
+/// tab, shoving the separator right by an amount that varied with each line's
+/// indent depth. Note the assertion is on the POST-expansion column: the raw
+/// text is now deliberately narrower per tab, which is what makes it land flush.
+#[test]
+fn split_separator_column_is_identical_on_every_row() {
+    let tabbed = DiffKind::Text(vec![Hunk {
+        old_start: 1,
+        old_lines: 8,
+        new_start: 1,
+        new_lines: 8,
+        lines: vec![
+            ctx("func f() {"),
+            ctx("\tif ok {"),
+            ctx("\t\tfor i := range xs {"),
+            rem("\t\t\tkn.CPU = q.String()"),
+            add("\t\t\tkn.CPUMilli = q.MilliValue()"),
+            ctx("\t\t}"),
+            ctx("\t}"),
+            ctx("}"),
+        ],
+    }]);
+    let model = single_file(FileStatus::Modified, tabbed, Some("k8s.go"), Some("k8s.go"));
+
+    // Every tab_width a user can configure, at two widths — the bug scaled with
+    // tab_width, so a fix that only works for the default isn't a fix.
+    for tab_width in [1, 2, 4, 8] {
+        for width in [100, 120] {
+            let out = super::render_diff_tw(
+                &model,
+                &Theme::default(),
+                DiffLayout::SideBySide,
+                width,
+                tab_width,
+            );
+            let cols = separator_columns(&out, tab_width);
+            // 6 context rows + one paired remove|add row, plus any wrap
+            // continuation rows (a large tab_width can push a line over the
+            // column width) — those carry a separator too and must align just
+            // the same, so they're deliberately included.
+            assert!(
+                cols.len() >= 7,
+                "expected >=7 split rows, got {}",
+                cols.len()
+            );
+            let first = cols[0].1;
+            let bad: Vec<_> = cols.iter().filter(|(_, c, _)| *c != first).collect();
+            assert!(
+                bad.is_empty(),
+                "tab_width={tab_width} width={width}: separator wanders — rows {:?} differ from column {first}.\n{}",
+                bad.iter().map(|(i, c, _)| (*i, *c)).collect::<Vec<_>>(),
+                cols.iter()
+                    .map(|(i, c, f)| format!("  row {i:>2} sep@{c:>3}  {f:?}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            );
+        }
+    }
+}
+
+/// Space-indented content was never affected, so it must stay byte-identical —
+/// the tab accounting has to be a no-op when there are no tabs.
+#[test]
+fn split_layout_unchanged_for_space_indented_content() {
+    let spaced = DiffKind::Text(vec![Hunk {
+        old_start: 1,
+        old_lines: 4,
+        new_start: 1,
+        new_lines: 4,
+        lines: vec![
+            ctx("fn f() {"),
+            ctx("    if ok {"),
+            rem("        let x = old();"),
+            add("        let x = new();"),
+            ctx("    }"),
+        ],
+    }]);
+    let model = single_file(FileStatus::Modified, spaced, Some("a.rs"), Some("a.rs"));
+    let theme = Theme::default();
+    let baseline = text(&super::render_diff_tw(
+        &model,
+        &theme,
+        DiffLayout::SideBySide,
+        100,
+        1,
+    ));
+    for tab_width in [2, 4, 8] {
+        assert_eq!(
+            text(&super::render_diff_tw(
+                &model,
+                &theme,
+                DiffLayout::SideBySide,
+                100,
+                tab_width
+            )),
+            baseline,
+            "tab_width must not affect tab-free content (tab_width={tab_width})"
+        );
+    }
 }


### PR DESCRIPTION
Your screenshot: the split diff's columns "are all disjointed — it makes the output untrustworthy."

## Measured, not guessed

Reproduced on a tab-indented Go file. The `│` separator per row:

```
row  2 sep@ 49    1  func f() {                    │   1  func f() {
row  3 sep@ 52    2      if ok {                     │   2      if ok {
row  4 sep@ 55    3          for i := range xs {       │   3          for i := range xs {
row  5 sep@ 58    4 -            kn.CPU = q.String()     │   4 +            kn.CPUMilli = …
row  6 sep@ 55    5          }                          │   5          }
row  7 sep@ 52    6      }                             │   6      }
row  8 sep@ 49    7  }                                │   7  }
```

**+3 per level of indentation** — exactly the stair-step in your screenshot.

## Root cause: two layers disagreed on how wide a tab is

`unicode_width` scores `\t` as **1** column, which is what `split_cell_rows` measured when padding each cell to exactly `col_w`. But the pager rewrites every `\t` to `[pager] tab_width` (default **4**) spaces before drawing — `pager::render::expand_tabs`, which runs *on this renderer's output*. So every tab made the finished cell `tab_width - 1` columns wider than its budget, shoving the separator and the whole right column over. Indent depth varies line to line, so the shove did too.

Worth saying plainly: **the diff itself was never wrong.** Pairing and word-level highlights were all correct — I checked. Only the geometry lied, which is arguably worse, because it made correct output look unreliable.

This is also why my earlier guess (the diff algorithm) was wrong, and why gofmt-style files were where you hit it: Go indents with tabs. Makefiles and a lot of C have the same shape.

## The fix

Measure tabs the way they'll actually render, rather than rewriting the text. `tabbed_width` / `char_cols` charge a `\t` its full `tab_width`, and `tab_width` is threaded from `[pager] tab_width` through `RenderCtx` → `render_model` → `render_diff_highlighted` → `split_cell_rows` / `wrap_spans`.

Measuring rather than pre-expanding is deliberate: it keeps the pager the single owner of tab rendering, so **`w` (show-whitespace) still draws its `→` tab markers**. Pre-expanding to plain spaces here would have silently killed that feature in the diff view.

Wrapping is covered too — `wrap_spans` now charges a tab its real cost, so a deeply-indented long line breaks in the right place instead of overflowing.

## Verification

- **End-to-end against a real git repo** with genuine gofmt tabs: all ten rows land on column 49.
- Regression test asserts the **post-expansion** separator column (what you actually see) is identical on every row, across `tab_width` 1/2/4/8 × two viewport widths — the bug scaled with `tab_width`, so a default-only fix wouldn't be one. Wrap-continuation rows are included, since they carry a separator too.
- A second test pins that **tab-free content is byte-identical at every `tab_width`**, so space-indented diffs can't be perturbed.
- `make check` green, 1642 tests.

Release binary built. Note the raw pre-expansion text is now intentionally narrower per tab — that's the mechanism that makes it land flush.

Generated with [Claude Code](https://claude.com/claude-code)