### PR TITLE
test(git): report the lock directory state when a worktree index write fails

### DIFF
--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -314,9 +314,10 @@ fn write_index_with_lock_retry(index: &mut gix::index::File) -> std::io::Result<
             }
             Err(e) => {
                 return Err(std::io::Error::other(format!(
-                    "write index ({} attempt(s)): {}",
+                    "write index ({} attempt(s)): {}{}",
                     attempt,
-                    error_chain(&e)
+                    error_chain(&e),
+                    describe_index_parent(index.path())
                 )));
             }
         }
@@ -324,6 +325,52 @@ fn write_index_with_lock_retry(index: &mut gix::index::File) -> std::io::Result<
     // The `attempt < ATTEMPTS` guard routes the final attempt's errors to the
     // catch-all above, so every path through the loop has already returned.
     unreachable!("write_index_with_lock_retry loop always returns")
+}
+
+/// Describe the state of the directory the index lock lives in, for a failure
+/// message. Empty string when the directory is present and readable (the boring
+/// case needs no words).
+///
+/// This exists to settle one specific recurring CI failure. `write index (1
+/// attempt(s)): Could not acquire lock … -> No such file or directory … at
+/// "<admin>/index.lock"` means nobody is holding the lock — the lock file's
+/// PARENT is missing. That should be impossible: `materialize_worktree` calls
+/// `create_dir_all(admin_dir)` before `checkout_and_write`, and the only thing
+/// between them is a checkout into a disjoint directory. Three rounds of
+/// retry-widening were spent on this while it was still being read as lock
+/// contention, so the next occurrence should answer the question instead of
+/// prompting a fourth guess: did the directory never get created, did it vanish,
+/// or did an ancestor vanish (a tempdir cleaned early)?
+///
+/// Walks ancestors so a missing grandparent is distinguishable from a missing
+/// admin dir — the two implicate completely different culprits.
+fn describe_index_parent(index_path: &Path) -> String {
+    let Some(parent) = index_path.parent() else {
+        return format!(" [index path {} has no parent]", index_path.display());
+    };
+    match std::fs::read_dir(parent) {
+        // Present and readable: not the directory's fault, say nothing.
+        Ok(entries) => {
+            let n = entries.count();
+            if n == 0 {
+                format!(" [{} exists but is empty]", parent.display())
+            } else {
+                String::new()
+            }
+        }
+        Err(e) => {
+            // Find the nearest ancestor that DOES exist — that boundary is the
+            // useful fact.
+            let existing = parent
+                .ancestors()
+                .find(|a| a.exists())
+                .map_or_else(|| "(none)".to_string(), |a| a.display().to_string());
+            format!(
+                " [{} unreadable: {e}; nearest existing ancestor: {existing}]",
+                parent.display()
+            )
+        }
+    }
 }
 
 /// Whether a failed index write is worth another attempt.
