### PR TITLE
fix(mouse): scroll the agents that ignore mouse reports, per verified keybinding

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -548,6 +548,12 @@ end).
   reload (`:mouse auto` returns to following the config). Default off (`[mouse]
   capture`). `^a u` quick-select and `y` in the pager are the mouse-free yank
   paths.
+  Over an agent pane the wheel does whatever that agent can actually receive:
+  **claude** requests mouse reporting, so the event is forwarded and claude
+  scrolls itself; **agy** ignores mouse reports but scrolls on Shift+Arrow, so
+  spyc sends those instead; **codex** discards mouse events *and* has no
+  main-view scroll (its transcript is behind its own `^T`), so the wheel does
+  nothing there — use `^a v` for spyc's transcript view.
 - **`:limit <glob>`** — temporary filter (e.g. `:limit *.rs`)
 - **`:limit !`** — show only picked files
 - **`:limit git`** / **`:limit g`** — show only files in `git status`

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -203,6 +203,34 @@ pub trait AgentProfile: Sync {
     fn detection_rules(&self) -> &'static [DetectionRule] {
         &[]
     }
+
+    /// Which keypresses scroll this agent's own view, for an agent that does
+    /// **not** speak mouse.
+    ///
+    /// Consulted only when [`crate::pane::Pane::wants_mouse`] is false: an agent
+    /// that requested mouse reporting gets the wheel forwarded verbatim (claude),
+    /// which is always better than synthesizing keys. `None` means spyc has no
+    /// verified scroll key for this agent and the wheel does nothing over its
+    /// pane — deliberately, because the wrong key is worse than no key here. Up
+    /// in a composer usually recalls prompt history, which is the exact bug DEC
+    /// 1007's wheel-to-arrows translation caused and that `[mouse] capture` was
+    /// turned on to fix.
+    ///
+    /// Only fill this in for a binding **observed** to scroll, not one that looks
+    /// plausible from a keymap file — several of these agents bind the same key to
+    /// history recall in their input box.
+    fn wheel_scroll(&self) -> Option<WheelScroll> {
+        None
+    }
+}
+
+/// The keys that scroll a non-mouse agent's own view one line, sent by spyc in
+/// place of a wheel event it cannot forward. See
+/// [`AgentProfile::wheel_scroll`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WheelScroll {
+    pub up: (crossterm::event::KeyCode, crossterm::event::KeyModifiers),
+    pub down: (crossterm::event::KeyCode, crossterm::event::KeyModifiers),
 }
 
 /// Shared helper: pick the session whose start time is closest to the
@@ -476,6 +504,17 @@ impl AgentProfile for AgyProfile {
     fn detection_rules(&self) -> &'static [DetectionRule] {
         AGY_DETECTION_RULES
     }
+
+    /// Shift+Up / Shift+Down, verified by hand in agy's default `native terminal
+    /// (inline)` rendering mode. agy discards mouse reports, so the wheel has
+    /// nothing to forward to and these are the only scroll affordance it offers.
+    fn wheel_scroll(&self) -> Option<WheelScroll> {
+        use crossterm::event::{KeyCode, KeyModifiers as M};
+        Some(WheelScroll {
+            up: (KeyCode::Up, M::SHIFT),
+            down: (KeyCode::Down, M::SHIFT),
+        })
+    }
 }
 
 /// Strip zot's resume flags so a saved baseline restores cleanly:
