### PR TITLE
feat(mouse): drag to select text in the pager, release to copy

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -548,6 +548,11 @@ end).
   reload (`:mouse auto` returns to following the config). Default off (`[mouse]
   capture`). `^a u` quick-select and `y` in the pager are the mouse-free yank
   paths.
+  **Drag in a pager to select text; release copies it** and the pager title
+  reports the line count. Works the same full-screen or popped-up, and copies the
+  content only — never the line-number gutter, the whitespace/line-break markers,
+  or the border. In a Markdown view `m` chooses what you get: rendered prose, or
+  the raw source. A click that doesn't move stays a click.
   Over an agent pane the wheel does whatever that agent can actually receive:
   **claude** requests mouse reporting, so the event is forwarded and claude
   scrolls itself; **agy** ignores mouse reports but scrolls on Shift+Arrow, so

--- a/docs/drafts/mouse_selection_plan.md
+++ b/docs/drafts/mouse_selection_plan.md
@@ -145,6 +145,86 @@ its full width, so an untrimmed selection pastes a rectangle of spaces.
 > OSC payloads and has a test using a hostile `\x1b]52;c;…` string — the escaping
 > hazard is understood in-tree.
 
+## Owner spec (2026-08-05) — three surfaces, and "the content, not the chrome"
+
+Scope is settled, and it is wider than the earlier "pane + pager, skip the list"
+recommendation. All three spyc-owned surfaces are in:
+
+1. **Pager** — must work identically whether it's full-screen (`Mount::Overlay`)
+   or the pop-up (`Mount::TopPane` / `LowerPane`), and regardless of whether
+   line numbers, whitespace/line-break markers, or markdown rendering are on.
+   The copy is **the content and nothing else** — no gutter digits, no `·`/`→`/`$`
+   markers, no border or title.
+2. **File list** — select file names. A modifier gives the **full path**; without
+   it, just the **name**.
+3. **Status bar** — select and copy the whole top/status line text.
+
+### Resolved: how "the content and nothing else" is satisfied
+
+Two facts in the existing pager make this nearly free, and they're the reason this
+does NOT need a screen-buffer scrape:
+
+- **The decoration is render-time only.** `show_line_numbers` builds the gutter in
+  `render.rs` (`gutter_w`, ~line 149) and `expand_tabs` / `apply_whitespace_markers`
+  add the markers there too (~186–188). None of it is in `view.lines`. So
+  extraction that reads `view.lines` is decoration-free *by construction* — there
+  is no filtering step to get wrong, and turning line numbers on cannot change
+  what a copy produces.
+- **The markdown source is retained.** `alt_lines` holds the other side of the
+  rendered↔source pair and `m` toggles which is live (`markdown_rendered`).
+  `source_text()` already prefers `alt_lines` for exactly this reason ("POLA for
+  paste into chat").
+
+So: **a selection always yields the text currently displayed, taken from
+`view.lines`.** In a markdown view, `m` is what chooses rendered prose vs raw
+markdown, and the selection follows it. That satisfies "the underlying actual
+markdown *or* the text being displayed" without inventing a rendered→source line
+map, which is impossible to do faithfully anyway — the two sides have different
+line counts, so a *ranged* selection has no well-defined image in the other. Whole-view
+source copy stays `y` (`source_yank_text`), which is unchanged.
+
+> [!IMPORTANT]
+> Do not implement pager selection by reading the rendered `Buffer`. It is the
+> obvious shortcut and it silently re-introduces every decoration the spec
+> excludes, plus wrap artifacts — and it would make the copy depend on whether
+> the gutter happened to be on.
+
+### Charwise selection has to be added
+
+`VisualKind` today is `Line | Block` only. A mouse drag is neither: it starts
+mid-line and ends mid-line, taking everything between (vim's `v`, and what every
+terminal does). That is a third kind, `Char`.
+
+Adding it is contained — `Line`/`Block` already have arms to extend in the three
+places that matter: `VisualSelection::range`, the highlight arms in
+`render.rs` (~350–410), and `visual_yank_text`. It also lands keyboard `v` for
+free, which the pager currently lacks.
+
+### Wrap is the trap
+
+With `wrap = true` (the scrollback default) one source line occupies N visual
+rows, so a pointer row is not a line index. `layout::visual_rows` already owns
+that math for scrolling and must be the single source of truth for the
+pointer→(line, col) hit-test too. A second, independent mapping here is how the
+highlight and the copied text come to disagree about what was selected.
+
+### Per-surface extraction
+
+| Surface | Selection unit | Copy yields |
+|---|---|---|
+| Pager | charwise (`VisualKind::Char`), from `view.lines` | displayed text, decoration-free; trailing per-line whitespace trimmed |
+| File list | rows | file **names**, or **absolute paths** with the modifier held |
+| Status bar | whole line | the status text as displayed |
+
+For the file-list modifier: **not Shift** (the terminal's own
+selection-bypass, frequently consumed before spyc sees it) — that constraint
+already applies to block-select below. Use Ctrl or Alt, and state it in
+`FEATURES.md` + `docs/KEYBINDINGS.md`.
+
+The list is *not* the pick mechanism. Picks persist and drive operations; a
+selection is transient and only feeds the clipboard. Keeping them separate avoids
+a drag silently changing what the next file operation acts on.
+
 ## Open decisions
 
 These need answers before implementation, and two of them change the shape.
@@ -165,13 +245,12 @@ the whole class of bug impossible rather than handled, and the machinery exists.
 Cost: a drag implicitly freezes the pane, which must be visible (the divider
 already indicates scroll mode) and must auto-exit on release-with-no-selection.
 
-### 2. Which surfaces in v1
+### 2. ~~Which surfaces in v1~~ RESOLVED
 
-Pane-only is a coherent, useful v1 and is where the demand came from. The pager
-is the second-most valuable (`:activity dump`, `:grep` results, diffs) but costs
-more (spans, not cells). The list is the least valuable and overlaps picks.
-
-**Recommendation: pane + pager. Skip the list.**
+Superseded by the owner spec above: pager + file list + status bar, all three.
+The pane is covered for a mouse-aware child by #224 (its own selection) and needs
+spyc-side selection only for a non-mouse child, which is now the *last* piece
+rather than the first.
 
 ### 3. ~~Auto-copy on release, or an explicit copy step?~~ RESOLVED
 
@@ -206,22 +285,26 @@ clipboard rather than shipping alongside a fix for something it didn't break.
 
 **Recommendation: separate PR, landed before Tier 5.**
 
-## Suggested PR split
+## PR split
 
-1. **OSC 52 clipboard routing** — `auto` (client-side over SSH, OS clipboard
-   locally), applied to the existing yank paths. Independently valuable; fixes a
-   live bug for every SSH user.
-2. **1002 + drag plumbing** — enable button-event tracking, stop dropping `Drag`,
-   extend `Gesture`, and forward drags to mouse-aware children. **This alone
-   brings claude's native selection alive inside the pane**, which may satisfy
-   most of the original complaint before spyc-side selection exists at all.
-3. **Pane selection** — the state machine, freeze-on-drag, highlight, and
-   copy-on-release for a non-mouse child.
-4. **Pager selection** — the span-range highlight and range-scoped extraction.
-
-PR 2 is the one to land first and evaluate: if dragging inside claude works, the
-remaining gap is only non-mouse children and the pager, and the priority of 3–4
-should be re-judged against real use rather than assumed.
+1. ~~**1002 + drag plumbing**~~ — **SHIPPED (#224).** Brought claude's own
+   in-pane selection alive, which is what "copy in a claude session works great"
+   refers to.
+2. **`VisualKind::Char`** — charwise selection in the pager, keyboard-first
+   (`v`), with the `range` / highlight / yank arms. No mouse yet, so it is
+   reviewable against the existing `V`/`^v` behaviour it extends.
+3. **Pager mouse selection** — the press→motion→release state machine (Tier 1),
+   the `visual_rows`-based pointer→(line, col) hit-test, and copy-on-release.
+   Delivers the `:activity` / `:grep` / diff case that motivated all of this.
+4. **File list + status bar** — row selection with the name/full-path modifier,
+   and whole-line status copy. Smaller, and independent of 2–3.
+5. **OSC 52 clipboard routing** — `auto`: client-side over SSH, OS clipboard
+   locally. Fixes a live bug for every SSH user on the *existing* yank paths
+   (`y`, `^a u`), so it is independently valuable. Should land before selection
+   makes copy the primary path, but does not block 2–4 locally.
+6. **Pane selection for a non-mouse child** — freeze-on-drag (decision 1) and
+   `contents_between` extraction. Last, because #224 already covers the
+   mouse-aware children and this only serves plain shells.
 
 ## Verification
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -864,6 +864,18 @@ pub struct ViewState {
     /// the pane first. Children track button state — claude fires its click on the
     /// release — so both an unpaired and a missing release misbehave.
     pub mouse_press_forwarded: bool,
+    /// A left press landed on a pager and a spyc-side text selection owns the
+    /// drag until the button comes up.
+    ///
+    /// The exact counterpart of `mouse_press_forwarded`, and mutually exclusive
+    /// with it: a gesture belongs to whoever received its press. Without this, a
+    /// drag begun on a pager would fall through to the child-forwarding path and
+    /// start typing mouse reports into the agent mid-selection.
+    ///
+    /// Holds the mount so the drag keeps addressing the pager it started in even
+    /// if the pointer wanders over another region — a selection that retargeted
+    /// mid-drag would extend against the wrong buffer's line indices.
+    pub mouse_selection: Option<crate::ui::pager::Mount>,
     /// Whether an agent-transcript scrollback (`^a v`) renders the agent's
     /// tool-use / tool-result lines. `t` toggles it; the transcript is
     /// re-rendered with the new value. Session-scoped (persists across
@@ -957,6 +969,7 @@ impl ViewState {
             tab_state: None,
             scroll_last: None,
             mouse_press_forwarded: false,
+            mouse_selection: None,
             transcript_show_tool_calls: true,
             term_size: crossterm::terminal::size().unwrap_or((80, 24)),
         }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -78,6 +78,14 @@ pub(super) enum MouseSink {
     FocusAndForward,
     /// Give the keyboard to the region under the pointer.
     FocusRegion,
+    /// Give the keyboard to the pager under the pointer AND anchor a text
+    /// selection there.
+    ///
+    /// Both halves in one variant for the same reason [`Self::FocusAndForward`]
+    /// carries both: #219 shipped a sink that did only the forwarding half while a
+    /// test asserting the sink still passed. A press that anchored without focusing
+    /// would leave the pager's own keys (`y`, Esc) going somewhere else.
+    FocusAndSelect(Mount),
     /// Paste the system clipboard wherever a paste would land.
     Paste,
     /// Open the leader menu (right-click, from anywhere).
@@ -212,11 +220,18 @@ pub(super) const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseS
             // Left is click-THROUGH: focus the region, and (for a mouse-aware
             // child) let the event reach it too. The pane is live and visible, so
             // swallowing the first click just to focus would read as broken.
-            return if matches!(region, Region::Pane) && snap.can_forward_to_child() {
-                MouseSink::FocusAndForward
-            } else {
-                MouseSink::FocusRegion
-            };
+            if matches!(region, Region::Pane) && snap.can_forward_to_child() {
+                return MouseSink::FocusAndForward;
+            }
+            // A pager is painted over the list, so a press in the list region is
+            // really on the pager and starts a text selection there. Checked before
+            // the plain focus arm, which would otherwise consume the press.
+            if matches!(region, Region::List | Region::RightColumn)
+                && let Some(mount) = snap.pager_mount
+            {
+                return MouseSink::FocusAndSelect(mount);
+            }
+            return MouseSink::FocusRegion;
         }
         Gesture::Wheel => {}
     }
@@ -326,6 +341,27 @@ impl super::App {
         // held: claude's own handler starts a selection on press and fires the
         // actual click on RELEASE, so a press-only click leaves it drag-selecting
         // forever and never clicks anything.
+        // A gesture belongs to whoever received its press. When that was a pager,
+        // spyc's own selection owns the drag and the release — checked BEFORE the
+        // forwarding paths below, which would otherwise deliver mouse reports into
+        // the agent while the user is selecting text somewhere else entirely.
+        if self.view.mouse_selection.is_some() {
+            match ev.kind {
+                MouseEventKind::Drag(MouseButton::Left) => {
+                    return self.extend_pager_selection(ev);
+                }
+                MouseEventKind::Up(MouseButton::Left) => {
+                    return self.finish_pager_selection(ev);
+                }
+                // Any other button mid-drag abandons the selection rather than
+                // interleaving two gestures.
+                MouseEventKind::Down(_) | MouseEventKind::Up(_) => {
+                    self.view.mouse_selection = None;
+                }
+                _ => {}
+            }
+        }
+
         if let MouseEventKind::Up(button) = ev.kind {
             return self.forward_release(ev, button, frame);
         }
@@ -445,6 +481,11 @@ impl super::App {
             }
             MouseSink::PaneForward => self.forward_to_child(ev, &layout),
             MouseSink::PaneScrollKeys => self.send_scroll_keys(delta),
+
+            MouseSink::FocusAndSelect(mount) => {
+                self.focus_region(region);
+                self.begin_pager_selection(ev, mount)
+            }
         }
     }
 
@@ -482,6 +523,76 @@ impl super::App {
             // pty buries its real exit message under one repeat per wheel line.
             err_prefix: None,
         }]
