### PR TITLE
fix(mouse): make the terminal's mouse state authoritative on every path

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -195,7 +195,7 @@ arrow keys (which a focused pane receives as history navigation).
 > | | |
 > |---|---|
 > | **Bypass modifier** (per-drag) | Hold **Shift** — Ghostty, WezTerm, kitty, Alacritty, most others. **Option** or **Fn** on iTerm2. |
-> | **`:mouse off`** (per-session) | Immediate, no restart, no file edit. `:mouse on` to re-enable. |
+> | **`:mouse off`** (per-session) | Immediate, no restart, no file edit. `:mouse on` to re-enable, `:mouse auto` to follow the config again. Survives a config reload — it is scoped to the session, not written to a file. |
 > | **`capture = false`** (permanent) | The default. |
 >
 > spyc's mouse-free yank paths: **`^a u`** quick-select (URLs / paths / SHAs) and

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -540,11 +540,12 @@ end).
 - **`:marks`** — show all marks in a pager popup
 - **`:set key=value`** — runtime settings (e.g. `:set sort=mtime`)
 - **`:bprev`** / **`:bnext`** — navigate pager buffer history (also `[b`/`]b` in pager)
-- **`:mouse on|off`** — real mouse reporting: the wheel scrolls whatever is under
+- **`:mouse on|off|auto`** — real mouse reporting: the wheel scrolls whatever is under
   the pointer, left-click focuses that region (and clicks through to a mouse-aware
   agent), middle-click pastes, right-click opens the leader menu. **Costs native click-drag text
   selection while on** (hold Shift to select anyway — Option/Fn on iTerm2);