@@ -1124,6 +1171,55 @@ mod tests {
         assert!(
             !index_path.exists(),
             "index must not be written out under a held lock"
+        );
+        // Contention is not a missing-directory fault, so the parent note stays
+        // out of the message — it would be noise on the common failure.
+        assert!(
+            !err.to_string().contains("nearest existing ancestor"),
+            "a held lock must not be reported as a directory problem: {err}"
+        );
+    }
+
+    /// A write whose target directory is MISSING must say so.
+    ///
+    /// This reproduces the CI failure's shape deliberately: the outer error is
+    /// `Could not acquire lock`, but nothing holds the lock — the parent is gone.
+    /// Three rounds of retry-widening were spent while that read as contention, so
+    /// the message now has to distinguish them, and it has to name the nearest
+    /// ancestor that does exist (a missing grandparent implicates a different
+    /// culprit than a missing admin dir).
+    #[test]
+    fn a_missing_parent_directory_is_reported_as_such_not_as_contention() {
+        let (_tmp, main) = init_repo();
+        let repo = gix::open(&main).expect("open repo");
+        let tree = repo
+            .head_commit()
+            .expect("head commit")
+            .tree_id()
+            .expect("tree id")
+            .detach();
+        let mut index = repo.index_from_tree(&tree).expect("index from tree");
+
+        // Two levels of missing directory, so the "nearest existing ancestor"
+        // report has something non-trivial to find.
+        let missing = main.join(".git").join("gone").join("deeper");
+        index.set_path(missing.join("index"));
+
+        let err = super::write_index_with_lock_retry(&mut index)
+            .expect_err("writing into a missing directory must fail");
+        let msg = err.to_string();
+        // Failed fast — this is deterministic, not contention.
+        assert!(
+            msg.contains("1 attempt(s)"),
+            "a missing directory must not burn the retry budget: {msg}"
+        );
+        assert!(
+            msg.contains("nearest existing ancestor"),
+            "must report the directory state, not just the lock error: {msg}"
+        );
+        assert!(
+            msg.contains(".git"),
+            "the nearest existing ancestor should be named: {msg}"
         );
     }
 


### PR DESCRIPTION
The recurring worktree-`add` CI failure is **not lock contention**, and hasn't been. This makes the next occurrence answer the question instead of prompting a fourth guess.

## What the last failure actually said

`list_from_linked_worktree_still_shows_main_first` failed on #218's CI. Thanks to the source-chain reporting added in the previous round, the error was legible for the first time:

```
write index (1 attempt(s)): Could not acquire lock for index file
  -> Another IO error occurred while obtaining the lock
  -> No such file or directory (os error 2)
     at ".../repo/.git/worktrees/feature/index.lock"
```

Two facts overturn the standing diagnosis:

1. **The root cause is ENOENT.** Nobody holds the lock — the lock file's *parent directory* is missing when gix tries to create it. `AcquireLock` collapses `PermanentlyLocked` (real contention) and `Io` (couldn't create the file at all), and only the outer `Display` made them look alike. So #117's retry, #118's mutex and #138's 5→10 widening were all aimed at the wrong thing.
2. **`1 attempt(s)` is correct, not a regression.** `lock_contention_is_transient` deliberately fails fast on deterministic IO kinds so the real fault surfaces rather than burning ~1.8s and then being misreported. That guard is what exposed this.

**This is why the retry must not be widened again.** It would be pure waste.

## The remaining puzzle

`materialize_worktree` calls `create_dir_all(admin_dir)` *before* `checkout_and_write`, and the only thing between them is a checkout into a disjoint directory. Each test owns its own tempdir, so cross-test deletion by path is impossible. Not reproducible locally (3× at `--test-threads 16`, clean) — consistent with every prior round.

So the open question is narrow and factual: **did the directory never get created, did it vanish, or did an ancestor vanish?** Those implicate completely different culprits, and the current message can't tell them apart.

## This change

On a terminal write failure, the message now describes the lock directory's state:

- present and non-empty → says nothing (the boring case needs no words)
- present but empty → says so
- unreadable/missing → reports the error **and walks ancestors to name the nearest one that does exist**

That last part is the point: a missing grandparent (a tempdir cleaned early) and a missing admin dir (something deleted it between create and write) are different bugs, and the boundary identifies which.

## Tests

- `a_missing_parent_directory_is_reported_as_such_not_as_contention` — reproduces the CI failure's exact shape (outer error says "could not acquire lock", nothing holds it, parent gone) and asserts it fails on **1 attempt** with the ancestor note. This is the first test covering the ENOENT path at all.
- Extended `write_index_gives_up_on_a_stuck_lock_instead_of_hanging` to assert the parent note is **absent** for genuine contention — otherwise the note becomes noise on the common failure, and the two remain indistinguishable.

No behaviour change: same retry policy, same classifier, same give-up contract. Diagnostics only.

`make check` green, 1684 tests.

Generated with [Claude Code](https://claude.com/claude-code)
