### PR TITLE
fix(mcp): refuse to overwrite an agent config we can't parse

### DIFF
--- a/src/mcp/config.rs
+++ b/src/mcp/config.rs
@@ -10,6 +10,7 @@ use super::server::{notify_disconnect, pid_from_sock_path};
 use super::{mcp_log, socket_path};
 
 /// Status of MCP configuration for this directory.
+#[derive(Debug)]
 pub enum McpConfigStatus {
     /// .mcp.json written/updated to point at our socket.
     Configured,
@@ -24,6 +25,21 @@ pub enum McpConfigStatus {
     /// resolves through the org config; we run the socket server but
     /// skip writing local `.mcp.json` (and clean up any prior write).
     ManagedByEnterprise,
+}
+
+/// An "I won't touch that file" error.
+///
+/// Returned instead of rewriting an agent config we can't safely splice into.
+/// These files are the user's: `.mcp.json` can define other MCP servers,
+/// `.codex/config.toml` holds their `model` and `approval_policy`. Replacing one
+/// with a spyc-only document because a trailing comma made it unparseable is
+/// silent data loss, and the caller's `Err` arm already flashes and lets the
+/// pane launch — so refusing costs spyc's tools in that repo, not their config.
+///
+/// `InvalidData` rather than `Other`: the file exists and is readable, its
+/// contents are the problem.
+fn refuse(msg: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, msg.to_string())
 }
 
 /// Given the `SPYC_MCP_SOCK` value parsed out of an existing client config,
@@ -236,34 +252,53 @@ fn ensure_spyc_in_mcp_json(
         }
     });
 