+    }
+
+    /// Anchor a charwise selection where the pointer pressed.
+    ///
+    /// Claims the drag (`view.mouse_selection`) only if the press actually landed
+    /// on a character. A press on the gutter or below the last line focuses the
+    /// pager and nothing more, so it cannot strand a selection that never had an
+    /// anchor — and, because claiming is what diverts drags away from the child,
+    /// an unclaimed press leaves forwarding exactly as it was.
+    fn begin_pager_selection(&mut self, ev: MouseEvent, mount: Mount) -> Vec<Effect> {
+        let Some(view) = self.active_pager_matching_mut(mount) else {
+            return Vec::new();
+        };
+        let Some((line, col)) = view.hit_test(ev.column, ev.row) else {
+            return Vec::new();
+        };
+        view.begin_char_selection(line, col);
+        self.view.mouse_selection = Some(mount);
+        Vec::new()
+    }
+
+    /// Extend the in-progress selection to the pointer.
+    ///
+    /// A pointer that has left the content rect (`hit_test` → `None`) holds the
+    /// selection where it was rather than collapsing it: dragging slightly past the
+    /// edge is normal, and losing the selection there would read as a bug.
+    fn extend_pager_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        let Some(mount) = self.view.mouse_selection else {
+            return Vec::new();
+        };
+        if let Some(view) = self.active_pager_matching_mut(mount)
+            && let Some((line, col)) = view.hit_test(ev.column, ev.row)
+        {
+            view.extend_char_selection(line, col);
+        }
+        Vec::new()
+    }
+
+    /// Finish the gesture: copy when it selected something, and treat a press that
+    /// never moved as the plain click it was.
+    fn finish_pager_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        let Some(mount) = self.view.mouse_selection.take() else {
+            return Vec::new();
+        };
+        let Some(view) = self.active_pager_matching_mut(mount) else {
+            return Vec::new();
+        };
+        if let Some((line, col)) = view.hit_test(ev.column, ev.row) {
+            view.extend_char_selection(line, col);
+        }
+        if !view.char_selection_is_nonempty() {
+            // A click, not a drag. Drop the zero-width selection so it doesn't
+            // linger as a stray highlight, and leave the clipboard alone.
+            view.visual = None;
+            return Vec::new();
+        }
+        // `visual_yank_text` consumes the selection (it exits visual mode) — the
+        // same contract the `y` key relies on.
+        let Some((text, lines, _)) = view.visual_yank_text(false) else {
+            return Vec::new();
+        };
+        if text.is_empty() {
+            return Vec::new();
+        }
+        // `CopyToPagerClipboard`, not `CopyToClipboard`: it lands the confirmation
+        // in the pager title where the user is already looking, which is the same
+        // place the `y` key reports to. A status-bar flash would be behind the
+        // full-frame mount.
+        let ok_msg = format!("copied {lines} line{}", if lines == 1 { "" } else { "s" });
+        vec![Effect::CopyToPagerClipboard { text, ok_msg }]
     }
 
     /// Encode `ev` in the child's own protocol and send it to the active pane.