@@ -594,6 +633,40 @@ pub fn detect(cmd: &str) -> &'static dyn AgentProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Which agents claim a wheel scroll key, and what it encodes to on the wire.
+    ///
+    /// Asserting the BYTES, not just the `KeyCode`: the whole failure mode here is
+    /// silent — a binding that encodes to something the agent ignores looks
+    /// identical to no binding at all from the outside, which is how this bug
+    /// reached a user in the first place.
+    #[test]
+    fn wheel_scroll_is_claimed_only_where_it_was_verified() {
+        // agy: ignores mouse reports, scrolls on Shift+Arrow in its default
+        // inline rendering mode. `\e[1;2A` / `\e[1;2B` are xterm Shift+Up/Down.
+        let agy = detect("agy")
+            .wheel_scroll()
+            .expect("agy scrolls on Shift+Arrow");
+        let enc = |(code, mods)| {
+            crate::pane::input::encode_key(crossterm::event::KeyEvent::new(code, mods))
+        };
+        assert_eq!(enc(agy.up), b"\x1b[1;2A");
+        assert_eq!(enc(agy.down), b"\x1b[1;2B");
+
+        // claude requests mouse reporting (?1000h/?1002h/?1003h + SGR), so the
+        // wheel is forwarded verbatim and a synthesized key would be strictly
+        // worse — it cannot carry coordinates.
+        assert!(detect("claude").wheel_scroll().is_none());
+
+        // codex discards mouse events outright (`map_crossterm_event` maps only
+        // Key/Resize/Paste/Focus) AND has no binding that scrolls its main view —
+        // scrolling lives behind its `^T` transcript overlay. So there is nothing
+        // correct to send, and `Up` would recall prompt history instead.
+        assert!(detect("codex").wheel_scroll().is_none());
+
+        // A plain process is not an agent: its scrollback belongs to spyc.
+        assert!(detect("bash -lc 'make'").wheel_scroll().is_none());
+    }
 
     #[test]
     fn detects_known_agents_and_other() {

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -63,6 +63,14 @@ pub(super) enum MouseSink {
     Pager(Mount),
     /// Encode and forward to the pane's child (which requested mouse reporting).
     PaneForward,
+    /// Send the child's own scroll keys, for an agent that doesn't speak mouse
+    /// but does scroll on a keypress ([`crate::agent::AgentProfile::wheel_scroll`]).
+    ///
+    /// Distinct from [`Self::PaneForward`] because the wheel is being *translated*
+    /// rather than delivered: only an agent with a hand-verified binding gets this,
+    /// so the translation can't degenerate into the wheel-to-arrows history
+    /// cycling that `[mouse] capture` exists to avoid.
+    PaneScrollKeys,
     /// Give the keyboard to the pane AND forward the event to its child — the
     /// left-click-through contract. Both halves, in one variant, because a sink
     /// that only forwarded was how the focus half came to be silently missing
@@ -116,6 +124,10 @@ pub(super) struct MouseSnapshot {
     pub has_scroll_pager: bool,
     /// The active tab's child has exited — there is nothing to forward to.
     pub pane_closed: bool,
+    /// The pane's agent has a verified scroll keybinding
+    /// ([`crate::agent::AgentProfile::wheel_scroll`]). Only consulted when the
+    /// child does NOT want mouse — forwarding a real mouse report always wins.
+    pub pane_scroll_keys: bool,
 }
 
 impl MouseSnapshot {
@@ -219,9 +231,16 @@ pub(super) const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseS
         Region::Pane => {
             if snap.can_forward_to_child() {
                 MouseSink::PaneForward
+            } else if snap.pane_scroll_keys && !snap.pane_closed && !snap.has_scroll_pager {
+                // The child ignores mouse reports but scrolls on a keypress
+                // (agy). Same two guards forwarding uses: a dead child has
+                // nothing to scroll, and a `^a v` pager owns the pane's rect, so
+                // keys would scroll a child the user can't see.
+                MouseSink::PaneScrollKeys
             } else {
-                // No spyc-owned pane scrollback in v1 (see the plan's Deferred
-                // section): silence beats typing `\e[<64;20;5M` at a shell.
+                // No verified scroll key and nothing to forward (codex): silence
+                // beats typing `\e[<64;20;5M` — or a history-recalling Up — into
+                // a child that never asked for either.
                 MouseSink::Swallow
             }
         }
@@ -378,6 +397,7 @@ impl super::App {
             is_prompting: matches!(self.state.mode, super::Mode::Prompting(_)),
             has_scroll_pager: self.view.scroll_pager.is_some(),
             pane_closed: self.state.pane.pane_snapshot.is_closed,
+            pane_scroll_keys: self.active_pane_wheel_scroll().is_some(),
         };
 
         match route_mouse(snap, gesture) {
@@ -424,7 +444,44 @@ impl super::App {
                 self.forward_to_child(ev, &layout)
             }
             MouseSink::PaneForward => self.forward_to_child(ev, &layout),
+            MouseSink::PaneScrollKeys => self.send_scroll_keys(delta),
         }
+    }
+
+    /// The active pane agent's verified scroll keybinding, if it has one.
+    fn active_pane_wheel_scroll(&self) -> Option<crate::agent::WheelScroll> {
+        let tabs = self.runtime.pane_tabs.as_ref()?;
+        crate::agent::detect(&tabs.active_info().command).wheel_scroll()
+    }
+
+    /// Translate a wheel tick into the child's own scroll keys, one press per
+    /// line, and send them as a single batch.
+    ///
+    /// One `SendToPane` rather than N: the executor writes to the pty once, so a
+    /// three-line tick can't interleave with the child's own output mid-burst.
+    fn send_scroll_keys(&self, delta: i32) -> Vec<Effect> {
+        let Some(scroll) = self.active_pane_wheel_scroll() else {
+            return Vec::new();
+        };
+        let (code, mods) = if delta < 0 { scroll.up } else { scroll.down };
+        let key = crossterm::event::KeyEvent::new(code, mods);
+        let per_press = crate::pane::input::encode_key(key);
+        if per_press.is_empty() {
+            return Vec::new();
+        }
+        let repeats = delta.unsigned_abs().max(1) as usize;
+        let mut bytes = Vec::with_capacity(per_press.len() * repeats);
+        for _ in 0..repeats {
+            bytes.extend_from_slice(&per_press);
+        }
+        vec![Effect::SendToPane {
+            target: super::effect::PaneTarget::Active,
+            input: super::effect::PaneInput::Bytes(bytes),
+            on_ok: None,
+            // Same reasoning as `forward_to_child`: no per-tick flash, or a dead
+            // pty buries its real exit message under one repeat per wheel line.
+            err_prefix: None,
+        }]
     }
 
     /// Encode `ev` in the child's own protocol and send it to the active pane.
@@ -599,6 +656,7 @@ mod tests {
             is_prompting: false,
             has_scroll_pager: false,
             pane_closed: false,
+            pane_scroll_keys: false,
         }
     }
 
@@ -644,10 +702,55 @@ mod tests {
     #[test]
     fn pane_child_without_mouse_mode_swallows_never_forwards() {
         // The #170 class: forwarding to a child that never enabled mouse mode
-        // types `\e[<64;20;5M` into its prompt. Silence is the correct v1 answer.
+        // types `\e[<64;20;5M` into its prompt. Silence is the correct answer for
+        // a child with no verified scroll key either (codex).
         let s = snap(Some(Region::Pane));
-        assert!(!s.pane_wants_mouse);
+        assert!(!s.pane_wants_mouse && !s.pane_scroll_keys);
         assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::Swallow);
+    }
+
+    /// An agent that ignores mouse reports but scrolls on a keypress (agy) gets
+    /// its keys instead of silence — the regression `[mouse] capture` introduced
+    /// by turning DEC 1007's wheel-to-arrows translation off.
+    #[test]
+    fn non_mouse_child_with_a_verified_scroll_key_gets_keys() {
+        let s = MouseSnapshot {
+            pane_scroll_keys: true,
+            ..snap(Some(Region::Pane))
+        };
+        assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::PaneScrollKeys);
+    }
+
+    /// Forwarding a real mouse report always beats synthesizing keys: a child that
+    /// speaks mouse gets exact coordinates, which keys cannot express.
+    #[test]
+    fn forwarding_wins_over_scroll_keys_when_the_child_speaks_mouse() {
+        let s = MouseSnapshot {
+            pane_wants_mouse: true,
+            pane_scroll_keys: true,
+            ..snap(Some(Region::Pane))
+        };
+        assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::PaneForward);
+    }
+
+    /// Same two guards forwarding uses. A dead child has nothing to scroll, and a
+    /// `^a v` pager owns the pane's rect — scrolling the child behind it would move
+    /// something the user cannot see.
+    #[test]
+    fn scroll_keys_are_suppressed_for_a_dead_or_covered_child() {
+        for (closed, covered) in [(true, false), (false, true)] {
+            let s = MouseSnapshot {
+                pane_scroll_keys: true,
+                pane_closed: closed,
+                has_scroll_pager: covered,
+                ..snap(Some(Region::Pane))
+            };
+            assert_eq!(
+                route_mouse(s, Gesture::Wheel),
+                MouseSink::Swallow,
+                "closed={closed} covered={covered}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Enabling `[mouse] capture` turns DEC 1007 off, so the terminal stops translating the wheel into arrow keys for the child. claude was unaffected — it requests mouse reporting, so spyc forwards the real event — but **agy and codex request no mouse reporting at all**, hit the deliberate `Swallow` in `route_mouse`, and lost wheel scrolling entirely. Reported from dog-fooding: "codex and agy scrolling are not working — only works for claude".

## Measured, not assumed

Captured each agent's init escape sequences in a pty. (The first attempt read only the "trust this folder?" gate, which made *claude* look like it wanted no mouse either — worth knowing if anyone re-runs this.)

| agent | mouse DECSETs | screen | verdict |
|---|---|---|---|
| claude | `?1000h ?1002h ?1003h ?1006h` | alt (`?1049h`) | forward — works today |
| agy | none | inline | scrolls on Shift+Arrow |
| codex | none | inline, DECSTBM region `1;8` | nothing to send |

## Design

The right behaviour differs per agent, so it goes on `AgentProfile` beside `detection_rules()` / `status_hooks()`: a new `wheel_scroll()` returning the keys that scroll that agent's own view. Consulted **only** when the child does not want mouse — a real mouse report always wins, because it carries coordinates a key cannot.

- **agy** → `Shift+Up` / `Shift+Down`, verified by hand in its default `native terminal (inline)` rendering mode.
- **codex** → deliberately `None`. Its `map_crossterm_event` ([`event_stream.rs:236`](https://github.com/openai/codex/blob/main/codex-rs/tui/src/tui/event_stream.rs)) maps only Key/Resize/Paste/Focus, so `Event::Mouse` is dropped outright; and no namespace in its keymap scrolls the main chat view — scrolling lives behind its `^T` transcript overlay. Sending `Up` would recall prompt history, which is the exact bug capture was turned on to fix, so silence stays correct.
- **plain shell** → unchanged; its scrollback belongs to spyc (still deferred, see `docs/drafts/native_scroll_plan.md`).

The new `PaneScrollKeys` sink reuses forwarding's two guards: a dead child has nothing to scroll, and a `^a v` pager owns the pane's rect, so keys would scroll a child the user can't see.

## Tests

Assert the encoded **bytes** for agy (`\e[1;2A` / `\e[1;2B`), not just the `KeyCode`. A binding that encodes to something the agent ignores is indistinguishable from no binding at all from the outside — which is how this reached a user. Plus routing tests for forward-beats-keys, and suppression when the child is dead or covered.

`make check` green.

## Testing this

Not auto-merging — behaviour change. Release binary built at `target/release/spyc` on this branch. To verify: `[mouse] capture = true`, then wheel over an **agy** pane (should scroll) and a **codex** pane (should still do nothing, by design), and confirm **claude** is unchanged.

## Follow-ups filed

- #225 — wheel direction is inverted in the file tree; wants a `natural_scroll` toggle.
- codex upstream: it discards mouse events and has no in-place scroll. Related: openai/codex#1064, openai/codex#15874.
