### PR TITLE
fix(version): name the exact build everywhere a version is shown

### DIFF
--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -271,7 +271,7 @@ fn why_git_lines(app: &App) -> Vec<String> {
     let mut out = vec![
         format!(
             "spyc {} (pid {}) — git dump @ {}",
-            env!("CARGO_PKG_VERSION"),
+            crate::VERSION,
             std::process::id(),
             crate::sysinfo::format_now(),
         ),
@@ -521,7 +521,7 @@ fn activity_dump_lines(app: &App) -> Vec<String> {
     let now = std::time::Instant::now();
     let mut out = vec![format!(
         "spyc {} (pid {}) — activity dump @ {}",
-        env!("CARGO_PKG_VERSION"),
+        crate::VERSION,
         std::process::id(),
         crate::sysinfo::format_now(),
     )];
@@ -629,7 +629,7 @@ fn agent_registry_lines(app: &App) -> Vec<String> {
     let now = crate::sysinfo::epoch_secs();
     let mut out = vec![format!(
         "spyc {} (pid {}) — scope registry @ {}",
-        env!("CARGO_PKG_VERSION"),
+        crate::VERSION,
         std::process::id(),
         crate::sysinfo::format_now(),
     )];
@@ -675,7 +675,7 @@ fn agent_list_lines(app: &App) -> Vec<String> {
     };
     let mut out = vec![format!(
         "spyc {} — agents @ {}",
-        env!("CARGO_PKG_VERSION"),
+        crate::VERSION,
         crate::sysinfo::format_now(),
     )];
     let Some(tabs) = app.runtime.pane_tabs.as_ref() else {

--- a/src/app/render/overlays.rs
+++ b/src/app/render/overlays.rs
@@ -355,9 +355,8 @@ impl App {
         let term = &self.view.hud_term;
         let truecolor = self.view.hud_truecolor;
         let l4 = format!(
-            " spyc v{} ({})  {term}{}  {}\u{00d7}{} ",
-            env!("CARGO_PKG_VERSION"),
-            env!("SPYC_GIT_SHA"),
+            " spyc v{}  {term}{}  {}\u{00d7}{} ",
+            crate::VERSION,
             if truecolor { " truecolor" } else { "" },
             frame_area.width,
             frame_area.height,

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -591,10 +591,7 @@ impl App {
 
     pub fn show_session_info(&mut self) {
         let mut lines: Vec<String> = Vec::new();
-        lines.push(format!(
-            "\u{1f336}\u{fe0f} spyc {}",
-            env!("CARGO_PKG_VERSION")
-        ));
+        lines.push(format!("\u{1f336}\u{fe0f} spyc {}", crate::VERSION));
         lines.push(format!("session  : {}", self.state.session_display()));
         lines.push(format!("project  : {}", self.state.project_home_display()));
         lines.push(format!("user@host: {}", self.state.user_host));

--- a/src/app/state/apply.rs
+++ b/src/app/state/apply.rs
@@ -445,10 +445,7 @@ impl AppState {
             // -- Info --
             Action::Date => self.flash_info(crate::sysinfo::format_now()),
             Action::Version => {
-                self.flash_info(format!(
-                    "\u{1f336}\u{fe0f} spyc {}",
-                    env!("CARGO_PKG_VERSION")
-                ));
+                self.flash_info(format!("\u{1f336}\u{fe0f} spyc {}", crate::VERSION));
             }
             Action::SetEnvPrompt => {
                 self.mode =

--- a/src/app/state/dispatch.rs
+++ b/src/app/state/dispatch.rs
@@ -165,10 +165,7 @@ impl AppState {
 
         // :version
         if input == "version" {
-            self.flash_info(format!(
-                "\u{1f336}\u{fe0f} spyc {}",
-                env!("CARGO_PKG_VERSION")
-            ));
+            self.flash_info(format!("\u{1f336}\u{fe0f} spyc {}", crate::VERSION));
             return CommandResult::Handled;
         }
 


### PR DESCRIPTION
`:version` printed `spyc 2.1.0-CURRENT` with no SHA, while `--version` and the `A` overlay both showed `2.1.0-CURRENT (6515ac3)`.

On the `-CURRENT` stream that gap matters more than it looks: the bare version is **static for a whole minor**, so it cannot distinguish one build from another. The SHA is the only thing that can.

It matters most on the four **diagnostic dumps**, which exist to be pasted into a bug report — `:activity dump`, `:why-git`, `:agent list`, `:agent registry`. Their header named a version consistent with any of a hundred builds. That's how this came up: pasting `:activity` output to identify a build, and the output couldn't identify it.

## Change

All seven display sites now use `crate::VERSION`, AGENTS.md's documented source of build identity:

| site | was |
|---|---|
| `:version` | bare version |
| `Action::Version` | bare version — **a separate path printing the same string** |
| `Space s` session info | bare version |
| `:activity dump` header | bare version |
| `:why-git` header | bare version |
| `:agent list` header | bare version |
| `:agent registry` header | bare version |

`:version` and `Action::Version` being two independent code paths for one string is its own small smell, and exactly how they came to differ from `--version` in the first place.

The `A` overlay also stops re-composing `CARGO_PKG_VERSION` + `SPYC_GIT_SHA` by hand and uses the constant instead — **rendered text unchanged**, one less place to drift.

## Deliberately unchanged

- `--version --verbose` — already prints `git:` on its own line; adding the SHA inline would duplicate it.
- The skill manifest and session-file `version` fields — those are **persisted data**, not display. A SHA there would change a file format and a staleness fingerprint.

`make check` green, 1689 tests.

Generated with [Claude Code](https://claude.com/claude-code)