@@ -751,6 +862,67 @@ mod tests {
                 "closed={closed} covered={covered}"
             );
         }
+    }
+
+    /// A left press on a pager anchors a text selection there instead of only
+    /// moving focus. Both mounts that paint over the list qualify, and so does the
+    /// right column's pager.
+    #[test]
+    fn left_press_on_a_pager_starts_a_selection() {
+        for mount in [Mount::Overlay, Mount::TopPane] {
+            let s = MouseSnapshot {
+                pager_mount: Some(mount),
+                ..snap(Some(Region::List))
+            };
+            assert_eq!(
+                route_mouse(s, Gesture::Left),
+                MouseSink::FocusAndSelect(mount),
+                "{mount:?} over the list region"
+            );
+        }
+        let right = MouseSnapshot {
+            pager_mount: Some(Mount::TopPane),
+            ..snap(Some(Region::RightColumn))
+        };
+        assert_eq!(
+            route_mouse(right, Gesture::Left),
+            MouseSink::FocusAndSelect(Mount::TopPane)
+        );
+    }
+
+    /// With no pager mounted there is no text to select, so a left press stays a
+    /// plain focus click on the file list.
+    #[test]
+    fn left_press_on_the_bare_list_only_focuses() {
+        assert_eq!(
+            route_mouse(snap(Some(Region::List)), Gesture::Left),
+            MouseSink::FocusRegion
+        );
+    }
+
+    /// Selection must not steal the click-through contract: a press over a
+    /// mouse-aware child still focuses AND forwards, even with a pager mounted up
+    /// top (the `D` + pane coexistence case).
+    #[test]
+    fn left_press_on_a_mouse_aware_pane_still_forwards_with_a_pager_mounted() {
+        let s = MouseSnapshot {
+            pane_wants_mouse: true,
+            pager_mount: Some(Mount::TopPane),
+            ..snap(Some(Region::Pane))
+        };
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::FocusAndForward);
+    }
+
+    /// A prompt still wins over starting a selection — the arm that keeps a
+    /// right-click from latching a chord also covers left.
+    #[test]
+    fn a_prompt_suppresses_selection() {
+        let s = MouseSnapshot {
+            is_prompting: true,
+            pager_mount: Some(Mount::Overlay),
+            ..snap(Some(Region::List))
+        };
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::Swallow);
     }
 
     #[test]

