### PR TITLE
fix(diff): measure split-column wrap in grapheme clusters, not chars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4385,6 +4385,7 @@ dependencies = [
  "toml",
  "trash",
  "two-face",
+ "unicode-segmentation",
  "unicode-width",
  "uuid",
  "uzers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,10 @@ pretty-hex = "0.4"
 syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"] }
 unicode-width = "0.2"
+# Grapheme-cluster segmentation. `unicode-width` scores a cluster (e.g. a
+# base char + U+FE0F) wider than the sum of its chars, so anything that
+# measures text incrementally has to advance by cluster to agree with it.
+unicode-segmentation = "1"
 libc = "0.2"
 ignore = "0.4"
 # Git plumbing — the gitoxide crate. Pure-Rust (zlib-rs is the default

--- a/src/ui/diff_render/mod.rs
+++ b/src/ui/diff_render/mod.rs
@@ -25,7 +25,7 @@ use std::ops::Range;
 
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
-use unicode_width::UnicodeWidthChar;
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::git::model::{CommitMeta, DiffKind, DiffModel, FileDiff, FileStatus, Hunk, LineOrigin};
 use crate::ui::display_width;
@@ -56,6 +56,13 @@ const MAX_WRAP_ROWS_PER_CELL: usize = 512;
 
 /// Display columns `s` occupies once the pager has expanded its tabs.
 ///
+/// The **single** width metric for the side-by-side layout: both the wrap scan
+/// ([`wrap_spans`]) and the cell padding ([`split_cell_rows`]) measure with this,
+/// and the layout is only correct while they agree. Two metrics that disagree by
+/// one column produce exactly the raggedness this exists to prevent, so measure
+/// per grapheme cluster and route it through here rather than adding a
+/// per-`char` shortcut.
+///
 /// `unicode_width` scores a `\t` as ONE column, but the pager rewrites every
 /// `\t` to `tab_width` spaces before drawing (`pager::render::expand_tabs`). The
 /// side-by-side layout pads each cell to an exact width, so measuring with
@@ -64,17 +71,11 @@ const MAX_WRAP_ROWS_PER_CELL: usize = 512;
 /// shoves the `│` separator (and the whole right column) right by that much.
 /// Since indent depth varies line to line, so does the shove: the columns come
 /// out visibly ragged on any tab-indented file (gofmt, Makefiles, plenty of C).
+/// Tabs expand to a fixed width rather than to the next tab stop, which is what
+/// makes a flat `tab_width` per tab exact.
 fn tabbed_width(s: &str, tab_width: usize) -> usize {
     let tabs = s.bytes().filter(|b| *b == b'\t').count();
     display_width(s) + tabs * tab_width.max(1).saturating_sub(1)
-}
-
-/// Per-character counterpart to [`tabbed_width`], for the wrap scan.
-fn char_cols(ch: char, tab_width: usize) -> usize {
-    if ch == '\t' {
-        return tab_width.max(1);
-    }
-    UnicodeWidthChar::width(ch).unwrap_or(0)
 }
 
 /// A diff's syntax highlight, computed once and reused across every
@@ -721,21 +722,26 @@ fn wrap_spans(spans: &[Span<'static>], width: usize, tab_width: usize) -> Vec<Ve
             }
             let mut consumed_bytes = 0usize;
             let mut visual = 0usize;
-            for (idx, ch) in rest.char_indices() {
-                let w = char_cols(ch, tab_width);
+            // Advance by grapheme cluster, measured with `tabbed_width` — the
+            // same fn the cell padding uses. A per-`char` walk under-counts an
+            // emoji-presentation sequence (base + U+FE0F: 1 + 0 per char, 2 as
+            // a cluster), so it would admit a column the padding then believes
+            // is already occupied, and the cell would overrun its budget.
+            for (idx, cluster) in rest.grapheme_indices(true) {
+                let w = tabbed_width(cluster, tab_width);
                 if visual + w > remaining {
                     break;
                 }
-                consumed_bytes = idx + ch.len_utf8();
+                consumed_bytes = idx + cluster.len();
                 visual += w;
             }
-            // Force at least one char even if it's wider than `remaining`
+            // Force at least one cluster even if it's wider than `remaining`
             // so a 2-col glyph in a 1-col viewport doesn't infinite-loop.
             if consumed_bytes == 0
-                && let Some(first) = rest.chars().next()
+                && let Some(first) = rest.graphemes(true).next()
             {
-                consumed_bytes = first.len_utf8();
-                visual = char_cols(first, tab_width).max(1);
+                consumed_bytes = first.len();
+                visual = tabbed_width(first, tab_width).max(1);
             }
             let chunk = rest[..consumed_bytes].to_string();
             rest = &rest[consumed_bytes..];

--- a/src/ui/diff_render/tests.rs
+++ b/src/ui/diff_render/tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the diff/show renderers (`super::render_diff` / `render_show`).
 //! Split out of `diff_render.rs` verbatim during the 800-LoC decomposition.
 
-use super::{DiffLayout, render_diff, render_show};
+use super::{DiffLayout, TEST_TAB_WIDTH, render_diff, render_show};
 use crate::git::model::{
     CommitMeta, DiffKind, DiffLine, DiffModel, FileDiff, FileStatus, Hunk, LineOrigin,
 };
@@ -326,15 +326,19 @@ fn side_by_side_rows_never_exceed_width() {
     // display width must be ≤ the width it was rendered for. (A row wider
     // than the pager body wraps, and the wrapped padding tail shows as a
     // stray tinted bar — the bug this guards against.)
+    //
+    // Measured POST tab-expansion, on the flattened row. Summing per span over
+    // the raw text measures neither what the user sees (the pager expands tabs
+    // to `tab_width` first) nor the width the layout budgeted against, and it
+    // splits grapheme clusters at span boundaries — so it would pass while the
+    // drawn row overran.
     let theme = Theme::default();
     for width in [40usize, 60, 80, 81, 100, 137] {
         let out = render_diff(&modify_model(), &theme, DiffLayout::SideBySide, width);
         for line in &out {
-            let w: usize = line
-                .spans
-                .iter()
-                .map(|s| crate::ui::display_width(s.content.as_ref()))
-                .sum();
+            let flat: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            let expanded = flat.replace('\t', &" ".repeat(TEST_TAB_WIDTH));
+            let w = crate::ui::display_width(&expanded);
             assert!(w <= width, "row width {w} exceeds {width}: {line:?}");
         }
     }
@@ -734,6 +738,57 @@ fn split_separator_column_is_identical_on_every_row() {
                     .join("\n")
             );
         }
+    }
+}
+
+/// The separator must also hold for content whose grapheme clusters are wider
+/// than the sum of their chars. An emoji-presentation sequence (base char +
+/// U+FE0F) is the common case: `unicode_width` scores the cluster as 2 columns —
+/// which is what the terminal draws — while a per-`char` walk sees 1 + 0.
+///
+/// The wrap scan and the cell padding must therefore measure the SAME way. When
+/// they disagree the padding believes the row is full, skips the pad, and the
+/// cell runs over its budget — the separator shifts right by one column per
+/// sequence, which is the same ragged-column symptom tab handling produced.
+/// Lines are long enough to pack the column, since a short row pads either way.
+#[test]
+fn split_separator_holds_for_clusters_wider_than_their_chars() {
+    // `⚠️` / `✔️` are base-char + VS16. The trailing text pushes each line up
+    // against the column budget so the padding branch is actually exercised.
+    let emoji = DiffKind::Text(vec![Hunk {
+        old_start: 1,
+        old_lines: 4,
+        new_start: 1,
+        new_lines: 4,
+        lines: vec![
+            ctx("// ⚠️ the checked path below is load-bearing, do not reorder it"),
+            rem("let status = \"✔️ ok\"; // ⚠️ verified against the upstream fixture"),
+            add("let status = \"✔️ done\"; // ⚠️ verified against the upstream table"),
+            ctx("// ⚠️ ✔️ ⚠️ ✔️ trailing cluster run to fill out the column budget"),
+        ],
+    }]);
+    let model = single_file(FileStatus::Modified, emoji, Some("a.rs"), Some("a.rs"));
+
+    for width in [80, 100, 120] {
+        let out =
+            super::render_diff_tw(&model, &Theme::default(), DiffLayout::SideBySide, width, 4);
+        let cols = separator_columns(&out, 4);
+        assert!(
+            cols.len() >= 3,
+            "expected >=3 split rows, got {}",
+            cols.len()
+        );
+        let first = cols[0].1;
+        let bad: Vec<_> = cols.iter().filter(|(_, c, _)| *c != first).collect();
+        assert!(
+            bad.is_empty(),
+            "width={width}: separator wanders on cluster-wide content — rows {:?} differ from column {first}.\n{}",
+            bad.iter().map(|(i, c, _)| (*i, *c)).collect::<Vec<_>>(),
+            cols.iter()
+                .map(|(i, c, f)| format!("  row {i:>2} sep@{c:>3}  {f:?}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
     }
 }
 


### PR DESCRIPTION
Follow-up to #205. That fix was correct for tabs but left the split layout measuring width **two different ways**, so the ragged columns still reproduce — just via a different trigger.

## The bug

`wrap_spans` bounded each row with a per-`char` walk (`char_cols`); `split_cell_rows` padded the cell with `tabbed_width`, which uses `unicode_width`'s cluster-aware `str::width`.

They disagree on any grapheme cluster wider than the sum of its chars. `⚠️` is U+26A0 + VS16 — scored `1 + 0` per char, but `2` as a cluster, and 2 is what the terminal draws. So the wrap let in one extra column, the padding then saw `used >= content_w` and skipped the pad, and the cell overran by **exactly one column per cluster**.

Measured on the new fixture at width 80 — the true column is 39, and each cluster pushes it right:

```
row  2 sep@ 40   // ⚠️ the checked path below is l │    // ⚠️ the checked path below is l
row  3 sep@ 39         oad-bearing, do not reorder it   │      oad-bearing, do not reorder it
row  4 sep@ 41  -let status = "✔️ ok"; // ⚠️ verifi │   +let status = "✔️ done"; // ⚠️ veri
row  6 sep@ 43   // ⚠️ ✔️ ⚠️ ✔️ trailing cluster run  │    // ⚠️ ✔️ ⚠️ ✔️ trailing cluster run
```

Four clusters on row 6, four columns of drift. Also fires on `✔️ ❤️ ▶️`, keycap sequences, and stray non-tab control characters (`char_cols` scores those 0, `display_width` scores them 1).

## The fix

Deleted `char_cols` outright rather than patching it, and made the wrap scan advance by grapheme cluster measured with `tabbed_width`. **One metric now governs both halves**, so they can't drift apart again — a second metric is what caused this, so removing it is the fix rather than aligning two.

`tabbed_width` is additive across cluster boundaries, which is what makes the incremental accumulation exact.

Also confirmed while here: **the tab accounting in #205 was already exact**, not an approximation. The pager expands `\t` to a fixed `tab_width` rather than advancing to the next tab stop, so charging a flat `tab_width` per tab is precisely right. Now documented on `tabbed_width`, since that's the non-obvious part and the next reader would reasonably assume tab stops.

## Dependency

Adds `unicode-segmentation` as a *direct* dependency. It was already in the tree via ratatui, so nothing new is pulled in — `cargo deny` passes unchanged.

## Tests

- **New:** `split_separator_holds_for_clusters_wider_than_their_chars` — VS16 sequences in column-filling lines. Verified failing before the fix with the drift above.
- **Strengthened:** `side_by_side_rows_never_exceed_width` summed `display_width` per span over the **raw** text. That measures neither what the user sees (the pager expands tabs first) nor what the layout budgeted against, and it splits clusters at span boundaries — so it passed while the drawn row overran. It now measures the flattened, tab-expanded row. This is the test that should have caught the bug.

`make check` green, 1671 tests.

## Provenance

Found by an audit of everything that landed today, prompted by the work having been authored on a weaker model. The mechanism was confirmed from source before any code changed, and the fixture reproduced it before the fix went in.

Generated with [Claude Code](https://claude.com/claude-code)
