### PR TITLE
feat(mouse): forward drags, so a child's own text selection works

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -205,13 +205,25 @@ arrow keys (which a focused pane receives as history navigation).
 
 | Button | Action |
 |---|---|
-| **Left** | Focus the region under the pointer. Over a mouse-aware child (claude, vim, htop) the click also reaches it — the pane is live, so swallowing the first click just to focus would read as broken. |
+| **Left** | Focus the region under the pointer. Over a mouse-aware child (claude, vim, htop) the click also reaches it — the pane is live, so swallowing the first click just to focus would read as broken. **Dragging** is forwarded too, so the child's own text selection works. |
 | **Middle** | Paste the system clipboard wherever a paste would land (pane, `:` line, shell prompt). |
 | **Right** | Open the leader menu, from any region, with no chord-hint delay. |
 
 Middle and right are **always spyc's** — never forwarded, even over a mouse-aware
 child, since otherwise the gesture would be unavailable in exactly the region where
 the pane holds focus. If you need a child's own right-click menu, `:mouse off`.
+
+### Selecting text
+
+Capture takes the terminal's own click-drag selection away. Where that leaves you:
+
+| | |
+|---|---|
+| **Inside a mouse-aware child** (claude, vim, htop) | Drag normally — the drag is forwarded, so the child's own selection works. |
+| **Anywhere else** (plain shell pane, pager, file list) | Hold **Shift** (Option/Fn on iTerm2) to hand the drag to your terminal, or `:mouse off`. |
+| **Copying a diagnostic** | `:activity dump`, `:grep`, `:why-git` etc. open a pager — **`y`** yanks the source to the clipboard, **`Y`** the visible text. No mouse needed. |
+
+spyc-owned selection for the surfaces it draws itself is planned, not built.
 
 Clicking a *row* in the file list is deliberately not a thing: clicking a region is
 coarse and hard to get wrong, while aiming at a one-cell-tall line invites

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -311,6 +311,21 @@ impl super::App {
             return self.forward_release(ev, button, frame);
         }
 
+        // A drag belongs to whoever received the press, for the same reason a
+        // release does: it is the middle of one gesture, not a new decision. So it
+        // rides the same `mouse_press_forwarded` pairing — which also means a drag
+        // that began on the file list never leaks into the child, and a drag that
+        // began in the child keeps reaching it after the pointer leaves the pane
+        // (children track their own selection across the whole drag).
+        //
+        // spyc-side selection for a NON-mouse child is deliberately not here: this
+        // change only stops throwing drags away, so a child that speaks mouse gets
+        // its own selection back (claude's `onSelectionDrag` was dead solely
+        // because these events were dropped). See `docs/drafts/mouse_selection_plan.md`.
+        if matches!(ev.kind, MouseEventKind::Drag(_)) {
+            return self.forward_drag(ev, frame);
+        }
+
         let lines = self.state.config.mouse.scroll_lines.max(1);
         // `delta` is only meaningful for a wheel gesture; buttons ignore it.
         let (gesture, delta): (Gesture, i32) = match ev.kind {
@@ -445,6 +460,19 @@ impl super::App {
         }]
     }
 
+    /// Deliver a drag to the child that received the press, if any.
+    ///
+    /// Unlike a release this does NOT consume the pairing flag — a drag is the
+    /// middle of the gesture and more will follow, so the flag has to survive
+    /// until the release actually arrives.
+    fn forward_drag(&mut self, ev: MouseEvent, frame: ratatui::layout::Rect) -> Vec<Effect> {
+        if !self.view.mouse_press_forwarded {
+            return Vec::new();
+        }
+        let layout = self.frame_layout(frame);
+        self.forward_to_child(ev, &layout)
+    }
+
     /// Deliver a button release to the child that received the press.
     ///
     /// Keyed on the press having been forwarded rather than on where the pointer