-  `:mouse off` gives it back immediately, no restart. Default off (`[mouse]
+  `:mouse off` gives it back immediately, no restart, and survives a config
+  reload (`:mouse auto` returns to following the config). Default off (`[mouse]
   capture`). `^a u` quick-select and `y` in the pager are the mouse-free yank
   paths.
 - **`:limit <glob>`** — temporary filter (e.g. `:limit *.rs`)

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -168,6 +168,8 @@ impl App {
             resolver: Resolver::new(),
             user_keymap,
             config,
+            // No runtime `:mouse` toggle yet — follow the config.
+            mouse_capture_override: None,
             mode: Mode::Normal,
             project_home,
             session_name,

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -424,30 +424,46 @@ pub(super) fn cmd_hooks(app: &mut App, args: &str) -> Vec<Effect> {
 pub(super) fn cmd_mouse(app: &mut App, args: &str) -> Vec<Effect> {
     match args.trim() {
         "on" | "enable" | "yes" | "y" => {
-            app.state.config.mouse.capture = true;
+            // The override, not `config.mouse.capture`: a config reload replaces
+            // the whole config struct and would silently undo this.
+            app.state.mouse_capture_override = Some(true);
             app.state.flash_info(
                 "mouse: reporting on — terminal text selection needs Shift (Option/Fn on iTerm2)",
             );
         }
         "off" | "disable" | "no" | "n" => {
-            app.state.config.mouse.capture = false;
+            app.state.mouse_capture_override = Some(false);
             app.state
                 .flash_info("mouse: reporting off — native text selection restored");
         }
         "" | "status" => {
-            let want = app.state.config.mouse.capture;
+            let want = app.mouse_capture_wanted();
             // Report both halves: they diverge for exactly one loop iteration,
             // and if they ever diverge for longer that's the bug to see.
-            let actual = app.view.mouse_capture_on;
+            let actual = crate::mouse_capture_is_on();
             let note = if want == actual { "" } else { " (applying…)" };
+            let src = if app.state.mouse_capture_override.is_some() {
+                " (this session)"
+            } else {
+                ""
+            };
             app.state.flash_info(format!(
-                "mouse: {}{note} — `:mouse on|off` to change",
+                "mouse: {}{note}{src} — `:mouse on|off` to change",
                 if want { "on" } else { "off" }
+            ));
+        }
+        // Hand control back to `[mouse] capture`, so a config change takes effect
+        // again without restarting.
+        "auto" | "default" | "config" => {
+            app.state.mouse_capture_override = None;
+            let want = app.state.config.mouse.capture;
+            app.state.flash_info(format!(
+                "mouse: following config ([mouse] capture = {want})"
             ));
         }
         other => app
             .state
-            .flash_error(format!("usage: :mouse on|off  (got `{other}`)")),
+            .flash_error(format!("usage: :mouse on|off|auto  (got `{other}`)")),
     }
     Vec::new()
 }

--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -636,10 +636,9 @@ impl App {
                 Effect::SetTerminalTitle { title } => {
                     let _ = crate::term_title::set(&title);
                 }
-                // A-class: the P3-1 agent-status ping. The gating + suppression +
-                // text all happened in the producer (`settle_agent_activity`);
-                // here we just fire the OS notification (off-thread, best-effort)
-                // and ring the bell if requested (inline stdout write).
+                // Middle-click paste. Reads the system clipboard, then hands the
+                // text to `handle_paste` so routing and bracketed-paste gating are
+                // inherited rather than duplicated.
                 Effect::PasteFromClipboard => match crate::clipboard::paste() {
                     Ok(text) if text.is_empty() => {
                         self.state.flash_info("paste: clipboard is empty");
@@ -656,11 +655,14 @@ impl App {
                 Effect::SetMouseMode { capture } => {
                     // Mutually exclusive with 1007 alternate-scroll: a terminal
                     // honoring both could deliver one wheel tick twice.
+                    //
+                    // `set_mouse_capture` records the new terminal state itself, and
+                    // only on success — so a failed write leaves the reconcile
+                    // seeing divergence and retrying, rather than going quiet on a
+                    // state the terminal never reached.
                     if let Err(e) = crate::set_mouse_capture(terminal, capture) {
                         self.state
                             .flash_error(format!("mouse: could not set reporting: {e:#}"));
-                    } else {
-                        self.view.mouse_capture_on = capture;
                     }
                 }
                 Effect::Notify { system, osc9, bell } => {
@@ -765,7 +767,6 @@ impl App {
                     // if the user wants it. `resume_tui` deliberately doesn't do
                     // this itself — it has no config access, and the settle is
                     // the single place that decides.
-                    self.view.mouse_capture_on = false;
                     // --- after-work (moved verbatim from the run loop's
                     // former `if let PostAction::Spawn` call site) ---
                     // Runs regardless of the spawn result: the pager

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -849,13 +849,6 @@ pub struct ViewState {
     /// P3-1 `desktop_via = "auto"` routing — OSC-9 (client-side) over SSH, the OS
     /// notifier locally — so the pure `notification_for_transition` never reads env.
     pub is_ssh: bool,
-    /// What mouse mode the TERMINAL is currently in — not what the user asked
-    /// for (that's `state.config.mouse.capture`). `App::settle_mouse_mode`
-    /// reconciles the two at loop bottom, so this is the "actual" half of the
-    /// pair and the reason the reconcile can be idempotent. Reset to `false` by
-    /// the `ForegroundExec` executor, since `suspend_tui` hands reporting to the
-    /// child.
-    pub mouse_capture_on: bool,
     /// Tab-completion / cycle state.
     // Module-private (type `TabState` is module-private).
     tab_state: Option<TabState>,
@@ -951,7 +944,6 @@ impl ViewState {
             // `setup_terminal` starts us in 1007 alternate-scroll, so the
             // terminal is NOT in real mouse reporting yet. `settle_mouse_mode`
             // turns it on at the first loop bottom if config asks for it.
-            mouse_capture_on: false,
             tab_state: None,
             scroll_last: None,
             transcript_show_tool_calls: true,

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -12,9 +12,8 @@
 //! [`FrameLayout`] the renderer used, and [`route_mouse`] takes that region —
 //! never `state.focus`.
 //!
-//! This module decides; it does not act. Wiring the decision to an
-//! `Event::Mouse` arm is a later change, which is why nothing here reads or
-//! mutates `App`.
+//! The pure half ([`route_mouse`], [`region_at`]) decides; the `impl App` half
+//! below acts on that decision.
 
 use ratatui::layout::Rect;
 
@@ -212,12 +211,20 @@ use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
 impl super::App {
     /// Handle one mouse event: hit-test the pointer, route it, dispatch the sink.
     ///
-    /// Only reachable while `[mouse] capture` is on — with it off the terminal
-    /// sends DEC 1007 arrow keys instead and this never fires.
+    /// Ignores everything unless spyc actually asked the terminal for mouse
+    /// reporting.
+    ///
+    /// Not a redundant assertion: spyc receiving a mouse event does NOT imply it
+    /// requested one. A foreground child can leave its own reporting enabled when
+    /// it dies without resetting, and some terminals/multiplexers report
+    /// regardless of what was asked — the case `proc.rs`'s motion filter already
+    /// guards against. Without this gate those unsolicited events were fully acted
+    /// upon with the feature switched off: middle-click pasted the clipboard and
+    /// right-click opened the leader menu.
     pub(super) fn handle_mouse(&mut self, ev: MouseEvent) -> Vec<Effect> {
-        // Wheel only for now; buttons are a later change and `route_mouse` is
-        // deliberately reached through one `MouseEventKind` match so adding them
-        // is contained.
+        if !crate::mouse_capture_is_on() {
+            return Vec::new();
+        }
         let lines = self.state.config.mouse.scroll_lines.max(1);
         // `delta` is only meaningful for a wheel gesture; buttons ignore it.
         let (gesture, delta): (Gesture, i32) = match ev.kind {

--- a/src/app/mouse_mode.rs
+++ b/src/app/mouse_mode.rs
@@ -14,25 +14,45 @@
 use super::{App, Effect};
 
 impl App {
-    /// Reconcile the terminal's mouse mode against `[mouse] capture`.
+    /// Whether the user wants real mouse reporting: the `:mouse` runtime override
+    /// if one is set, else `[mouse] capture` from the config.
     ///
-    /// Two values, one truth: `state.config.mouse.capture` is what the user asked
-    /// for, `view.mouse_capture_on` is what the terminal is actually in. Comparing
-    /// them at loop bottom covers every transition through one path — startup,
-    /// `:mouse on|off`, a live `^R` config reload, and returning from a foreground
-    /// child (whose `suspend_tui` handed the mouse away, recorded by the
-    /// `ForegroundExec` executor resetting the flag).
+    /// The override exists because `:mouse off` has to survive a config reload.
+    /// `reload_config` replaces `state.config` wholesale, so a `:mouse` that wrote
+    /// `config.mouse.capture` was silently undone by any save of a watched config
+    /// file — including the automatic fs-watch reload, which fires without the
+    /// user doing anything deliberate. Every doc surface promises the toggle is
+    /// session-scoped ("Immediate, no restart, no file edit"), and re-arming
+    /// capture underneath a user who turned it off to select text is the exact
+    /// surprise those words rule out.
+    pub(super) fn mouse_capture_wanted(&self) -> bool {
+        self.state
+            .mouse_capture_override
+            .unwrap_or(self.state.config.mouse.capture)
+    }
+
+    /// Reconcile the terminal's mouse mode against what the user wants.
+    ///
+    /// Two values, one truth: [`Self::mouse_capture_wanted`] is the request,
+    /// [`crate::mouse_capture_is_on`] is what the terminal is actually in.
+    /// Comparing them at loop bottom covers every transition through one path —
+    /// startup, `:mouse on|off`, a live `^R` config reload, and returning from a
+    /// foreground child (whose `suspend_tui` handed the mouse away).
+    ///
+    /// Actual-state lives in a process-global, not on `ViewState`, because the
+    /// panic hook and `restore_terminal` also change it and can't reach `App` —
+    /// see [`crate::mouse_capture_is_on`] for the failure that caused.
     ///
     /// Emits nothing when the two already agree, so this is free at idle and
     /// preserves 0 dps — there is no deadline and no wake, just a bool compare on
     /// an iteration that was going to happen anyway.
     ///
-    /// `&self`, unlike the other `settle_*` methods: the decision is a read of two
-    /// fields, and the state change belongs to the executor (which records what the
-    /// terminal actually accepted). That split is what makes it idempotent.
+    /// `&self`, unlike the other `settle_*` methods: the decision is a read, and
+    /// the state change belongs to the executor (which records what the terminal
+    /// actually accepted). That split is what makes it idempotent.
     pub(super) fn settle_mouse_mode(&self) -> Vec<Effect> {
-        let want = self.state.config.mouse.capture;
-        if want == self.view.mouse_capture_on {
+        let want = self.mouse_capture_wanted();
+        if want == crate::mouse_capture_is_on() {
             return Vec::new();
         }
         vec![Effect::SetMouseMode { capture: want }]
@@ -46,13 +66,17 @@ mod tests {
 
     /// The reconcile emits only on divergence — that's what makes it free to call
     /// every loop bottom, and what keeps idle at 0 dps.
+    ///
+    /// "Actual" is a process-global written by the executor, so these tests drive
+    /// it through `crate::set_mouse_capture_for_test` rather than a struct field.
     #[test]
     fn settle_emits_only_when_desired_and_actual_disagree() {
+        let _lock = crate::mouse_test_lock();
         let mut app = App::test_app(std::env::temp_dir());
+        crate::set_mouse_capture_for_test(false);
 
         // Agreement (both off, the default) → nothing.
         assert!(!app.state.config.mouse.capture);
-        assert!(!app.view.mouse_capture_on);
         assert!(app.settle_mouse_mode().is_empty(), "off/off must be silent");
 
         // User asks for capture → one enable.
@@ -65,7 +89,7 @@ mod tests {
 
         // The executor records what it did; the settle then goes quiet. Emitting
         // again here would re-send the escape every iteration.
-        app.view.mouse_capture_on = true;
+        crate::set_mouse_capture_for_test(true);
         assert!(app.settle_mouse_mode().is_empty(), "on/on must be silent");
 
         // `:mouse off` (or a config reload) → one disable.
@@ -75,21 +99,22 @@ mod tests {
             matches!(fx.as_slice(), [Effect::SetMouseMode { capture: false }]),
             "want-off/actual-on must emit disable, got {fx:?}"
         );
+        crate::set_mouse_capture_for_test(false);
     }
 
-    /// A foreground child's `suspend_tui` hands the mouse away, and the
-    /// `ForegroundExec` executor records that by clearing the flag. The settle has
-    /// to notice and take it back, or the wheel silently stops working after every
-    /// `v` / `;` round-trip.
+    /// A foreground child's `suspend_tui` hands the mouse away and clears the
+    /// global. The settle has to notice and take it back, or the wheel silently
+    /// stops working after every `v` / `;` round-trip.
     #[test]
     fn settle_reclaims_capture_after_a_foreground_child() {
+        let _lock = crate::mouse_test_lock();
         let mut app = App::test_app(std::env::temp_dir());
         app.state.config.mouse.capture = true;
-        app.view.mouse_capture_on = true;
+        crate::set_mouse_capture_for_test(true);
         assert!(app.settle_mouse_mode().is_empty());
 
-        // What the executor does after `fg.run(..)` returns.
-        app.view.mouse_capture_on = false;
+        // What `suspend_tui` does when the child takes the tty.
+        crate::set_mouse_capture_for_test(false);
 
         assert!(
             matches!(
@@ -98,5 +123,74 @@ mod tests {
             ),
             "must re-enable after the child gave the tty back"
         );
+        crate::set_mouse_capture_for_test(false);
+    }
+
+    /// The same reclaim covers the panic hook, which is NOT exit-only: `Pane`
+    /// catches a known vt100 panic (nvim leaving the alt screen) and spyc keeps
+    /// running. Before the actual-state moved to a global the hook disabled
+    /// reporting at the terminal while `App` still believed it was on, so the
+    /// reconcile saw agreement and never restored it — mouse dead for the session,
+    /// with `:mouse` reporting "on".
+    #[test]
+    fn settle_reclaims_capture_after_a_caught_panic_restored_the_terminal() {
+        let _lock = crate::mouse_test_lock();
+        let mut app = App::test_app(std::env::temp_dir());
+        app.state.config.mouse.capture = true;
+        crate::set_mouse_capture_for_test(true);
+        assert!(app.settle_mouse_mode().is_empty());
+
+        // What the panic hook does — reaching no App field.
+        crate::set_mouse_capture_for_test(false);
+
+        assert!(
+            matches!(
+                app.settle_mouse_mode().as_slice(),
+                [Effect::SetMouseMode { capture: true }]
+            ),
+            "a caught panic must not leave the mouse dead for the session"
+        );
+        crate::set_mouse_capture_for_test(false);
+    }
+
+    /// `:mouse off` must survive a config reload. The override is why: writing
+    /// `config.mouse.capture` instead meant any save of a watched config file —
+    /// including the automatic fs-watch reload — silently re-armed capture
+    /// underneath a user who turned it off to select text.
+    #[test]
+    fn a_runtime_override_outlives_a_config_reload() {
+        let _lock = crate::mouse_test_lock();
+        let mut app = App::test_app(std::env::temp_dir());
+        crate::set_mouse_capture_for_test(true);
+        app.state.config.mouse.capture = true;
+
+        // `:mouse off`.
+        app.state.mouse_capture_override = Some(false);
+        assert!(!app.mouse_capture_wanted());
+        assert!(matches!(
+            app.settle_mouse_mode().as_slice(),
+            [Effect::SetMouseMode { capture: false }]
+        ));
+        crate::set_mouse_capture_for_test(false);
+
+        // A reload replaces the whole Config — capture is true again in it.
+        app.state.config.mouse.capture = true;
+        assert!(
+            !app.mouse_capture_wanted(),
+            "a config reload must not undo `:mouse off`"
+        );
+        assert!(
+            app.settle_mouse_mode().is_empty(),
+            "reload must not re-arm capture behind the user"
+        );
+
+        // `:mouse auto` hands control back to the config.
+        app.state.mouse_capture_override = None;
+        assert!(app.mouse_capture_wanted());
+        assert!(matches!(
+            app.settle_mouse_mode().as_slice(),
+            [Effect::SetMouseMode { capture: true }]
+        ));
+        crate::set_mouse_capture_for_test(false);
     }
 }

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -594,6 +594,13 @@ pub struct AppState {
     pub resolver: Resolver,
     pub user_keymap: UserKeymap,
     pub config: Config,
+    /// `:mouse on|off` for this session, overriding `[mouse] capture`.
+    ///
+    /// Separate from `config` on purpose: `reload_config` replaces the whole
+    /// `Config`, so a runtime toggle stored there is silently reverted by any
+    /// save of a watched config file — including the automatic fs-watch reload.
+    /// `:mouse auto` clears it and hands control back to the config.
+    pub mouse_capture_override: Option<bool>,
     pub mode: Mode,
     pub start_dir: PathBuf,
     pub project_home: Option<PathBuf>,
@@ -983,6 +990,7 @@ impl AppState {
             resolver: Resolver::new(),
             user_keymap: UserKeymap::default(),
             config: Config::default(),
+            mouse_capture_override: None,
             mode: Mode::Normal,
             start_dir: cwd,
             project_home: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@ pub mod fuzz {
 }
 
 use std::io;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::Result;
 use clap::Parser;
@@ -230,6 +231,10 @@ pub fn run() -> Result<()> {
             ShowMousePointer,
             crossterm::cursor::Show,
         );
+        // This hook is NOT exit-only (`pane::Pane` catches a known vt100 panic
+        // and spyc keeps running), so the flag has to follow the terminal or the
+        // reconcile will believe capture is still on and never restore it.
+        MOUSE_CAPTURE_ON.store(false, Ordering::Relaxed);
         let _ = term_title::pop();
 
         // Dump to the debug log if active.
@@ -497,12 +502,80 @@ impl crossterm::Command for DisableWheelReporting {
     fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
         // Reverse order of the enable, so a terminal that tracks a mode stack
         // unwinds cleanly.
-        f.write_str("\x1b[?1006l\x1b[?1000l")
+        //
+        // Clears 1002/1003 too, which spyc never ENABLES: a foreground child
+        // (vim, htop) sets its own motion reporting, and one that dies without
+        // resetting — SIGKILL, a crash — hands the tty back with 1002/1003 still
+        // on. Clearing only our own pair would then leave motion reporting live,
+        // which both defeats the 1007 exclusivity `resume_tui` re-establishes and
+        // leaks motion events into the user's shell after spyc exits.
+        f.write_str("\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l")
     }
     #[cfg(windows)]
     fn execute_winapi(&self) -> std::io::Result<()> {
         Ok(())
     }
+}
+
+/// Whether the TERMINAL is currently in real mouse reporting — as distinct from
+/// whether the user asked for it (`[mouse] capture` + the `:mouse` override).
+///
+/// A process-global rather than a field on `ViewState`, because two of the three
+/// things that change this state run outside `App` and cannot reach its fields:
+/// [`restore_terminal`] and the **panic hook**. The hook is not exit-only —
+/// `pane::Pane` deliberately `catch_unwind`s a known vt100 panic (nvim leaving
+/// the alternate screen is the documented trigger) and spyc keeps running — so
+/// with the flag on `ViewState` that path disabled reporting at the terminal
+/// while `App` still believed it was on. `settle_mouse_mode` then saw no
+/// divergence and never re-enabled: the mouse was dead for the rest of the
+/// session, and `:mouse` reported "on" because want matched the stale actual.
+static MOUSE_CAPTURE_ON: AtomicBool = AtomicBool::new(false);
+
+/// Read the terminal's actual mouse-reporting state. The `settle_mouse_mode`
+/// reconcile compares this against what the user asked for.
+pub fn mouse_capture_is_on() -> bool {
+    MOUSE_CAPTURE_ON.load(Ordering::Relaxed)
+}
+
+/// Set the terminal-state flag WITHOUT touching the terminal — tests only.
+///
+/// Lets a unit test stand in for the executor / panic hook / `suspend_tui`, none
+/// of which a test can drive (they need a real `Tui`).
+#[cfg(test)]
+pub(crate) fn set_mouse_capture_for_test(on: bool) {
+    MOUSE_CAPTURE_ON.store(on, Ordering::Relaxed);
+}
+
+/// Serialize the tests that drive [`MOUSE_CAPTURE_ON`].
+///
+/// It's process-global and `cargo test` runs tests on parallel threads, so
+/// without this they clobber each other's setup — an intermittent failure that
+/// depends on scheduling, which is the worst kind to chase (see the CI-only gix
+/// index-lock flake for the same lesson). Recovers from a poisoned lock so one
+/// failing test doesn't cascade into every other test in the group.
+#[cfg(test)]
+pub(crate) fn mouse_test_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    LOCK.lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// The escape sequence [`set_mouse_capture`] emits for `capture`.
+///
+/// Extracted from the `execute!` so the exclusivity invariant is unit-testable:
+/// `set_mouse_capture` takes `&mut Tui`, which no test can construct, so before
+/// this the one rule the whole feature rests on — 1007 and 1000 are never both
+/// enabled — had no test at all.
+fn mouse_mode_seq(capture: bool) -> String {
+    let mut s = String::new();
+    if capture {
+        let _ = crossterm::Command::write_ansi(&DisableAlternateScroll, &mut s);
+        let _ = crossterm::Command::write_ansi(&EnableWheelReporting, &mut s);
+    } else {
+        let _ = crossterm::Command::write_ansi(&DisableWheelReporting, &mut s);
+        let _ = crossterm::Command::write_ansi(&EnableAlternateScroll, &mut s);
+    }
+    s
 }
 
 /// No-op handler for SIGINT / SIGQUIT. Replaces the default
@@ -659,6 +732,7 @@ fn restore_terminal(terminal: &mut Tui) -> Result<()> {
         DisableWheelReporting,
         ShowMousePointer
     )?;
+    MOUSE_CAPTURE_ON.store(false, Ordering::Relaxed);
     let _ = term_title::pop();
     terminal.show_cursor()?;
     Ok(())
@@ -673,19 +747,16 @@ fn restore_terminal(terminal: &mut Tui) -> Result<()> {
 /// only from the `Effect::SetMouseMode` executor, which in turn is emitted only by
 /// the reconcile in `App::settle_mouse_mode`.
 pub fn set_mouse_capture(terminal: &mut Tui, capture: bool) -> Result<()> {
-    if capture {
-        execute!(
-            terminal.backend_mut(),
-            DisableAlternateScroll,
-            EnableWheelReporting
-        )?;
-    } else {
-        execute!(
-            terminal.backend_mut(),
-            DisableWheelReporting,
-            EnableAlternateScroll
-        )?;
-    }
+    use std::io::Write as _;
+    // One write of the paired sequence (see `mouse_mode_seq`) so the disable and
+    // the enable cannot be separated by a failure between two `execute!` calls.
+    let seq = mouse_mode_seq(capture);
+    terminal.backend_mut().write_all(seq.as_bytes())?;
+    terminal.backend_mut().flush()?;
+    // Record only on success: a failed write leaves the terminal in its previous
+    // mode, and claiming otherwise is what makes the reconcile go quiet on a
+    // state it never reached.
+    MOUSE_CAPTURE_ON.store(capture, Ordering::Relaxed);
     Ok(())
 }
 
@@ -709,6 +780,9 @@ pub fn suspend_tui(terminal: &mut Tui) -> Result<()> {
         // and leaving ours on would have both of us reading the same events.
         DisableWheelReporting,
     )?;
+    // The child owns the mouse now. Clearing this is what makes
+    // `settle_mouse_mode` reclaim it on the next iteration after we resume.
+    MOUSE_CAPTURE_ON.store(false, Ordering::Relaxed);
     terminal.show_cursor()?;
     Ok(())
 }
@@ -730,8 +804,16 @@ pub fn resume_tui(terminal: &mut Tui) -> Result<()> {
         Clear(ClearType::All),
         MoveTo(0, 0),
         EnableBracketedPaste,
+        // Clear any reporting the child left behind BEFORE turning 1007 back on.
+        // A child killed without resetting (SIGKILLed vim, a crashed TUI) hands
+        // the tty back with its own 1000/1002/1003 still live; enabling 1007 on
+        // top of that is the both-modes-on state the pairing exists to prevent,
+        // and the terminal may then deliver one wheel tick twice.
+        DisableWheelReporting,
         EnableAlternateScroll
     )?;
+    // `suspend_tui` already cleared this; the reconcile re-enables per config on
+    // the next iteration if the user wants capture.
     terminal.hide_cursor()?;
     force_full_repaint(terminal)?;
     Ok(())
@@ -799,5 +881,123 @@ mod mouse_reporting_tests {
         let sgr = disable.find("1006").expect("1006");
         let btn = disable.find("1000").expect("1000");
         assert!(sgr < btn, "expected 1006l before 1000l: {disable:?}");
+    }
+
+    /// The disable also clears 1002/1003, which spyc never *enables*.
+    ///
+    /// A foreground child (vim, htop) sets its own motion reporting; one killed
+    /// without resetting hands the tty back with those still live. Clearing only
+    /// our own pair would leave motion reporting on — which breaks the 1007
+    /// exclusivity `resume_tui` re-establishes, and leaks motion events into the
+    /// user's shell after spyc exits.
+    #[test]
+    fn disable_also_clears_a_childs_leftover_motion_reporting() {
+        let disable = ansi(&DisableWheelReporting);
+        for mode in ["1002", "1003"] {
+            assert!(
+                disable.contains(&format!("\x1b[?{mode}l")),
+                "?{mode}l missing — a child's leaked motion mode would survive: {disable:?}"
+            );
+        }
+    }
+
+    /// **The invariant the whole feature rests on**, in both directions: DEC 1007
+    /// (wheel-as-arrows) and DEC 1000 (real reporting) are never both enabled. A
+    /// terminal honoring both delivers one wheel tick twice — once as arrow keys,
+    /// once as a mouse event.
+    ///
+    /// Untestable before `mouse_mode_seq` was split out of `set_mouse_capture`,
+    /// which takes `&mut Tui` — a type no unit test can construct. So the one rule
+    /// that matters most had no coverage at all.
+    #[test]
+    fn the_two_modes_are_never_both_enabled() {
+        // Enabling capture: 1007 off, 1000/1006 on.
+        let on = super::mouse_mode_seq(true);
+        assert!(on.contains("\x1b[?1007l"), "must disable 1007: {on:?}");
+        assert!(on.contains("\x1b[?1000h"), "must enable 1000: {on:?}");
+        assert!(!on.contains("\x1b[?1007h"), "must not enable 1007: {on:?}");
+
+        // Disabling capture: the mirror.
+        let off = super::mouse_mode_seq(false);
+        assert!(off.contains("\x1b[?1000l"), "must disable 1000: {off:?}");
+        assert!(off.contains("\x1b[?1007h"), "must enable 1007: {off:?}");
+        assert!(
+            !off.contains("\x1b[?1000h"),
+            "must not enable 1000: {off:?}"
+        );
+
+        // Ordering: in each direction the disable precedes the enable, so there is
+        // no instant with both modes live even for a terminal applying them
+        // sequentially.
+        assert!(
+            on.find("1007l") < on.find("1000h"),
+            "disable 1007 before enabling 1000: {on:?}"
+        );
+        assert!(
+            off.find("1000l") < off.find("1007h"),
+            "disable 1000 before enabling 1007: {off:?}"
+        );
+    }
+
+    /// Neither direction may request motion reporting — the `?1003h` redraw storm
+    /// is invisible on a still pointer, so only a byte assertion catches it.
+    #[test]
+    fn neither_direction_requests_motion_reporting() {
+        for capture in [true, false] {
+            let seq = super::mouse_mode_seq(capture);
+            for motion in ["1002h", "1003h"] {
+                assert!(
+                    !seq.contains(motion),
+                    "capture={capture} must not request ?{motion}: {seq:?}"
+                );
+            }
+        }
+    }
+
+    /// Source-scan guard: nothing in `src/` may use crossterm's own
+    /// `EnableMouseCapture`.
+    ///
+    /// The byte tests above only cover the structs spyc defines. `EnableMouseCapture`
+    /// emits `?1000h ?1002h ?1003h ?1015h ?1006h` — the motion modes included — so
+    /// one convenient-looking call anywhere (`setup_terminal`, `resume_tui`, a future
+    /// feature) reintroduces the redraw storm while every existing test still passes.
+    /// It reads as the obvious API to reach for, which is exactly why this is a
+    /// guard and not a comment.
+    #[test]
+    fn production_code_never_uses_crossterms_mouse_capture() {
+        use std::path::{Path, PathBuf};
+
+        // Assembled so this test's own source doesn't trip the scan.
+        let banned = ["Enable", "MouseCapture"].concat();
+
+        fn scan(dir: &Path, banned: &str, offenders: &mut Vec<PathBuf>) {
+            for entry in std::fs::read_dir(dir).expect("read src dir") {
+                let path = entry.expect("dir entry").path();
+                if path.is_dir() {
+                    scan(&path, banned, offenders);
+                } else if path.extension().is_some_and(|e| e == "rs")
+                    && std::fs::read_to_string(&path)
+                        .expect("read .rs")
+                        .contains(banned)
+                {
+                    offenders.push(path);
+                }
+            }
+        }
+
+        let mut offenders = Vec::new();
+        scan(
+            &Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+            &banned,
+            &mut offenders,
+        );
+        // This file legitimately names it in prose (the doc comment on
+        // `EnableWheelReporting` explains why spyc doesn't use it).
+        offenders.retain(|p| p.file_name().is_none_or(|n| n != "lib.rs"));
+        assert!(
+            offenders.is_empty(),
+            "crossterm's EnableMouseCapture emits ?1003h (any-motion) — use \
+             EnableWheelReporting instead. Offenders: {offenders:?}"
+        );
     }
 }

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -266,7 +266,7 @@ const SECTIONS: &[Section] = &[
                 "claude/codex/agy auto-status hooks (asked once on launch); on! restarts+resumes a claude pane",
             ),
             (
-                ":mouse on|off",
+                ":mouse on|off|auto",
                 "real mouse reporting (scroll what's under the pointer); off restores terminal text selection",
             ),
             (


### PR DESCRIPTION
Mouse PR A of three, from the audit of the merged mouse work. Five defects with one root cause.

## Root cause

"What mode is the terminal actually in" lived on `ViewState` — but two of the three things that change it run **outside `App`** and can't reach a field.

`view.mouse_capture_on` had exactly two writers (the `SetMouseMode` executor and `ForegroundExec`). `restore_terminal` and the **panic hook** also change the real terminal.

And the panic hook is not exit-only. `pane::Pane` deliberately `catch_unwind`s a known vt100 panic, and its documented trigger is **nvim leaving the alternate screen**:

```
capture on → nvim in a pane → :q
  → hook fires, emits ?1006l ?1000l, spyc keeps running
  → terminal: reporting OFF.  App: still believes ON.
  → settle_mouse_mode sees agreement, never re-enables
```

Mouse dead for the rest of the session — and `:mouse` **lies**, reporting "on", because want matches the stale actual.

Now a process-global `MOUSE_CAPTURE_ON`, written by `set_mouse_capture` (only on success, so a failed write leaves the reconcile retrying rather than going quiet on a state the terminal never reached), the panic hook, `restore_terminal`, and `suspend_tui`. The `ForegroundExec` special case is **deleted**: `suspend_tui` clearing the flag is what makes the reconcile reclaim capture, so resume needs no bespoke handling.

## Four more

**`:mouse off` was clobbered by any config reload.** It wrote `config.mouse.capture`, and `reload_config` replaces the whole struct — so saving any watched config file, *including the automatic fs-watch reload*, silently re-armed capture underneath a user who'd turned it off to select text. Four doc surfaces promise the toggle is session-scoped ("Immediate, no restart, no file edit"). Now a `state.mouse_capture_override` the reload can't touch, plus **`:mouse auto`** to hand control back to the config.

**`resume_tui` re-enabled 1007 without clearing mouse reporting first.** A child killed without resetting (SIGKILLed vim) hands the tty back with its own 1000/1002/1003 live; adding 1007 on top is exactly the both-modes-on state the pairing exists to prevent, and the terminal may then deliver one wheel tick twice.

**`DisableWheelReporting` cleared only 1006+1000**, so a child's leaked 1002/1003 survived spyc's exit and leaked motion reporting into the user's shell. Now clears all four.

**No `capture` gate on `handle_mouse`** — its doc comment merely *asserted* the path was unreachable with capture off. Receiving a mouse event doesn't imply requesting one: a child can leave reporting on, and some terminals report regardless (the case `proc.rs`'s motion filter already guards against). Those unsolicited events were fully acted upon with the feature **switched off** — middle-click pasted your clipboard, right-click opened the leader menu.

## Tests

**The invariant the entire feature rests on had no test.** 1007 and 1000 must never both be enabled, but `set_mouse_capture` takes `&mut Tui` — a type no unit test can construct — so it was unreachable. Split out a pure `mouse_mode_seq(capture)` and asserted both directions plus disable-before-enable ordering.

**Added a source-scan guard** forbidding `crossterm::event::EnableMouseCapture` anywhere in `src/`. It emits `?1003h` (any-motion), so one convenient-looking call reintroduces the redraw storm *while every existing byte test still passes*. It's the obvious API to reach for, which is why it needs a guard rather than a comment.

Also covered: reclaim-after-caught-panic, and `:mouse off` surviving a reload. The global plus `cargo test` parallelism needs serializing, so those tests take a lock — same lesson as the CI-only gix index-lock flake.

## Also

Two stale comments removed: `mouse.rs`'s *"Wheel only for now; buttons are a later change"* — sitting directly above the button match, and "for now" is precisely what AGENTS.md's comment rule forbids — and an `Effect::Notify` doc comment that had drifted to sit above `Effect::PasteFromClipboard`, describing the wrong arm entirely.

## Not included

**SIGTERM/SIGHUP still leak `?1000h`** on `pkill spyc` — only SIGINT/SIGQUIT/SIGTTOU are handled. Left out deliberately: it leaks raw mode and the alternate screen too, both worse than the mouse mode, so it's process-teardown work rather than a mouse-shaped half of it. Doing it properly needs async-signal-safe restore (a raw `write` of a fixed byte string, then `_exit`), which is its own review. **It gates the `capture = true` flip.**

`make check` green, 1678 tests.

Generated with [Claude Code](https://claude.com/claude-code)