--- a/src/app/pager_handler/mod.rs
+++ b/src/app/pager_handler/mod.rs
@@ -356,6 +356,30 @@ impl App {
         }
     }
 
+    /// The pager that owns input, mutably, resolved through the same slot ladder
+    /// as [`Self::active_pager_ref`].
+    ///
+    /// `mount` is a guard, not a lookup key: it must match the pager currently in
+    /// the slot, so a gesture that began on one pager can't keep mutating a
+    /// *different* one that replaced it mid-drag (a stream landing its content, a
+    /// tab switch restoring a stashed scrollback). Returns `None` on a mismatch,
+    /// which callers treat as "the selection's target is gone".
+    pub(super) fn active_pager_matching_mut(
+        &mut self,
+        mount: crate::ui::pager::Mount,
+    ) -> Option<&mut PagerView> {
+        let view = match self.active_pager_slot() {
+            PagerSlot::Modal | PagerSlot::Top => self.view.pager.as_mut(),
+            PagerSlot::Scrollback => self.view.scroll_pager.as_mut(),
+            PagerSlot::Right => self
+                .view
+                .pager_right
+                .as_mut()
+                .or(self.view.right_pager.as_mut()),
+        }?;
+        (view.mount == mount).then_some(view)
+    }
+
     /// Decide which pager slot owns input — the single source of truth shared by
     /// [`Self::active_pager_ref`] and the `active_pager_mut!` macro. A flat
     /// priority ladder: a full-frame modal first, then the focused region (right

--- a/src/ui/pager/construct.rs
+++ b/src/ui/pager/construct.rs
@@ -46,6 +46,9 @@ impl PagerView {
             flash: None,
             last_viewport_h: std::cell::Cell::new(0),
             last_body_w: std::cell::Cell::new(0),
+            // Zero-sized until the first render, which `hit_test` reads as "this
+            // view has never been drawn, so no pointer position names a character".
+            last_content_area: std::cell::Cell::new(ratatui::layout::Rect::ZERO),
             visual: None,
             placement: None,
             mount: Mount::Overlay,

--- a/src/ui/pager/mod.rs
+++ b/src/ui/pager/mod.rs
@@ -311,6 +311,16 @@ pub struct PagerView {
     /// lines that wrap to multiple rows don't cause the trailing
     /// logical lines to fall off the viewport at "Bot".
     pub last_body_w: std::cell::Cell<u16>,
+    /// Last screen rect the renderer drew this view's *content* into — borders,
+    /// title and search row already excluded. Zero-sized until the first render.
+    ///
+    /// Exists so the mouse hit-test can work in absolute screen coordinates
+    /// without re-deriving where the pager landed. Re-deriving means duplicating
+    /// the mount→rect choice, `full_width`, the border inset and the search-row
+    /// split; each is a place the highlight and the copied text could disagree
+    /// about which character the pointer was on. Same reason (and same shape) as
+    /// `last_body_w` / `last_viewport_h`.
+    pub last_content_area: std::cell::Cell<ratatui::layout::Rect>,
     /// vi-style visual line selection. `None` outside the mode;
     /// `Some({ anchor, cursor })` while the user is selecting a
     /// range with `V` + `j`/`k`/`G`/etc. `y` yanks the inclusive

--- a/src/ui/pager/mod.rs
+++ b/src/ui/pager/mod.rs
@@ -76,6 +76,15 @@ pub enum Mount {
 pub enum VisualKind {
     Line,
     Block,
+    /// Charwise (vim `v`): starts mid-line and ends mid-line, taking everything
+    /// between. What a mouse drag means, and expressible as neither `Line` (whole
+    /// lines only) nor `Block` (a rectangle).
+    ///
+    /// Unlike `Block`, the two columns are **not** an independent range: the
+    /// endpoints are ordered as `(line, col)` pairs, so a backwards drag keeps
+    /// the columns attached to their own lines. See
+    /// [`VisualSelection::char_endpoints`].
+    Char,
 }
 
 /// vi-style visual selection inside the pager. Active when
@@ -120,6 +129,25 @@ impl VisualSelection {
             (self.anchor_col, self.cursor_col)
         } else {
             (self.cursor_col, self.anchor_col)
+        }
+    }
+
+    /// The `Char`-mode endpoints as `((start_line, start_col), (end_line, end_col))`,
+    /// ordered by the `(line, col)` pair.
+    ///
+    /// **Not** `range()` + `col_range()`. Those order the two axes independently,
+    /// which is right for a `Block` rectangle and wrong for charwise: dragging
+    /// from `(3, 10)` up-right to `(5, 2)` would yield start col 2 on line 3,
+    /// selecting text the pointer never crossed. Ordering the pairs keeps each
+    /// column attached to the line it was taken on.
+    pub const fn char_endpoints(&self) -> ((usize, usize), (usize, usize)) {
+        let a = (self.anchor, self.anchor_col);
+        let c = (self.cursor, self.cursor_col);
+        // Tuple comparison isn't const-friendly, so compare the pair by hand.
+        if a.0 < c.0 || (a.0 == c.0 && a.1 <= c.1) {
+            (a, c)
+        } else {
+            (c, a)
         }
     }
 }

--- a/src/ui/pager/render.rs
+++ b/src/ui/pager/render.rs
@@ -120,6 +120,7 @@ pub fn render(frame: &mut Frame, area: Rect, view: &PagerView, theme: &Theme) {
     // showing only the top half of the pager filled with content
     // and the rest with `~` until the user manually scrolled).
     view.last_viewport_h.set(content_area.height);
+    view.last_content_area.set(content_area);
 
     if let Some(chunks) = multi_col_chunks {
         render_multi_column(frame, content_area, view, theme, ncols, &chunks);

--- a/src/ui/pager/render.rs
+++ b/src/ui/pager/render.rs
@@ -383,6 +383,29 @@ fn apply_row_styling(
                         theme.cursor_bg,
                     );
                 }
+                // Charwise: same painter as Block, but the column bounds are
+                // per-row rather than a shared rectangle — first row from its
+                // start column to end-of-line, interior rows whole, last row up
+                // to its end column.
+                VisualKind::Char => {
+                    let ((s_line, s_col), (e_line, e_col)) = sel.char_endpoints();
+                    let eol = line_plain_text(&styled).chars().count().saturating_sub(1);
+                    let from = if abs_idx == s_line { s_col } else { 0 };
+                    let to = if abs_idx == e_line { e_col } else { eol };
+                    let cursor_col = if abs_idx == sel.cursor {
+                        Some(sel.cursor_col)
+                    } else {
+                        None
+                    };
+                    styled = paint_block_selection(
+                        &styled,
+                        from,
+                        to,
+                        cursor_col,
+                        theme.cursor_bg_dim,
+                        theme.cursor_bg,
+                    );
+                }
             }
         }
     }