@@ -514,24 +542,27 @@ fn mouse_report(
     use crossterm::event::KeyModifiers as K;
     use crossterm::event::MouseButton as B;
 
-    // xterm button encoding: 0/1/2 = left/middle/right, 64/65 = wheel up/down.
-    let (button, release) = match ev.kind {
-        MouseEventKind::ScrollUp => (64, false),
-        MouseEventKind::ScrollDown => (65, false),
-        MouseEventKind::Down(B::Left) => (0, false),
-        MouseEventKind::Down(B::Middle) => (1, false),
-        MouseEventKind::Down(B::Right) => (2, false),
-        MouseEventKind::Up(B::Left) => (0, true),
-        MouseEventKind::Up(B::Middle) => (1, true),
-        MouseEventKind::Up(B::Right) => (2, true),
-        // Not forwarded. Motion (`Drag`/`Moved`) shouldn't arrive at all — spyc
-        // requests only 1000 — and horizontal wheel has no spyc behaviour. Listed
-        // exhaustively so a new `MouseEventKind` is a compile error here rather
-        // than a silent no-op.
-        MouseEventKind::Drag(_)
-        | MouseEventKind::Moved
-        | MouseEventKind::ScrollLeft
-        | MouseEventKind::ScrollRight => return None,
+    // xterm button encoding: 0/1/2 = left/middle/right, 64/65 = wheel up/down;
+    // a drag is the held button with the motion bit set (added by `encode_mouse`).
+    let (button, release, motion) = match ev.kind {
+        MouseEventKind::ScrollUp => (64, false, false),
+        MouseEventKind::ScrollDown => (65, false, false),
+        MouseEventKind::Down(B::Left) => (0, false, false),
+        MouseEventKind::Down(B::Middle) => (1, false, false),
+        MouseEventKind::Down(B::Right) => (2, false, false),
+        MouseEventKind::Up(B::Left) => (0, true, false),
+        MouseEventKind::Up(B::Middle) => (1, true, false),
+        MouseEventKind::Up(B::Right) => (2, true, false),
+        MouseEventKind::Drag(B::Left) => (0, false, true),
+        MouseEventKind::Drag(B::Middle) => (1, false, true),
+        MouseEventKind::Drag(B::Right) => (2, false, true),
+        // Not forwarded. `Moved` is buttonless motion, which spyc never asks for
+        // (1002 reports only while a button is held) and `proc.rs` filters;
+        // horizontal wheel has no spyc behaviour. Listed exhaustively so a new
+        // `MouseEventKind` is a compile error here rather than a silent no-op.
+        MouseEventKind::Moved | MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
+            return None;
+        }
     };
 
     let origin = layout
@@ -540,6 +571,7 @@ fn mouse_report(
     Some(crate::pane::input::MouseReport {
         button,
         release,
+        motion,
         col: ev.column.saturating_sub(origin.x),
         row: ev.row.saturating_sub(origin.y),
         shift: ev.modifiers.contains(K::SHIFT),
@@ -969,20 +1001,25 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         };
 
-        // xterm: 0/1/2 = left/middle/right; 64/65 = wheel up/down.
-        for (kind, button, release) in [
-            (MouseEventKind::Down(MouseButton::Left), 0, false),
-            (MouseEventKind::Down(MouseButton::Middle), 1, false),
-            (MouseEventKind::Down(MouseButton::Right), 2, false),
-            (MouseEventKind::Up(MouseButton::Left), 0, true),
-            (MouseEventKind::Up(MouseButton::Middle), 1, true),
-            (MouseEventKind::Up(MouseButton::Right), 2, true),
-            (MouseEventKind::ScrollUp, 64, false),
-            (MouseEventKind::ScrollDown, 65, false),
+        // xterm: 0/1/2 = left/middle/right; 64/65 = wheel up/down. A drag is the
+        // held button with the motion flag — `encode_mouse` turns that into bit 32.
+        for (kind, button, release, motion) in [
+            (MouseEventKind::Down(MouseButton::Left), 0, false, false),
+            (MouseEventKind::Down(MouseButton::Middle), 1, false, false),
+            (MouseEventKind::Down(MouseButton::Right), 2, false, false),
+            (MouseEventKind::Up(MouseButton::Left), 0, true, false),
+            (MouseEventKind::Up(MouseButton::Middle), 1, true, false),
+            (MouseEventKind::Up(MouseButton::Right), 2, true, false),
+            (MouseEventKind::Drag(MouseButton::Left), 0, false, true),
+            (MouseEventKind::Drag(MouseButton::Middle), 1, false, true),
+            (MouseEventKind::Drag(MouseButton::Right), 2, false, true),
+            (MouseEventKind::ScrollUp, 64, false, false),
+            (MouseEventKind::ScrollDown, 65, false, false),
         ] {
             let r = super::mouse_report(at(kind), &layout).expect("forwardable");
             assert_eq!(r.button, button, "{kind:?} must encode button {button}");
             assert_eq!(r.release, release, "{kind:?} release flag");
+            assert_eq!(r.motion, motion, "{kind:?} motion flag");
             // The wheel bit must not leak onto a real button, and vice versa.
             assert_eq!(
                 r.button & 64 != 0,
@@ -991,10 +1028,11 @@ mod tests {
             );
         }
 
-        // Motion and horizontal wheel are not forwarded at all.
+        // Buttonless motion and horizontal wheel are not forwarded at all.
+        // `Moved` in particular: spyc asks for 1002, which reports motion only
+        // while a button is held, so a `Moved` is motion nobody requested.
         for kind in [
             MouseEventKind::Moved,
-            MouseEventKind::Drag(MouseButton::Left),
             MouseEventKind::ScrollLeft,
             MouseEventKind::ScrollRight,
         ] {

--- a/src/app/proc.rs
+++ b/src/app/proc.rs
@@ -101,18 +101,20 @@ pub(super) fn spawn_input_reader(tx: std::sync::mpsc::Sender<Message>) -> Reader
                                         k.kind == KeyEventKind::Press
                                             || k.kind == KeyEventKind::Repeat
                                     }
-                                    // Motion reporting is never requested (spyc
-                                    // emits 1000+1006, not 1002/1003), but a few
-                                    // terminals report it anyway. Drop it here:
-                                    // `run.rs` marks a redraw for every
-                                    // `Message::Input` and `coalesce_pending`
-                                    // surfaces one per loop iteration, so idle
-                                    // pointer movement would otherwise become a
-                                    // redraw-per-motion storm.
-                                    Event::Mouse(m) => !matches!(
-                                        m.kind,
-                                        MouseEventKind::Moved | MouseEventKind::Drag(_)
-                                    ),
+                                    // `Drag` is forwarded: spyc asks for 1002
+                                    // (button-event tracking), so a drag is a
+                                    // deliberate gesture and its redraw is wanted.
+                                    //
+                                    // `Moved` is still dropped. 1002 reports motion
+                                    // only while a button is HELD, so a buttonless
+                                    // `Moved` means the terminal reported motion
+                                    // spyc never asked for — and `run.rs` marks a
+                                    // redraw for every `Message::Input`, so idle
+                                    // pointer movement would become a
+                                    // redraw-per-motion storm. That is the 1003
+                                    // hazard arriving by accident, and this is the
+                                    // belt to 1002's braces.
+                                    Event::Mouse(m) => !matches!(m.kind, MouseEventKind::Moved),
                                     _ => true,
                                 };
                                 if forward && tx.send(Message::Input(ev)).is_err() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,18 +470,22 @@ impl crossterm::Command for DisableAlternateScroll {
     }
 }
 
-/// DEC private modes 1000 (button press/release) + 1006 (SGR extended
-/// coordinates) — real mouse reporting, so spyc gets `ScrollUp`/`ScrollDown` and
-/// button events *with coordinates* instead of 1007's coordinate-free arrow keys.
+/// DEC private modes 1000 (button press/release), 1002 (button-event tracking)
+/// and 1006 (SGR extended coordinates) — real mouse reporting, so spyc gets
+/// `ScrollUp`/`ScrollDown`, button and drag events *with coordinates* instead of
+/// 1007's coordinate-free arrow keys.
 ///
-/// Deliberately NOT 1002/1003 (drag / any-motion reporting), which is what
-/// `crossterm::event::EnableMouseCapture` emits. `run.rs` marks a redraw for every
-/// `Message::Input` and `coalesce_pending` surfaces input one event per loop
-/// iteration, so motion reporting would turn idle pointer movement into a
-/// redraw-per-motion storm — straight through the 0-dps-at-idle invariant.
+/// **1002 yes, 1003 emphatically no**, and the difference is the whole reason
+/// drags are affordable. 1002 reports motion only while a button is HELD; 1003
+/// (any-event) reports every pointer move. `run.rs` marks a redraw for every
+/// `Message::Input` and `coalesce_pending` surfaces one per loop iteration, so
+/// 1003 turns idle pointer movement into a redraw-per-motion storm — straight
+/// through the 0-dps-at-idle invariant. Under 1002 an untouched mouse generates
+/// nothing at all, and the redraws during a drag are the ones a drag needs.
+/// `crossterm::event::EnableMouseCapture` emits 1003, which is why spyc doesn't
+/// use it (guarded by `production_code_never_uses_crossterms_mouse_capture`).
 ///
-/// 1000h alone already reports the wheel (buttons 64/65) and clicks; 1006h keeps
-/// coordinates correct past column 223. Mutually exclusive with
+/// 1006h keeps coordinates correct past column 223. Mutually exclusive with
 /// [`EnableAlternateScroll`]: a terminal honoring both could deliver one tick
 /// twice (once as arrows, once as a mouse event), so the two are always toggled
 /// as a pair.
@@ -490,7 +494,7 @@ struct DisableWheelReporting;
 
 impl crossterm::Command for EnableWheelReporting {
     fn write_ansi(&self, f: &mut impl std::fmt::Write) -> std::fmt::Result {
-        f.write_str("\x1b[?1000h\x1b[?1006h")
+        f.write_str("\x1b[?1000h\x1b[?1002h\x1b[?1006h")
     }
     #[cfg(windows)]
     fn execute_winapi(&self) -> std::io::Result<()> {
@@ -851,17 +855,26 @@ mod mouse_reporting_tests {
     /// pointer move, straight through the 0-dps-at-idle invariant — and you'd only
     /// notice by waving the mouse while watching the `A` overlay. `crossterm`'s own
     /// `EnableMouseCapture` emits it, which is exactly why spyc doesn't use that.
+    ///
+    /// **1002 is requested and 1003 is not**, which is not a fine distinction: 1002
+    /// reports motion only while a button is held, so an untouched mouse generates
+    /// nothing and the invariant is untouched. Asserting only "no motion modes"
+    /// would have made drag support impossible to add without deleting the guard
+    /// that matters.
     #[test]
-    fn enable_asks_for_buttons_and_sgr_but_never_motion_reporting() {
+    fn enable_asks_for_buttons_drags_and_sgr_but_never_any_event_motion() {
         let seq = ansi(&EnableWheelReporting);
         assert!(seq.contains("\x1b[?1000h"), "button reporting: {seq:?}");
+        assert!(
+            seq.contains("\x1b[?1002h"),
+            "button-event tracking, for drags: {seq:?}"
+        );
         assert!(seq.contains("\x1b[?1006h"), "SGR coordinates: {seq:?}");
-        for motion in ["1002", "1003"] {
-            assert!(
-                !seq.contains(motion),
-                "must not request motion reporting (?{motion}h): {seq:?}"
-            );
-        }
+        assert!(
+            !seq.contains("1003"),
+            "must never request ANY-EVENT motion (?1003h) — that is the idle \
+             redraw storm: {seq:?}"
+        );
     }
 
     /// A leaked `?1000h` silently breaks click-drag selection in the user's shell
@@ -939,19 +952,28 @@ mod mouse_reporting_tests {
         );
     }
 
-    /// Neither direction may request motion reporting — the `?1003h` redraw storm
+    /// Neither direction may request ANY-EVENT motion — the `?1003h` redraw storm
     /// is invisible on a still pointer, so only a byte assertion catches it.
+    ///
+    /// `?1002h` (motion only while a button is held) is expected when enabling and
+    /// absent when disabling.
     #[test]
-    fn neither_direction_requests_motion_reporting() {
+    fn neither_direction_requests_any_event_motion() {
         for capture in [true, false] {
             let seq = super::mouse_mode_seq(capture);
-            for motion in ["1002h", "1003h"] {
-                assert!(
-                    !seq.contains(motion),
-                    "capture={capture} must not request ?{motion}: {seq:?}"
-                );
-            }
+            assert!(
+                !seq.contains("1003h"),
+                "capture={capture} must not request ?1003h: {seq:?}"
+            );
         }
+        assert!(
+            super::mouse_mode_seq(true).contains("1002h"),
+            "enabling capture must ask for drags"
+        );
+        assert!(
+            !super::mouse_mode_seq(false).contains("1002h"),
+            "disabling capture must not enable anything"
+        );
     }
 
     /// Source-scan guard: nothing in `src/` may use crossterm's own

--- a/src/pane/input.rs
+++ b/src/pane/input.rs
@@ -171,6 +171,12 @@ pub struct MouseReport {
     /// True for a button release. Wheel events are always presses — a wheel
     /// "release" isn't a thing, and emitting one confuses apps that count clicks.
     pub release: bool,
+    /// True for a drag: the pointer moved to a new cell while a button was held.
+    ///
+    /// Sets xterm's motion bit (32) in `Cb`. Only meaningful for a child that
+    /// asked for motion — [`encode_mouse`] drops it otherwise, since DEC 1000
+    /// reports press/release and no motion at all.
+    pub motion: bool,
     /// **Pane-relative**, 0-based. The child believes it owns a grid starting at
     /// its own `0,0`; passing frame-absolute coordinates here is the bug that
     /// makes clicks land N rows off and read as the child's fault.
@@ -197,16 +203,24 @@ pub fn encode_mouse(
     encoding: vt100::MouseProtocolEncoding,
 ) -> Vec<u8> {
     use vt100::MouseProtocolMode as M;
-    // `Press` (X10) reports presses only — a release would be noise it has no
-    // grammar for. Every other active mode reports both.
+    // Send only what the child's declared mode covers. `Press` (X10) reports
+    // presses only — a release is noise it has no grammar for. And **only
+    // ButtonMotion (1002) / AnyMotion (1003) report motion at all**: DEC 1000
+    // is press+release, so handing a drag to a `PressRelease` child is the same
+    // class of fault as forwarding to a child that asked for nothing.
     match mode {
         M::None => return Vec::new(),
         M::Press if ev.release => return Vec::new(),
+        M::Press | M::PressRelease if ev.motion => return Vec::new(),
         _ => {}
     }
 
     // xterm's Cb: button in the low bits, modifiers above it.
     let mut cb = u32::from(ev.button);
+    if ev.motion {
+        // Bit 5 marks "this is motion, not a fresh press".
+        cb |= 32;
+    }
     if ev.shift {
         cb |= 4;
     }
@@ -265,11 +279,93 @@ mod mouse_tests {
         MouseReport {
             button: 64,
             release: false,
+            motion: false,
             col: 0,
             row: 0,
             shift: false,
             alt: false,
             ctrl: false,
+        }
+    }
+
+    /// A left-drag at pane-relative (4,2): the held button plus the motion bit.
+    const fn left_drag() -> MouseReport {
+        MouseReport {
+            button: 0,
+            release: false,
+            motion: true,
+            col: 4,
+            row: 2,
+            shift: false,
+            alt: false,
+            ctrl: false,
+        }
+    }
+
+    /// **A drag only goes to a child that asked for motion.**
+    ///
+    /// DEC 1000 (`PressRelease`) reports press and release and *no motion at all*,
+    /// so handing it a drag is the same class of fault as forwarding to a child
+    /// that enabled nothing — bytes it has no grammar for. Only 1002
+    /// (`ButtonMotion`) and 1003 (`AnyMotion`) report motion.
+    ///
+    /// This is the one rule that makes drag-forwarding safe to turn on globally:
+    /// spyc now receives drags for every pane, and most children want none of them.
+    #[test]
+    fn a_drag_reaches_only_a_child_that_asked_for_motion() {
+        for mode in [Mode::None, Mode::Press, Mode::PressRelease] {
+            assert!(
+                encode_mouse(left_drag(), mode, Enc::Sgr).is_empty(),
+                "{mode:?} does not report motion — a drag must not be sent"
+            );
+        }
+        for mode in [Mode::ButtonMotion, Mode::AnyMotion] {
+            assert!(
+                !encode_mouse(left_drag(), mode, Enc::Sgr).is_empty(),
+                "{mode:?} reports motion — a drag must be sent"
+            );
+        }
+    }
+
+    /// A drag sets xterm's motion bit (32) on top of the held button, and keeps
+    /// the press final byte — it is motion, not a release.
+    #[test]
+    fn drag_sets_the_motion_bit_on_the_held_button() {
+        let out = encode_mouse(left_drag(), Mode::ButtonMotion, Enc::Sgr);
+        // button 0 | 32 = 32; coords 1-based → (5,3); `M` because it is not a release.
+        assert_eq!(
+            out,
+            b"\x1b[<32;5;3M".to_vec(),
+            "got {:?}",
+            String::from_utf8_lossy(&out)
+        );
+
+        // Middle and right carry their own button under the same bit.
+        for (button, cb) in [(1u8, 33), (2u8, 34)] {
+            let r = super::MouseReport {
+                button,
+                ..left_drag()
+            };
+            let out = encode_mouse(r, Mode::ButtonMotion, Enc::Sgr);
+            let expected = format!("\x1b[<{cb};5;3M").into_bytes();
+            assert_eq!(out, expected, "button {button} drag");
+        }
+    }
+
+    /// The legacy encodings mark a release with button 3, and that must not
+    /// swallow the motion bit — a drag is neither a fresh press nor a release, and
+    /// conflating it with either is how a child ends up thinking a button is stuck.
+    #[test]
+    fn drag_survives_the_legacy_encodings_release_trick() {
+        for enc in [Enc::Default, Enc::Utf8] {
+            let out = encode_mouse(left_drag(), Mode::ButtonMotion, enc);
+            assert!(!out.is_empty(), "{enc:?}: drag must encode");
+            // `ESC [ M` then Cb+32 = 32+32 = 64 = b'@'.
+            assert_eq!(&out[..3], b"\x1b[M", "{enc:?}: legacy prefix");
+            assert_eq!(
+                out[3], b'@',
+                "{enc:?}: Cb must be 32 (motion|button 0) + 32"
+            );
         }
     }
 


### PR DESCRIPTION
PR 2 of `docs/drafts/mouse_selection_plan.md` (#223), landed first on purpose — see the re-judge note at the bottom.

claude, vim and htop all implement text selection on drag. **None of it worked inside a spyc pane**, for one reason: spyc never asked the terminal for drags, and `proc.rs` dropped the ones that arrived anyway. claude's `onSelectionDrag` and `onHoverAt` have been sitting there dead.

## 1002, not 1003 — the whole bet

Enables DEC **1002** (button-event tracking) alongside 1000/1006. 1002 reports motion **only while a button is held**, which is the entire reason this is affordable:

|  | idle pointer movement | during a drag |
|---|---|---|
| **1003** (any-event) | event per cell → redraw per cell | same |
| **1002** (button-held) | **nothing** | event per cell — which a drag *wants* |

`run.rs` marks a redraw for every `Message::Input`, so 1003 is the storm this campaign has spent months avoiding. Under 1002 an untouched mouse generates nothing, so **0-dps-at-idle is untouched**.

`Moved` stays filtered: with 1002 it should never arrive, so one that does is motion nobody asked for — precisely the case that filter was written for. And #218 already made the disable clear 1002/1003, so teardown needed no change.

## Pairing

A drag routes like a release — to whoever received the **press**, keyed on `view.mouse_press_forwarded`. Two consequences that fall out for free:

- a drag begun on the file list never leaks into the child
- a drag begun in the child keeps reaching it **after the pointer leaves the pane**, which is required, because children track selection across the whole gesture

Unlike a release it does *not* consume the flag, since more drags follow.

## The rule that makes this safe globally

**A drag reaches only a child that asked for motion.**

DEC 1000 is press+release and reports no motion at all. So `encode_mouse` now drops a motion report for `None` / `Press` / `PressRelease` — handing a 1000-mode child a drag is the same fault class as forwarding to a child that enabled nothing (#170's shape). This matters because spyc now receives drags for **every** pane, and most children want none of them.

## Encoding

`MouseReport` gains `motion`, setting xterm's bit 5 (32) on the held button. Verified byte-exact rather than by reasoning:

```
left-drag at pane (4,2)  →  ESC [ < 32 ; 5 ; 3 M
```

`M`, not `m` — a drag is neither a fresh press nor a release. Also covered in the legacy encodings, whose button-3 release trick must not swallow the motion bit.

## Two tests deliberately inverted

`enable_asks_for_buttons_and_sgr_but_never_motion_reporting` asserted **no** 1002, and `every_button_encodes…` asserted `Drag` was **never** forwarded. Both were mine, from #213/#219, and both are now wrong.

Worth noting how they were rewritten: the 1003 assertions **stay**, but are now specific to 1003 instead of "any motion mode". The old wording would have forced deleting the guard that actually matters in order to add drags — so the replacement is narrower *and* stronger.

## Not included, and worth re-judging

spyc-owned selection for the surfaces spyc draws itself — a plain shell pane, the pager, the file list. That's PRs 3–4 of the plan.

**Please judge those against how much this alone covers.** If dragging inside claude now feels right, the residual gap is only non-mouse children and the pager, and the priority should come from use rather than from the plan. Docs say plainly that Shift-drag and the pager's `y`/`Y` are the paths for everything else.

## Manual check that no test can do

Capture on, **idle**, move the pointer with no button held → the `A` overlay must show **0 dps**. That is the 1002-vs-1003 bet, and it is invisible to every automated test here.

`make check` green, 1692 tests.

Generated with [Claude Code](https://claude.com/claude-code)