-    // Default content when there's no existing file or we can't safely
-    // splice into it (parse error, top-level not an object, mcpServers
-    // present but not an object). In all those cases we overwrite with
-    // a clean shape rather than panicking on `.as_object_mut().unwrap()`.
+    // Default content, for an absent or blank file only — there's nothing to
+    // lose in either case.
     let fresh = || {
         serde_json::to_string_pretty(&json!({ "mcpServers": { "spyc": spyc_entry } }))
             .expect("serializing a serde_json::Value cannot fail")
     };
     let content = match std::fs::read_to_string(path) {
-        Ok(text) => match serde_json::from_str::<Value>(&text) {
-            Ok(mut parsed) => {
-                let top = parsed.as_object_mut();
-                let servers = top.and_then(|t| {
-                    let entry = t.entry("mcpServers").or_insert_with(|| json!({}));
-                    entry.as_object_mut()
-                });
-                match servers {
-                    Some(map) => {
-                        map.insert("spyc".to_string(), spyc_entry);
-                        serde_json::to_string_pretty(&parsed)
-                            .expect("serializing a serde_json::Value cannot fail")
-                    }
-                    None => fresh(),
+        // An existing file is the user's data — it can hold other MCP servers,
+        // and rewriting it from scratch drops every one. Refuse instead: the
+        // caller flashes the error and the pane still launches, so the cost is
+        // spyc's tools being unavailable in this repo until they fix the file.
+        Ok(text) if !text.trim().is_empty() => {
+            let mut parsed: Value = serde_json::from_str(&text).map_err(|e| {
+                refuse(&format!(
+                    "{}: refusing to overwrite — exists but isn't valid JSON ({e}); \
+                     fix or delete it",
+                    path.display()
+                ))
+            })?;
+            let servers = parsed.as_object_mut().and_then(|t| {
+                let entry = t.entry("mcpServers").or_insert_with(|| json!({}));
+                entry.as_object_mut()
+            });
+            match servers {
+                Some(map) => {
+                    map.insert("spyc".to_string(), spyc_entry);
+                    serde_json::to_string_pretty(&parsed)
+                        .expect("serializing a serde_json::Value cannot fail")
+                }
+                None => {
+                    return Err(refuse(&format!(
+                        "{}: refusing to overwrite — top level or `mcpServers` is not an object",
+                        path.display()
+                    )));
                 }
             }
-            Err(_) => fresh(),
-        },
-        Err(_) => fresh(),
+        }
+        Ok(_) => fresh(),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => fresh(),
+        // Anything else (permissions, a directory in the way) is not "no file";
+        // writing over it would be a guess.
+        Err(e) => {
+            return Err(io::Error::new(
+                e.kind(),
+                format!("reading {}: {e}", path.display()),
+            ));
+        }
     };
 
     // agy's file sits one level down (`.agents/`); claude's parent is `dir`
@@ -373,30 +408,60 @@ pub fn ensure_codex_config_toml(
         servers.insert("spyc".into(), toml::Value::Table(build_entry()));
         let mut root = toml::Table::new();
         root.insert("mcp_servers".into(), toml::Value::Table(servers));
-        toml::to_string_pretty(&toml::Value::Table(root)).unwrap_or_default()
+        // A root holding one table and no bare values always serializes (TOML
+        // requires values before tables, which a single key trivially satisfies).
+        toml::to_string_pretty(&toml::Value::Table(root))
+            .expect("a single-table root always serializes")
     };
 
     let content = match std::fs::read_to_string(&path) {
-        Ok(text) => match toml::from_str::<toml::Value>(&text) {
-            Ok(mut parsed) => {
-                let top = parsed.as_table_mut();
-                let servers_ok = top.and_then(|t| {
-                    let entry = t
-                        .entry("mcp_servers")
-                        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
-                    entry.as_table_mut()
-                });
-                match servers_ok {
-                    Some(map) => {
-                        map.insert("spyc".to_string(), toml::Value::Table(build_entry()));
-                        toml::to_string_pretty(&parsed).unwrap_or_else(|_| fresh())
-                    }
-                    None => fresh(),
+        // This file is the user's codex config — `model`, `approval_policy`,
+        // their own hooks. Rewriting it from scratch because we couldn't parse
+        // it (one trailing comma, a half-finished edit) destroys all of it.
+        Ok(text) if !text.trim().is_empty() => {
+            let mut parsed: toml::Value = toml::from_str(&text).map_err(|e| {
+                refuse(&format!(
+                    "{}: refusing to overwrite — exists but isn't valid TOML ({e}); \
+                     fix or delete it",
+                    path.display()
+                ))
+            })?;
+            let servers_ok = parsed.as_table_mut().and_then(|t| {
+                let entry = t
+                    .entry("mcp_servers")
+                    .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+                entry.as_table_mut()
+            });
+            match servers_ok {
+                Some(map) => {
+                    map.insert("spyc".to_string(), toml::Value::Table(build_entry()));
+                    // Re-serializing a table we only inserted into can still
+                    // fail on TOML's values-before-tables rule. Refuse rather
+                    // than fall back to `fresh()` — that would be the clobber.
+                    toml::to_string_pretty(&parsed).map_err(|e| {
+                        refuse(&format!(
+                            "{}: refusing to overwrite — merged config won't \
+                             re-serialize ({e})",
+                            path.display()
+                        ))
+                    })?
+                }
+                None => {
+                    return Err(refuse(&format!(
+                        "{}: refusing to overwrite — top level or `mcp_servers` is not a table",
+                        path.display()
+                    )));
                 }
             }
-            Err(_) => fresh(),
-        },
-        Err(_) => fresh(),
+        }
+        Ok(_) => fresh(),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => fresh(),
+        Err(e) => {
+            return Err(io::Error::new(
+                e.kind(),
+                format!("reading {}: {e}", path.display()),
+            ));
+        }
     };
 
     // Create the `.codex/` parent directory if missing.

--- a/src/mcp/hooks.rs
+++ b/src/mcp/hooks.rs
@@ -186,17 +186,47 @@ pub fn ensure_claude_status_hooks(dir: &Path) -> bool {
     crate::fs::write_atomic(&path, out.as_bytes()).is_ok()
 }
 
+/// The root value a status-hook merge splices into, or `None` to refuse.
+///
+/// The distinction that matters is **absent vs. unparseable**, and conflating
+/// them is a data-loss bug: an existing file we can't parse still holds the
+/// user's content — permissions in claude's `settings.json`, `model` and
+/// `approval_policy` in codex's `config.toml`, their own named sets in agy's
+/// `hooks.json` — and starting from an empty document silently deletes all of
+/// it on the next write. A trailing comma or a half-finished hand-edit is
+/// enough to trigger it. Absent or blank is not a refusal: there is nothing to
+/// lose, so an empty root is correct.
+///
+/// Refusing costs the activity dots for that repo, which is recoverable and
+/// visible; clobbering the file is neither.
+fn merge_root_json(existing: Option<&str>) -> Option<Value> {
+    match existing {
+        Some(t) if !t.trim().is_empty() => serde_json::from_str::<Value>(t)
+            .ok()
+            .filter(Value::is_object),
+        _ => Some(json!({})),
+    }
+}
+
+/// [`merge_root_json`] for codex's TOML config. Same rule, same reasoning.
+fn merge_root_toml(existing: Option<&str>) -> Option<toml::Value> {
+    match existing {
+        Some(t) if !t.trim().is_empty() => toml::from_str::<toml::Value>(t)
+            .ok()
+            .filter(toml::Value::is_table),
+        _ => Some(toml::Value::Table(toml::Table::new())),
+    }
+}
+
 /// Merge spyc's status hooks into `existing` settings.json content (or a fresh
-/// `{}` when absent/unparseable), returning the serialized result with a
-/// trailing newline. `None` when the existing `hooks` value is a non-object we
-/// refuse to clobber, or on a serialization failure. Pure (no I/O) so the merge
+/// `{}` when absent), returning the serialized result with a
+/// trailing newline. `None` when we refuse: an unparseable existing file, a
+/// non-object root or `hooks` value, or a serialization failure — see
+/// [`merge_root_json`]. Pure (no I/O) so the merge
 /// — and its byte-level idempotency, which is what makes the write skippable —
 /// is unit-testable.
 fn merged_status_hooks_json(existing: Option<&str>, exe: &str, trace: bool) -> Option<String> {
-    let mut root = existing
-        .and_then(|t| serde_json::from_str::<Value>(t).ok())
-        .filter(Value::is_object)
-        .unwrap_or_else(|| json!({}));
+    let mut root = merge_root_json(existing)?;
     let obj = root.as_object_mut()?;
     let hooks = obj.entry("hooks").or_insert_with(|| json!({}));
     let hooks_obj = hooks.as_object_mut()?;
@@ -348,18 +378,16 @@ pub fn ensure_codex_status_hooks(dir: &Path) -> bool {
 /// Pure merge for codex's `config.toml`: add a `[[hooks.<Event>]]` group for
 /// each [`CODEX_STATUS_HOOKS`] entry into `existing` (or a fresh table),
 /// dropping a stale spyc group from a prior launch and preserving the user's
-/// own config (including our `[mcp_servers.spyc]`). `None` on a non-table
-/// existing value or a serialization failure. Pure (no I/O) so the merge — and
+/// own config (including our `[mcp_servers.spyc]`). `None` when we refuse: an
+/// unparseable existing file, a non-table root or `hooks` value, or a
+/// serialization failure — see [`merge_root_toml`]. Pure (no I/O) so the merge — and
 /// its byte-level idempotency, which lets the write be skipped — is testable.
 fn merged_codex_status_hooks_toml(
     existing: Option<&str>,
     exe: &str,
     trace: bool,
 ) -> Option<String> {
-    let mut root = existing
-        .and_then(|t| toml::from_str::<toml::Value>(t).ok())
-        .filter(toml::Value::is_table)
-        .unwrap_or_else(|| toml::Value::Table(toml::Table::new()));
+    let mut root = merge_root_toml(existing)?;
     let obj = root.as_table_mut()?;
     let hooks = obj
         .entry("hooks")
@@ -525,14 +553,12 @@ pub fn ensure_agy_status_hooks(dir: &Path) -> bool {
 }
 
 /// Pure merge for agy's `hooks.json`: own the `spyc-status` named set (replace
-/// any prior ours, preserving the user's other sets). `None` on a non-object
-/// existing value or a serialization failure. Pure → its byte-idempotency,
+/// any prior ours, preserving the user's other sets). `None` when we refuse: an
+/// unparseable existing file, a non-object root, or a serialization failure —
+/// see [`merge_root_json`]. Pure → its byte-idempotency,
 /// which lets the write be skipped, is testable.
 fn merged_agy_status_hooks_json(existing: Option<&str>, exe: &str, trace: bool) -> Option<String> {
-    let mut root = existing
-        .and_then(|t| serde_json::from_str::<Value>(t).ok())
-        .filter(Value::is_object)
-        .unwrap_or_else(|| json!({}));
+    let mut root = merge_root_json(existing)?;
     let obj = root.as_object_mut()?;
     let mut set = serde_json::Map::new();
     for (event, state) in AGY_STATUS_HOOKS {
@@ -1070,5 +1096,74 @@ mod tests {
             traced,
             merged_agy_status_hooks_json(Some(&traced), "spyc", true).expect("re-merge traced"),
         );
+    }
+    /// Every status-hook merge REFUSES an existing file it can't parse, rather
+    /// than starting from an empty document and writing the user's content away.
+    ///
+    /// These files are not spyc's: claude's `settings.json` holds permissions,
+    /// codex's `config.toml` holds `model` / `approval_policy`, agy's
+    /// `hooks.json` holds the user's own named hook sets. One trailing comma was
+    /// enough to lose all of it on the next pane launch. A refusal costs the
+    /// activity dots for that repo, which is recoverable; the write was not.
+    #[test]
+    fn every_merge_refuses_an_unparseable_existing_file() {
+        for bad in [
+            r#"{"permissions": {"allow": ["Bash"]},}"#, // trailing comma
+            "{ not json at all",
+            "}}}}{{{",
+        ] {
+            assert!(
+                merged_status_hooks_json(Some(bad), "spyc", false).is_none(),
+                "claude merge must refuse {bad:?}"
+            );
+            assert!(
+                merged_agy_status_hooks_json(Some(bad), "spyc", false).is_none(),
+                "agy merge must refuse {bad:?}"
+            );
+        }
+        for bad in ["}}}}{{{ not toml", "model = \n"] {
+            assert!(
+                merged_codex_status_hooks_toml(Some(bad), "spyc", false).is_none(),
+                "codex merge must refuse {bad:?}"
+            );
+        }
+    }
+
+    /// A root of the wrong shape is also refused — a JSON array or a bare TOML
+    /// scalar is still someone's file, and `merge_root_*` must not treat
+    /// "unexpected shape" as "empty".
+    #[test]
+    fn every_merge_refuses_a_wrong_shaped_root() {
+        for bad in ["[1, 2, 3]", "\"just a string\"", "42"] {
+            assert!(
+                merged_status_hooks_json(Some(bad), "spyc", false).is_none(),
+                "claude merge must refuse root {bad:?}"
+            );
+            assert!(
+                merged_agy_status_hooks_json(Some(bad), "spyc", false).is_none(),
+                "agy merge must refuse root {bad:?}"
+            );
+        }
+    }
+
+    /// The benign half of the same distinction: absent or blank is NOT a
+    /// refusal. Over-triggering would break hook install on first launch in a
+    /// fresh repo, which is the common case.
+    #[test]
+    fn absent_or_blank_still_merges_fresh() {
+        for existing in [None, Some(""), Some("   \n\t\n")] {
+            assert!(
+                merged_status_hooks_json(existing, "spyc", false).is_some(),
+                "claude merge must accept {existing:?}"
+            );
+            assert!(
+                merged_agy_status_hooks_json(existing, "spyc", false).is_some(),
+                "agy merge must accept {existing:?}"
+            );
+            assert!(
+                merged_codex_status_hooks_toml(existing, "spyc", false).is_some(),
+                "codex merge must accept {existing:?}"
+            );
+        }
     }
 }

--- a/src/mcp/tests/mod.rs
+++ b/src/mcp/tests/mod.rs
@@ -1008,20 +1008,97 @@ fn codex_config_fresh_rewrite_on_malformed_input() {
     assert!(parsed["mcp_servers"]["spyc"].is_table());
 }
 
+/// An unparseable MCP json config is REFUSED, not rewritten — the
+/// multi-server case.
+///
+/// An `.mcp.json`-shaped file is the standard place a project declares *all* its
+/// MCP servers, so replacing it with a spyc-only document doesn't just lose
+/// formatting, it disconnects every other tool the user had wired up.
+///
+/// Driven through `ensure_agy_mcp_config` rather than `ensure_mcp_json`: both
+/// call the same `ensure_spyc_in_mcp_json` helper, but claude's entry point
+/// checks enterprise policy first by reading absolute system paths
+/// (`/Library/Application Support/ClaudeCode/managed-mcp.json`). A machine whose
+/// org config defines spyc returns `ManagedByEnterprise` and never reaches the
+/// file logic, so testing through it would pass or fail based on the host.
 #[test]
-fn codex_config_rewrites_completely_invalid_toml() {
-    // Non-TOML content (e.g. corrupted file) falls back to a fresh
-    // rewrite rather than failing.
+fn mcp_json_refuses_to_overwrite_invalid_json() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join(".agents/mcp_config.json");
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    // A real-looking config with one trailing comma — the classic hand-edit slip.
+    let original = r#"{
+  "mcpServers": {
+    "postgres": { "command": "mcp-postgres", "args": ["--dsn", "…"] },
+  }
+}"#;
+    std::fs::write(&path, original).unwrap();
+
+    let err = ensure_agy_mcp_config(tmp.path(), true)
+        .expect_err("an unparseable existing config must not be overwritten");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("refusing to overwrite"),
+        "error should say what it declined to do: {err}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        original,
+        "the user's other MCP servers must survive byte-for-byte"
+    );
+}
+
+/// An unparseable `.codex/config.toml` is REFUSED, not rewritten.
+///
+/// This test previously asserted the opposite — "falls back to a fresh rewrite
+/// rather than failing" — which codified data loss as intended behavior. That
+/// file holds the user's `model` and `approval_policy`; a trailing comma or a
+/// half-finished hand-edit was enough to have spyc replace all of it with a
+/// spyc-only document on the next pane launch, with no backup and no warning.
+/// Failing is the correct outcome: the caller flashes it and the pane still
+/// launches, so the cost is spyc's MCP tools in that repo until it's fixed.
+#[test]
+fn codex_config_refuses_to_overwrite_invalid_toml() {
     let tmp = tempfile::tempdir().unwrap();
     let codex_dir = tmp.path().join(".codex");
     std::fs::create_dir_all(&codex_dir).unwrap();
     let path = codex_dir.join("config.toml");
-    std::fs::write(&path, "}}}}{{{ this is not toml").unwrap();
-    let status = ensure_codex_config_toml(tmp.path(), true).unwrap();
-    assert!(matches!(status, McpConfigStatus::Configured));
-    let written = std::fs::read_to_string(&path).unwrap();
-    let parsed: toml::Value = toml::from_str(&written).unwrap();
-    assert!(parsed["mcp_servers"]["spyc"].is_table());
+    let original = "model = \"o3\"\napproval_policy = \"never\"\n}}}}{{{ not toml";
+    std::fs::write(&path, original).unwrap();
+
+    let err = ensure_codex_config_toml(tmp.path(), true)
+        .expect_err("an unparseable existing config must not be overwritten");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("refusing to overwrite"),
+        "error should say what it declined to do: {err}"
+    );
+    // The point of the whole change: the user's bytes are still there.
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        original,
+        "the file must be byte-identical after a refusal"
+    );
+}
+
+/// A blank (or absent) file is NOT a refusal — there's nothing to lose, so the
+/// fresh-write path still applies. The distinction between "absent" and
+/// "present but unparseable" is the whole fix; this pins the benign half so the
+/// refusal doesn't over-trigger and break first-launch in a fresh repo.
+#[test]
+fn codex_config_writes_fresh_over_a_blank_file() {
+    for content in ["", "   \n\t\n"] {
+        let tmp = tempfile::tempdir().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        let path = codex_dir.join("config.toml");
+        std::fs::write(&path, content).unwrap();
+        let status = ensure_codex_config_toml(tmp.path(), true)
+            .expect("a blank file carries no user data to lose");
+        assert!(matches!(status, McpConfigStatus::Configured));
+        let parsed: toml::Value = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(parsed["mcp_servers"]["spyc"].is_table());
+    }
 }
 
 // ── socket-bind diagnostics (testing campaign, cluster 7) ──


### PR DESCRIPTION
The only data-loss-class finding from today's audit. Pre-existing, not from this week's work.

## The bug

Every writer of an agent config replaced the **whole file** whenever it failed to parse. Two shapes, four files:

```rust
// mcp/config.rs — the MCP entry writers
Err(_) => fresh(),

// mcp/hooks.rs — all three status-hook mergers
existing.and_then(|t| from_str(t).ok()).filter(is_object).unwrap_or_else(|| json!({}))
```

The second folds *unparseable* into *absent* and then writes an empty root back out. These files are the user's, not spyc's:

| File | What it holds |
|---|---|
| `.mcp.json` | every other MCP server the project declares |
| `.codex/config.toml` | `model`, `approval_policy`, their own hooks |
| `.claude/settings.json` | permissions |
| `.agents/hooks.json` | their own named hook sets |

**One trailing comma was enough to lose all of it** on the next agent-pane launch. No backup, no flash, no way to tell it happened. A half-finished hand-edit while a pane is launching does it too.

## The fix

The distinction that matters is **absent vs. present-but-unparseable**, and conflating them is the whole bug. Now only an absent or blank file reaches the fresh-write path — there's nothing to lose in either case. Everything else is refused:

- unparseable content
- a root of the wrong shape (a JSON array, a bare TOML scalar)
- a read error that isn't `NotFound` (permissions, a directory in the way)
- a merged document that won't re-serialize — TOML's values-before-tables rule can genuinely fail here, and the old code fell back to `fresh()`, which *is* the clobber

The two `Result` writers return an `InvalidData` io::Error naming the file and what it declined to do. **The caller's `Err` arm already flashes and lets the pane launch**, so no new plumbing and no new status variant — the cost of a refusal is spyc's tools in that repo until the file is fixed, which is recoverable and visible. The three pure mergers return `None`, which their callers already treat as "don't write".

Also replaced a `.unwrap_or_default()` on the codex fresh-write path, which could have written a **zero-byte** config on a serialization failure.

## Deliberately not included

The audit also found the **git-tracked guard is one-sided**: the hook writers check `is_tracked`, the MCP writers don't. So a repo that commits `.mcp.json` — the normal way to share MCP config with a team — gets it rewritten with a machine-specific `SPYC_MCP_SOCK=…mcp-<pid>.sock`, and cleanup then *refuses* to undo it because it's tracked. Permanently dirty tree with a PID in a committed file.

I left it out because it has a real trade-off rather than an obvious fix: refusing means spyc's MCP **cannot work at all** in such a repo, since the entry needs a per-PID socket path. That deserves its own decision, not a silent ride-along in a data-safety PR.

## Tests

- A refusal test per format that asserts the file is **byte-identical afterwards** — that's the actual guarantee, so it's what's asserted.
- The wrong-shaped-root case.
- `absent_or_blank_still_merges_fresh` — the benign half, so the refusal can't over-trigger and break hook install on first launch in a fresh repo. That's the common case and the obvious way to get this wrong.

**`codex_config_rewrites_completely_invalid_toml` asserted the old behaviour** — its comment read *"falls back to a fresh rewrite rather than failing"* — and is replaced. It codified the data loss as intended behaviour, which is a fair part of why this shipped and survived a review.

One incidental find while writing the `.mcp.json` test: it has to go through `ensure_agy_mcp_config` rather than `ensure_mcp_json`, because the claude entry point checks enterprise policy by reading absolute system paths. On a machine whose org `managed-mcp.json` defines spyc it returns `ManagedByEnterprise` and never reaches the file logic — so testing through it would pass or fail based on the host. Noted in the test.

`make check` green, 1676 tests.

Generated with [Claude Code](https://claude.com/claude-code)