@@ -405,7 +428,10 @@ fn apply_row_styling(
                         .collect::<Vec<_>>(),
                 );
             }
-            VisualKind::Block => {
+            // `Char` never reaches placement — it is produced by a mouse drag,
+            // which anchors on the press instead of pre-positioning. Grouped with
+            // Block so the match stays exhaustive without an unreachable arm.
+            VisualKind::Block | VisualKind::Char => {
                 // Re-style only the cursor cell so the rest of the row keeps
                 // its syntax-highlight / search styling while the user
                 // positions the placement anchor.

--- a/src/ui/pager/scroll_search.rs
+++ b/src/ui/pager/scroll_search.rs
@@ -470,6 +470,17 @@ impl PagerView {
                     hi + 1,
                     if count == 1 { "" } else { "s" },
                 ),
+                VisualKind::Char => {
+                    let ((s_line, s_col), (e_line, e_col)) = sel.char_endpoints();
+                    format!(
+                        "-- VISUAL --  L{}C{}-L{}C{}  ({count} line{})",
+                        s_line + 1,
+                        s_col + 1,
+                        e_line + 1,
+                        e_col + 1,
+                        if count == 1 { "" } else { "s" },
+                    )
+                }
                 VisualKind::Block => {
                     let (lo_col, hi_col) = sel.col_range();
                     let cols = hi_col - lo_col + 1;

--- a/src/ui/pager/selection.rs
+++ b/src/ui/pager/selection.rs
@@ -443,24 +443,33 @@ impl PagerView {
         Some((self.with_title_header(text, include_title), count, in_block))
     }
 
-    /// Map a pointer position inside the pager's **content rect** to
-    /// `(line_index, char_col)`.
+    /// Map an **absolute screen position** to `(line_index, char_col)` in this
+    /// view, or `None` when it names no character.
     ///
-    /// `row_off` / `col_off` are 0-based offsets within the rect
-    /// [`super::layout::pager_inner_area`] returns, so borders and title are
-    /// already accounted for by the caller.
+    /// Everything it needs comes from what the renderer recorded on the last
+    /// frame — `last_content_area` for where the content landed and `last_body_w`
+    /// for the wrap width. Nothing is re-derived, because every re-derivation
+    /// (mount→rect, borders, `full_width`, the gutter formula) is a chance for the
+    /// highlight and the copied text to disagree about which character the pointer
+    /// was on. `visual_rows` stays the sole owner of the wrap math for the same
+    /// reason.
     ///
-    /// Reads `last_body_w` — the body width the renderer *actually* used on the
-    /// last frame — rather than recomputing it. Recomputing means duplicating the
-    /// gutter formula, and any drift between the two shows up as the highlight and
-    /// the copied text disagreeing about what was selected. `visual_rows` is the
-    /// same wrap math the scroll bound uses, for the same reason.
-    ///
-    /// `None` when the pointer is over the gutter or past the last line — neither
-    /// names a character position.
-    pub fn hit_test(&self, row_off: u16, col_off: u16) -> Option<(usize, usize)> {
+    /// `None` for: a pointer outside the content rect, over the line-number
+    /// gutter, or past the last line. None of those is a character position.
+    pub fn hit_test(&self, col: u16, row: u16) -> Option<(usize, usize)> {
+        let area = self.last_content_area.get();
+        if area.width == 0
+            || area.height == 0
+            || col < area.x
+            || row < area.y
+            || col >= area.x.saturating_add(area.width)
+            || row >= area.y.saturating_add(area.height)
+        {
+            return None;
+        }
+        let row_off = row - area.y;
         let gutter_w = self.gutter_width();
-        let col_off = usize::from(col_off);
+        let col_off = usize::from(col - area.x);
         if col_off < gutter_w {
             return None; // over the line-number gutter
         }

--- a/src/ui/pager/selection.rs
+++ b/src/ui/pager/selection.rs
@@ -407,10 +407,129 @@ impl PagerView {
                     .collect::<Vec<_>>()
                     .join("\n")
             }
+            // Charwise: the first line from its start column to the end, whole
+            // lines between, the last line up to its end column. A single-line
+            // selection is the intersection of both bounds.
+            //
+            // Trailing whitespace is trimmed per line, not globally: `lines`
+            // carries render-padded content, and an untrimmed multi-line copy
+            // pastes a ragged block of spaces.
+            crate::ui::pager::VisualKind::Char => {
+                let ((s_line, s_col), (e_line, e_col)) = sel.char_endpoints();
+                let (s_line, e_line) = (s_line.min(max), e_line.min(max));
+                let mut out: Vec<String> = Vec::with_capacity(e_line - s_line + 1);
+                for (offset, line) in self.lines[s_line..=e_line].iter().enumerate() {
+                    let idx = s_line + offset;
+                    let plain = line_plain_text(line);
+                    let from = if idx == s_line { s_col } else { 0 };
+                    // `e_col` is inclusive; `None` means "to end of line".
+                    let to = if idx == e_line {
+                        Some(e_col.saturating_add(1))
+                    } else {
+                        None
+                    };
+                    let mut chars = plain.chars().skip(from);
+                    let piece: String = match to {
+                        Some(end) => chars.by_ref().take(end.saturating_sub(from)).collect(),
+                        None => chars.by_ref().collect(),
+                    };
+                    out.push(piece.trim_end().to_string());
+                }
+                out.join("\n")
+            }
         };
         let count = hi - lo + 1;
         self.visual = None;
         Some((self.with_title_header(text, include_title), count, in_block))
+    }
+
+    /// Map a pointer position inside the pager's **content rect** to
+    /// `(line_index, char_col)`.
+    ///
+    /// `row_off` / `col_off` are 0-based offsets within the rect
+    /// [`super::layout::pager_inner_area`] returns, so borders and title are
+    /// already accounted for by the caller.
+    ///
+    /// Reads `last_body_w` — the body width the renderer *actually* used on the
+    /// last frame — rather than recomputing it. Recomputing means duplicating the
+    /// gutter formula, and any drift between the two shows up as the highlight and
+    /// the copied text disagreeing about what was selected. `visual_rows` is the
+    /// same wrap math the scroll bound uses, for the same reason.
+    ///
+    /// `None` when the pointer is over the gutter or past the last line — neither
+    /// names a character position.
+    pub fn hit_test(&self, row_off: u16, col_off: u16) -> Option<(usize, usize)> {
+        let gutter_w = self.gutter_width();
+        let col_off = usize::from(col_off);
+        if col_off < gutter_w {
+            return None; // over the line-number gutter
+        }
+        let body_w = usize::from(self.last_body_w.get()).max(1);
+        let target = usize::from(row_off);
+
+        // Walk forward from the scroll position, spending each line's visual rows,
+        // until `target` lands inside one. With wrap off every line is one row, so
+        // this degenerates to `scroll + target`.
+        let mut consumed = 0usize;
+        for (offset, line) in self.lines.iter().enumerate().skip(self.scroll) {
+            let rows = if self.wrap {
+                visual_rows(line, body_w, self.tab_width).max(1)
+            } else {
+                1
+            };
+            if target < consumed + rows {
+                let wrapped_row = target - consumed;
+                let col = col_off - gutter_w + wrapped_row * body_w;
+                // Clamp into the line: clicking past end-of-line selects to the
+                // end rather than nothing, which is what every editor does.
+                let len = line_plain_text(line).chars().count();
+                return Some((offset, col.min(len.saturating_sub(1))));
+            }
+            consumed += rows;
+        }
+        None // past the last line
+    }
+
+    /// The line-number gutter width in cells, mirroring `render.rs`.
+    fn gutter_width(&self) -> usize {
+        if !self.show_line_numbers {
+            return 0;
+        }
+        let basis = self.lines.len().max(self.line_count_hint.unwrap_or(0));
+        basis.max(1).ilog10() as usize + 2
+    }
+
+    /// Begin a charwise selection at `(line, col)` — the mouse-press half of a
+    /// drag. Anchor and cursor coincide until the pointer moves.
+    pub const fn begin_char_selection(&mut self, line: usize, col: usize) {
+        self.visual = Some(VisualSelection {
+            anchor: line,
+            anchor_col: col,
+            cursor: line,
+            cursor_col: col,
+            kind: VisualKind::Char,
+        });
+    }
+
+    /// Extend an in-progress charwise selection to `(line, col)`. Ignored unless a
+    /// charwise selection is active, so a `V`/`^v` selection can't be hijacked
+    /// mid-drag.
+    pub const fn extend_char_selection(&mut self, line: usize, col: usize) {
+        if let Some(sel) = self.visual.as_mut()
+            && matches!(sel.kind, VisualKind::Char)
+        {
+            sel.cursor = line;
+            sel.cursor_col = col;
+        }
+    }
+
+    /// Whether a charwise selection is active and actually spans something — the
+    /// release-time test for "was this a drag or just a click?".
+    pub fn char_selection_is_nonempty(&self) -> bool {
+        self.visual.is_some_and(|s| {
+            matches!(s.kind, VisualKind::Char)
+                && (s.anchor != s.cursor || s.anchor_col != s.cursor_col)
+        })
     }
 
     /// Clamp any state holding line indices into the buffer after `lines`

--- a/src/ui/pager/tests/selection.rs
+++ b/src/ui/pager/tests/selection.rs
@@ -582,3 +582,130 @@ fn charwise_yank_clamps_rows_past_the_end() {
     let (text, ..) = view.visual_yank_text(false).expect("charwise yanks");
     assert!(text.starts_with("first line"), "got {text:?}");
 }
+
+// ── pointer hit-test ──────────────────────────────────────────────────
+
+/// Put the view in the state a render would have left it: content at `area`,
+/// wrap width recorded, and the gutter explicitly OFF.
+///
+/// `show_line_numbers` defaults to `true`, so without turning it off a press at
+/// the content rect's left edge lands on the gutter and correctly selects
+/// nothing. Stating it here keeps each test's column arithmetic obvious;
+/// `hit_test_excludes_the_gutter_and_offsets_columns_past_it` turns it back on.
+fn drawn(view: &mut PagerView, x: u16, y: u16, w: u16, h: u16) {
+    view.show_line_numbers = false;
+    view.last_content_area
+        .set(ratatui::layout::Rect::new(x, y, w, h));
+    view.last_body_w.set(w);
+}
+
+#[test]
+fn hit_test_maps_absolute_screen_position_to_line_and_col() {
+    let mut view = charwise_view();
+    view.wrap = false;
+    drawn(&mut view, 10, 5, 40, 3);
+    // Top-left of the content rect is line 0, col 0.
+    assert_eq!(view.hit_test(10, 5), Some((0, 0)));
+    // Third row down, four cells in.
+    assert_eq!(view.hit_test(14, 7), Some((2, 4)));
+}
+
+/// A never-rendered view has no geometry, so no position names a character.
+#[test]
+fn hit_test_returns_none_before_the_first_render() {
+    let view = charwise_view();
+    assert_eq!(view.hit_test(0, 0), None);
+}
+
+#[test]
+fn hit_test_rejects_positions_outside_the_content_rect() {
+    let mut view = charwise_view();
+    drawn(&mut view, 10, 5, 40, 3);
+    for (col, row) in [(9, 5), (10, 4), (50, 5), (10, 8)] {
+        assert_eq!(view.hit_test(col, row), None, "({col},{row}) is outside");
+    }
+}
+
+/// The gutter is chrome, not content — a press on the digits selects nothing.
+/// Also pins that the gutter shifts the column origin, so col 0 of the *text*
+/// is `gutter_w` cells in.
+#[test]
+fn hit_test_excludes_the_gutter_and_offsets_columns_past_it() {
+    let mut view = charwise_view();
+    view.wrap = false;
+    drawn(&mut view, 0, 0, 40, 3);
+    view.show_line_numbers = true;
+    // 3 lines → ilog10(3) == 0 → gutter is 2 cells.
+    assert_eq!(view.hit_test(0, 0), None, "col 0 is gutter");
+    assert_eq!(view.hit_test(1, 0), None, "col 1 is gutter");
+    assert_eq!(
+        view.hit_test(2, 0),
+        Some((0, 0)),
+        "text starts after gutter"
+    );
+}
+
+/// Scroll offsets which line the top row is.
+#[test]
+fn hit_test_follows_the_scroll_position() {
+    let mut view = charwise_view();
+    view.wrap = false;
+    view.scroll = 2;
+    drawn(&mut view, 0, 0, 40, 3);
+    assert_eq!(view.hit_test(0, 0), Some((2, 0)));
+    assert_eq!(view.hit_test(0, 1), None, "nothing below the last line");
+}
+
+/// Under wrap one logical line owns several screen rows, so a row is NOT a line
+/// index — and the column continues across the wrap rather than restarting.
+/// Getting this wrong is how the highlight and the copied text come to disagree.
+#[test]
+fn hit_test_accounts_for_wrapped_rows() {
+    let mut view = PagerView::new_plain("w", vec!["0123456789".to_string(), "second".to_string()]);
+    view.wrap = true;
+    // Body width 5 → line 0 occupies screen rows 0 and 1.
+    drawn(&mut view, 0, 0, 5, 4);
+    assert_eq!(view.hit_test(0, 0), Some((0, 0)));
+    assert_eq!(
+        view.hit_test(1, 1),
+        Some((0, 6)),
+        "second wrapped row of line 0"
+    );
+    assert_eq!(view.hit_test(0, 2), Some((1, 0)), "line 1 starts on row 2");
+}
+
+/// Clicking past end-of-line selects to the end, as every editor does, instead of
+/// returning nothing.
+#[test]
+fn hit_test_clamps_past_end_of_line() {
+    let mut view = charwise_view();
+    view.wrap = false;
+    drawn(&mut view, 0, 0, 40, 3);
+    // "second" is 6 chars; col 30 is well past it.
+    assert_eq!(view.hit_test(30, 1), Some((1, 5)));
+}
+
+/// A press that never moves must not leave a selection behind, and a moved one
+/// must report as selecting.
+#[test]
+fn char_selection_is_nonempty_only_after_the_pointer_moves() {
+    let mut view = charwise_view();
+    view.begin_char_selection(1, 2);
+    assert!(
+        !view.char_selection_is_nonempty(),
+        "a click selects nothing"
+    );
+    view.extend_char_selection(1, 3);
+    assert!(view.char_selection_is_nonempty());
+}
+
+/// Extending must not hijack a keyboard `V` / `^v` selection into charwise.
+#[test]
+fn extend_char_selection_ignores_a_line_or_block_selection() {
+    let mut view = charwise_view();
+    view.enter_visual(); // Line mode
+    view.extend_char_selection(2, 4);
+    let sel = view.visual.expect("still visual");
+    assert_eq!(sel.kind, VisualKind::Line);
+    assert_eq!(sel.cursor, 0, "cursor untouched by a charwise extend");
+}

--- a/src/ui/pager/tests/selection.rs
+++ b/src/ui/pager/tests/selection.rs
@@ -469,3 +469,116 @@ fn block_range_stays_inclusive_when_anchor_higher_than_cursor() {
     assert_eq!(sel.range(), (2, 5));
     assert_eq!(sel.col_range(), (3, 7));
 }
+
+// ── charwise (`VisualKind::Char`) ─────────────────────────────────────
+
+/// Build a view with known, non-uniform content for charwise slicing.
+fn charwise_view() -> PagerView {
+    PagerView::new_plain(
+        "c",
+        vec![
+            "first line".to_string(),
+            "second".to_string(),
+            "third line here".to_string(),
+        ],
+    )
+}
+
+fn char_sel(view: &mut PagerView, anchor: (usize, usize), cursor: (usize, usize)) {
+    view.visual = Some(VisualSelection {
+        anchor: anchor.0,
+        anchor_col: anchor.1,
+        cursor: cursor.0,
+        cursor_col: cursor.1,
+        kind: VisualKind::Char,
+    });
+}
+
+/// The headline: a charwise selection takes the first line from its start
+/// column, whole lines between, and the last line up to its end column.
+#[test]
+fn charwise_yank_spans_partial_first_and_last_lines() {
+    let mut view = charwise_view();
+    // "first line" from col 6 ("line") through "third" on line 2 (col 4).
+    char_sel(&mut view, (0, 6), (2, 4));
+    let (text, count, block) = view.visual_yank_text(false).expect("charwise yanks");
+    assert_eq!(text, "line\nsecond\nthird");
+    assert_eq!(count, 3);
+    assert!(!block, "charwise is not block mode");
+}
+
+/// A single-line charwise selection is the intersection of both column bounds,
+/// not "col..end of line".
+#[test]
+fn charwise_yank_within_one_line_is_bounded_both_ends() {
+    let mut view = charwise_view();
+    char_sel(&mut view, (2, 6), (2, 9));
+    let (text, ..) = view.visual_yank_text(false).expect("charwise yanks");
+    assert_eq!(text, "line");
+}
+
+/// A backwards drag must keep each column attached to its own line.
+///
+/// This is what `range()` + `col_range()` get wrong: ordering the axes
+/// independently would start at col 4 on line 0, selecting "st line…" — text the
+/// pointer never crossed. Dragging up-and-right is the case that exposes it,
+/// because the low line carries the HIGH column.
+#[test]
+fn charwise_backwards_drag_orders_by_line_col_pair_not_per_axis() {
+    let mut view = charwise_view();
+    // Anchor late on line 2, drag back to col 4 of line 0 → same selection as
+    // anchoring at (0,4) and dragging to (2,4).
+    char_sel(&mut view, (2, 4), (0, 4));
+    let (backwards, ..) = view.visual_yank_text(false).expect("charwise yanks");
+
+    let mut fwd = charwise_view();
+    char_sel(&mut fwd, (0, 4), (2, 4));
+    let (forwards, ..) = fwd.visual_yank_text(false).expect("charwise yanks");
+
+    assert_eq!(
+        backwards, forwards,
+        "drag direction must not change the text"
+    );
+    assert_eq!(backwards, "t line\nsecond\nthird");
+}
+
+/// Line numbers and whitespace markers are added in `render.rs`, never stored in
+/// `lines`, so toggling them cannot change what a selection copies. The spec's
+/// "the content and nothing else" depends on this staying true.
+#[test]
+fn charwise_yank_ignores_gutter_and_whitespace_decoration() {
+    let mut view = charwise_view();
+    char_sel(&mut view, (0, 0), (0, 4));
+    let plain = view.visual_yank_text(false).expect("charwise yanks").0;
+
+    let mut decorated = charwise_view();
+    decorated.show_line_numbers = true;
+    decorated.show_whitespace = true;
+    char_sel(&mut decorated, (0, 0), (0, 4));
+    let with_chrome = decorated.visual_yank_text(false).expect("charwise yanks").0;
+
+    assert_eq!(plain, "first");
+    assert_eq!(
+        with_chrome, plain,
+        "decoration must not reach the clipboard"
+    );
+}
+
+/// Grid-padded content would otherwise paste a ragged block of spaces.
+#[test]
+fn charwise_yank_trims_trailing_whitespace_per_line() {
+    let mut view = PagerView::new_plain("c", vec!["padded   ".to_string(), "b".to_string()]);
+    char_sel(&mut view, (0, 0), (1, 0));
+    let (text, ..) = view.visual_yank_text(false).expect("charwise yanks");
+    assert_eq!(text, "padded\nb");
+}
+
+/// Out-of-range rows are clamped rather than panicking — same contract the
+/// Line/Block arms have, and reachable when a streaming view front-trims.
+#[test]
+fn charwise_yank_clamps_rows_past_the_end() {
+    let mut view = charwise_view();
+    char_sel(&mut view, (0, 0), (99, 3));
+    let (text, ..) = view.visual_yank_text(false).expect("charwise yanks");
+    assert!(text.starts_with("first line"), "got {text:?}");
+}


### PR DESCRIPTION
Drag in a pager to select text; release copies it. The first of the three surfaces in the owner spec (pager → file list → status bar).

Works identically full-screen or popped-up, with line numbers, whitespace markers or Markdown rendering on or off — and copies **the content only**.

## How "the content and nothing else" is guaranteed

Not by filtering. By reading the right thing:

- **The decoration is render-time only.** The gutter (`render.rs` `gutter_w`) and the whitespace/line-break markers (`expand_tabs` / `apply_whitespace_markers`) are built during render and never stored in `view.lines`. Extraction reads `lines`, so it's decoration-free *by construction* — there's no filter step to get wrong, and toggling line numbers cannot change what a copy produces. Pinned by a test that flips `show_line_numbers` + `show_whitespace` and asserts the copy is byte-identical.
- **Markdown works via the existing toggle.** `alt_lines` already retains the source and `m` picks which side is live, so a selection that yields "what's displayed" gives rendered prose in rendered mode and raw markdown in source mode. No rendered→source line map is needed — which matters, because none could be faithful: the two sides have different line counts, so a *ranged* selection has no well-defined image in the other.

> Reading the rendered `Buffer` is the obvious shortcut here and it silently re-imports every decoration the spec excludes, plus wrap artifacts. Please keep extraction on `view.lines`.

## Two bugs the obvious implementation ships

**Charwise can't reuse `range()` + `col_range()`.** Those order the two axes independently — correct for a `Block` rectangle, wrong here. Dragging from `(3,10)` up-right to `(5,2)` would start at col 2 on line 3 and select text the pointer never crossed. `char_endpoints()` orders the `(line, col)` pairs so each column stays attached to its own line. There's a test that fails under the naive version.

**A drag that begins on a pager must not leak into the agent.** A gesture belongs to whoever received its press, so `view.mouse_selection` is the exact counterpart of `mouse_press_forwarded` and is checked *before* the child-forwarding paths. Without that ordering, `forward_drag` starts typing mouse reports into claude while you're selecting text somewhere else.

## Geometry

`hit_test` works in absolute screen coordinates by reading a new `last_content_area`, cached by the renderer exactly like `last_body_w` / `last_viewport_h`. Nothing is re-derived — mount→rect, `full_width`, the border inset and the search-row split are each a place the highlight and the copied text could disagree about which character the pointer was on. `visual_rows` stays the sole owner of the wrap math.

Two guards, both load-bearing rather than defensive:
- A press claims the drag only if it landed on a character. Gutter or below-last-line just focuses — and since claiming is what diverts drags from the child, an unclaimed press leaves forwarding untouched.
- `active_pager_matching_mut` takes the mount as a **guard, not a lookup key**: it must still match the pager in the slot, so a drag can't keep mutating a different pager that replaced it mid-gesture (a stream landing content, a tab switch restoring a stashed scrollback).

Dragging past the content rect holds the selection rather than collapsing it. A press that never moves is treated as the click it was — zero-width selection dropped, clipboard untouched.

## Tests

Hit-test across gutter × scroll × wrap × outside-the-rect × past-end-of-line; charwise extraction incl. the backwards drag, trailing-whitespace trim and row clamping; routing for bare-list-only-focuses, mouse-aware-pane-still-click-throughs-with-a-pager-mounted, and prompt-suppresses-everything.

`make check` green (verified by exit code — a filtered pipeline reported a false pass earlier in this work).

Gotcha for future tests: `show_line_numbers` defaults to **true**, so a press at the content rect's left edge lands on the gutter and correctly selects nothing. The `drawn` helper turns it off explicitly.

## Not in this PR

- File list (names / full paths with a modifier) and status-bar selection — next, and independent.
- **OSC 52.** `src/clipboard.rs` still shells to `pbcopy`/`xclip`, so over SSH this copies to the *server*. Pre-existing (already affects `y` and `^a u`) but selection makes it the primary path, so it's worth landing soon.
- Pane selection for a non-mouse child.

Rebased on `main` after #226; the `PaneScrollKeys` / `FocusAndSelect` sinks are both present and both test sets pass.
