### PR TITLE
fix(mouse): the pointer's surface owns the event, the wheel stops at the ends, and codex scrolls

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -180,7 +180,7 @@ without waiting for a real agent transition.
 ```toml
 [mouse]
 capture = false      # real mouse reporting (wheel + buttons). Default off.
-scroll_lines = 3     # lines per wheel tick, for surfaces spyc scrolls itself
+scroll_lines = 1     # lines per wheel tick, for surfaces spyc scrolls itself
 ```
 
 `capture` asks the terminal for real mouse reporting so spyc can scroll whatever
@@ -229,6 +229,10 @@ Clicking a *row* in the file list is deliberately not a thing: clicking a region
 coarse and hard to get wrong, while aiming at a one-cell-tall line invites
 near-misses that silently move the cursor. `j`/`k`, `F`, and frecency jumps are all
 faster and more precise.
+
+`scroll_lines` defaults to **1** because trackpads and most modern terminals
+already emit one wheel event per notional line — a multiplier there makes the list
+fly. Raise it for a detented wheel that sends one event per physical click.
 
 `scroll_lines` applies to the surfaces spyc scrolls itself. A pane forwarding to a
 mouse-aware child is unaffected — the child receives one event per tick and picks

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -556,9 +556,10 @@ end).
   Over an agent pane the wheel does whatever that agent can actually receive:
   **claude** requests mouse reporting, so the event is forwarded and claude
   scrolls itself; **agy** ignores mouse reports but scrolls on Shift+Arrow, so
-  spyc sends those instead; **codex** discards mouse events *and* has no
-  main-view scroll (its transcript is behind its own `^T`), so the wheel does
-  nothing there — use `^a v` for spyc's transcript view.
+  spyc sends those instead; **codex** discards mouse events and its main chat view
+  doesn't scroll, so the wheel sends plain arrows — those scroll its `^T`
+  transcript overlay, and outside it they only move the draft cursor (codex keeps
+  history recall on `^R`, so the wheel can't recall a past prompt).
 - **`:limit <glob>`** — temporary filter (e.g. `:limit *.rs`)
 - **`:limit !`** — show only picked files
 - **`:limit git`** / **`:limit g`** — show only files in `git status`

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -339,6 +339,25 @@ impl AgentProfile for CodexProfile {
     fn binary(&self) -> &'static str {
         "codex"
     }
+
+    /// Plain `Up` / `Down`, which scroll codex's `^T` transcript overlay — the only
+    /// scrollable view it has. Its main chat view doesn't scroll at all, and its
+    /// vt100 scrollback is empty (it confines the transcript to a DECSTBM scroll
+    /// region), so this is the only surface either side can move.
+    ///
+    /// Safe outside the overlay, which is why it's plain arrows and not PageUp:
+    /// codex binds `plain(Up)` to `editor.move_up` — move the cursor within the
+    /// draft — so on an empty or single-line composer it's a no-op. History recall
+    /// is on `Ctrl+R` / `Alt+Up`, so this can't reproduce the wheel-recalls-history
+    /// bug that DEC 1007 caused for claude. Worst case, with a multi-line draft in
+    /// progress, the draft cursor moves; nothing is submitted or lost.
+    fn wheel_scroll(&self) -> Option<WheelScroll> {
+        use crossterm::event::{KeyCode, KeyModifiers as M};
+        Some(WheelScroll {
+            up: (KeyCode::Up, M::NONE),
+            down: (KeyCode::Down, M::NONE),
+        })
+    }
     fn resolve_resume_target(
         &self,
         pane: &Pane,
@@ -659,10 +678,15 @@ mod tests {
         assert!(detect("claude").wheel_scroll().is_none());
 
         // codex discards mouse events outright (`map_crossterm_event` maps only
-        // Key/Resize/Paste/Focus) AND has no binding that scrolls its main view —
-        // scrolling lives behind its `^T` transcript overlay. So there is nothing
-        // correct to send, and `Up` would recall prompt history instead.
-        assert!(detect("codex").wheel_scroll().is_none());
+        // Key/Resize/Paste/Focus), so forwarding can never work — but plain arrows
+        // scroll its `^T` transcript overlay (`tui.keymap.pager.scroll_up`), and
+        // outside that overlay `plain(Up)` is `editor.move_up` (draft cursor), NOT
+        // history recall. `\e[A` / `\e[B` are bare xterm Up/Down.
+        let codex = detect("codex")
+            .wheel_scroll()
+            .expect("codex scrolls on arrows");
+        assert_eq!(enc(codex.up), b"\x1b[A");
+        assert_eq!(enc(codex.down), b"\x1b[B");
 
         // A plain process is not an agent: its scrollback belongs to spyc.
         assert!(detect("bash -lc 'make'").wheel_scroll().is_none());

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -53,13 +53,15 @@ pub(super) enum MouseSink {
     /// Drop the event. A modal owns the screen, the region isn't interactive, or
     /// the pane's child can't use it.
     Swallow,
-    /// Move the file-list cursor / scroll the list.
+    /// Move a file-list cursor. Carries the SIDE the pointer is over, because in a
+    /// vsplit the wheel must scroll the column under the pointer without dragging
+    /// keyboard focus to it — `cur()` would move the focused column instead.
     ///
     /// Not optional, and easy to mistake for one: wheel-over-list works today
     /// only because DEC 1007 has the *terminal* translate wheel into arrow keys.
     /// Enabling 1000 stops that translation, so without this sink turning capture
     /// on would trade a pane bug for a list bug.
-    ListCursor,
+    ListCursor(crate::app::state::Side),
     /// Scroll the pager under the pointer. Carries the SLOT rather than the mount:
     /// a mount can't tell `view.pager` from `view.right_pager`, and the wheel must
     /// scroll the pager the pointer is over, not the focused one.
@@ -194,6 +196,22 @@ pub(super) const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseS
         return MouseSink::Swallow;
     };
 
+    // A full-frame **modal pager** is the only interacting surface while it's open,
+    // matching how `route_input` gives it every key including meta chords. Clicking
+    // beside its box used to reach whatever the layout said was underneath —
+    // selecting content in the pane "under" a pager the user is reading, which is
+    // the POLA break reported against #228. Middle-click paste is kept (it targets
+    // the pager's own search/jump prompt), and the wheel/left arms below still route
+    // to it when the pointer is actually over its content.
+    if matches!(snap.pager_mount, Some(Mount::Overlay)) && !matches!(gesture, Gesture::Middle) {
+        return match (gesture, snap.covering_pager) {
+            (Gesture::Wheel, Some(slot)) => MouseSink::Pager(slot),
+            (Gesture::Left, Some(slot)) => MouseSink::FocusAndSelect(slot),
+            // Over the modal's frame but not its content: it still owns the event.
+            _ => MouseSink::Swallow,
+        };
+    }
+
     // A prompt owns the keyboard, so the only gesture that can mean anything is a
     // paste — which `handle_paste` already routes into the prompt buffer.
     //
@@ -256,9 +274,10 @@ pub(super) const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseS
 
     match region {
         // A pager over the list was already claimed by `covering_pager` above. What
-        // reaches here is the list itself — including the area beside a centered
-        // overlay, where the list is genuinely what the user sees.
-        Region::List | Region::RightColumn => MouseSink::ListCursor,
+        // reaches here is the list itself. The region names which column, so the
+        // wheel scrolls the one under the pointer.
+        Region::List => MouseSink::ListCursor(crate::app::state::Side::Left),
+        Region::RightColumn => MouseSink::ListCursor(crate::app::state::Side::Right),
         Region::Pane => {
             if snap.can_forward_to_child() {
                 MouseSink::PaneForward
@@ -471,21 +490,14 @@ impl super::App {
 
         match route_mouse(snap, gesture) {
             MouseSink::Swallow => Vec::new(),
-            MouseSink::ListCursor => {
-                // Reuse the cursor Actions rather than poking the cursor: they
-                // already handle clamping, the vsplit's focused column, and
-                // `list_generation` invalidation.
-                let action = if delta < 0 {
-                    crate::keymap::Action::Up(lines)
-                } else {
-                    crate::keymap::Action::Down(lines)
-                };
-                // A cursor move can't fail, but `apply` is fallible for other
-                // actions; surface rather than swallow if that ever changes.
-                self.apply(&action).unwrap_or_else(|e| {
-                    self.state.flash_error(format!("mouse: {e:#}"));
-                    Vec::new()
-                })
+            MouseSink::ListCursor(side) => {
+                // NOT `Action::Up/Down`: those move `cur()` (the focused column) and
+                // wrap at the ends via `rem_euclid`. The wheel must move the column
+                // under the POINTER, and must stop at the ends — wrapping from the
+                // bottom of the list back to the top is what made scrolling feel
+                // like it was flying out of control.
+                self.state.cursor_scroll_side(side, delta as isize);
+                Vec::new()
             }
             MouseSink::Pager(slot) => {
                 self.scroll_pager_in_slot(slot, delta);
@@ -516,7 +528,12 @@ impl super::App {
             MouseSink::PaneScrollKeys => self.send_scroll_keys(delta),
 
             MouseSink::FocusAndSelect(slot) => {
-                self.focus_region(region);
+                // The pager's OWN region, not the one the layout says is under the
+                // pointer. An Overlay covering the pane made `region` be `Pane`, so
+                // clicking inside the pager focused the pty behind it — the reported
+                // "clicking in the pager also sends a click through to the underlying
+                // pane".
+                self.focus_pager_slot(slot);
                 self.begin_pager_selection(ev, slot)
             }
         }
@@ -601,10 +618,11 @@ impl super::App {
         // — which, since a physically-held drag keeps generating `Drag` events as
         // long as the pointer moves at all, gives a continuous scroll-and-extend
         // for as long as the user holds past the edge and wiggles the pointer.
-        if ev.row < view.last_content_area.get().y {
-            view.scroll_by(-1, view.last_viewport_h.get());
-        } else if ev.row >= view.last_content_area.get().y + view.last_content_area.get().height {
-            view.scroll_by(1, view.last_viewport_h.get());
+        let area = view.last_content_area.get();
+        if ev.row < area.y {
+            view.scroll_by_within_content(-1, view.last_viewport_h.get());
+        } else if ev.row >= area.y.saturating_add(area.height) {
+            view.scroll_by_within_content(1, view.last_viewport_h.get());
         }
         if let Some((line, c)) = view.hit_test(col, row) {
             view.extend_char_selection(line, c);
@@ -731,6 +749,28 @@ impl super::App {
     /// while `^a z`-zoomed (the target region is collapsed off-screen) and, coming
     /// back from the pane, restores whichever split column the user left from.
     /// Assigning `state.focus` directly would lose both.
+    /// Give the keyboard to the region that OWNS `slot`.
+    ///
+    /// Distinct from [`Self::focus_region`], which answers from layout geometry: a
+    /// pager drawn over the pane's rect would otherwise focus the pty behind it.
+    /// A `Modal` needs no move — `recompute_focus` resolves a full-frame Overlay to
+    /// `Focus::Pager(Overlay)` on its own, and touching pane focus here is exactly
+    /// what leaked a click through to the pane.
+    fn focus_pager_slot(&mut self, slot: PagerSlot) {
+        match slot {
+            PagerSlot::Modal => {}
+            PagerSlot::Scrollback => self.set_pane_focus(true),
+            PagerSlot::Top => {
+                self.set_pane_focus(false);
+                self.vsplit_focus(crate::app::state::Side::Left);
+            }
+            PagerSlot::Right => {
+                self.set_pane_focus(false);
+                self.vsplit_focus(crate::app::state::Side::Right);
+            }
+        }
+    }
+
     fn focus_region(&mut self, region: Option<Region>) {
         match region {
             Some(Region::Pane) => self.set_pane_focus(true),
@@ -983,13 +1023,15 @@ mod tests {
 
     #[test]
     fn list_routes_to_the_cursor_or_to_a_pager_covering_it() {
+        // The side comes from the REGION, so the wheel scrolls the column under the
+        // pointer rather than the focused one.
         assert_eq!(
             route_mouse(snap(Some(Region::List)), Gesture::Wheel),
-            MouseSink::ListCursor
+            MouseSink::ListCursor(Side::Left)
         );
         assert_eq!(
             route_mouse(snap(Some(Region::RightColumn)), Gesture::Wheel),
-            MouseSink::ListCursor
+            MouseSink::ListCursor(Side::Right)
         );
         // A pager COVERING the pointer takes those events.
         for slot in [PagerSlot::Modal, PagerSlot::Top] {
@@ -1386,6 +1428,7 @@ mod tests {
 
     use super::PagerSlot;
     use crate::app::Effect;
+    use crate::app::state::Side;
     use crate::ui::pager::{PagerView, VisualKind};
     use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
@@ -1595,19 +1638,24 @@ mod tests {
         assert_eq!(route_mouse(s, Gesture::Left), MouseSink::FocusAndForward);
     }
 
-    /// Beside a centered overlay the user genuinely sees the file list, so the
-    /// pointer there drives the list — coverage is per-rect, not "a pager exists".
-    /// The old `pager_mount`-based arm got this wrong: any mounted pager claimed the
-    /// whole list region.
+    /// **Deliberate reversal of what #228 shipped.** That version reasoned that
+    /// beside a centered overlay the user still sees the list, so clicking there
+    /// should reach it. In practice that read as a POLA break: it let a click
+    /// select content in the pane *underneath* a pager the user was reading. An
+    /// open modal pager is now the only interacting surface, matching how
+    /// `route_input` hands it every key.
+    ///
+    /// Scoped to `Overlay` on purpose — see
+    /// `a_non_modal_pager_leaves_the_rest_of_the_frame_alone`.
     #[test]
-    fn the_list_beside_a_centered_overlay_is_still_the_list() {
+    fn a_modal_pager_swallows_input_beside_its_box() {
         let s = MouseSnapshot {
             pager_mount: Some(Mount::Overlay), // mounted...
             covering_pager: None,              // ...but not under THIS point
             ..snap(Some(Region::List))
         };
-        assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::ListCursor);
-        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::FocusRegion);
+        assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::Swallow);
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::Swallow);
     }
 
     /// A prompt still outranks a covering pager, and middle/right stay spyc's
@@ -1626,5 +1674,36 @@ mod tests {
             ..snap(Some(Region::Pane))
         };
         assert_eq!(route_mouse(covered, Gesture::Middle), MouseSink::Paste);
+    }
+    /// **A full-frame modal pager is the only interacting surface while it's open.**
+    ///
+    /// Clicking beside its box used to reach whatever the layout said was
+    /// underneath — starting a selection in the pane "under" a pager the user is
+    /// reading. Matches how `route_input` hands an Overlay every key.
+    #[test]
+    fn a_modal_pager_is_exclusive_even_where_it_does_not_cover() {
+        let s = MouseSnapshot {
+            pager_mount: Some(Mount::Overlay),
+            covering_pager: None, // beside the box, over the pane's rect
+            pane_wants_mouse: true,
+            ..snap(Some(Region::Pane))
+        };
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::Swallow);
+        assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::Swallow);
+        // Middle-click still pastes: it targets the pager's own search / jump prompt.
+        assert_eq!(route_mouse(s, Gesture::Middle), MouseSink::Paste);
+    }
+
+    /// A NON-modal pager stays scoped to its own rect — it must not make the whole
+    /// frame inert the way an Overlay does.
+    #[test]
+    fn a_non_modal_pager_leaves_the_rest_of_the_frame_alone() {
+        let s = MouseSnapshot {
+            pager_mount: Some(Mount::TopPane),
+            covering_pager: None,
+            pane_wants_mouse: true,
+            ..snap(Some(Region::Pane))
+        };
+        assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::PaneForward);
     }
 }

--- a/src/app/state/navigation.rs
+++ b/src/app/state/navigation.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 
 use crate::app::{Effect, Matcher};
 
-use super::{AppState, Commander};
+use super::{AppState, Commander, Side};
 
 impl Commander {
     /// Snap `view_top` to the page containing the cursor, given the last
@@ -42,6 +42,35 @@ impl AppState {
         let new_row = (row_in_col as isize + delta).rem_euclid(col_len as isize) as usize;
         self.cur_mut().cursor.index = col_start + new_row;
         true
+    }
+
+    /// Move a *specific* column's cursor by `delta`, **clamped** to the list — the
+    /// mouse-wheel entry point.
+    ///
+    /// Two deliberate differences from [`Self::cursor_move_vertical`], which the
+    /// keyboard uses:
+    ///
+    /// - **Targets `side`, not `cur()`.** The wheel scrolls the column under the
+    ///   pointer, so in a vsplit it must move the pointed column's cursor without
+    ///   moving keyboard focus there. `cur()` would move the *focused* column
+    ///   instead, i.e. the one the user isn't pointing at.
+    /// - **Clamps instead of wrapping.** `cursor_move_vertical` wraps with
+    ///   `rem_euclid` (correct for `j`/`k`), but a wheel that teleports from the end
+    ///   of the list back to the top reads as the list flying out of control — one
+    ///   of the two causes of the "uncontrollably fast" report, alongside the
+    ///   `scroll_lines` default.
+    ///
+    /// Scrolls the whole list, not the on-screen column: with a multi-column grid
+    /// the wheel should walk the listing in order rather than stop dead at the
+    /// bottom of the first column.
+    pub fn cursor_scroll_side(&mut self, side: Side, delta: isize) {
+        let len = self.col(side).rows.len();
+        if len == 0 {
+            return;
+        }
+        let cur = self.col(side).cursor.index as isize;
+        let last = len as isize - 1;
+        self.col_mut(side).cursor.index = (cur + delta).clamp(0, last) as usize;
     }
 
     /// Move across the entire list (PageUp/PageDown). Wraps globally.
@@ -236,5 +265,57 @@ impl AppState {
             self.focus_on_path(&canonical);
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod scroll_side_tests {
+    use crate::app::state::{AppState, Side};
+
+    fn state_with(rows: usize) -> AppState {
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        let mut s = AppState::test_default(tmp);
+        s.left.rows = (0..rows)
+            .map(|i| crate::app::RowData {
+                path: std::path::PathBuf::from(format!("f{i}")),
+                display: format!("f{i}"),
+                kind: crate::fs::EntryKind::File,
+                deleted: false,
+            })
+            .collect();
+        s
+    }
+
+    /// The wheel must STOP at the ends. `cursor_move_vertical` wraps via
+    /// `rem_euclid` — correct for `j`/`k`, but a wheel that teleports from the
+    /// bottom of the list back to the top is what made scrolling feel out of
+    /// control.
+    #[test]
+    fn cursor_scroll_side_clamps_instead_of_wrapping() {
+        let mut s = state_with(5);
+        s.left.cursor.index = 4; // last row
+        s.cursor_scroll_side(Side::Left, 3);
+        assert_eq!(s.left.cursor.index, 4, "must not wrap past the end");
+
+        s.left.cursor.index = 0;
+        s.cursor_scroll_side(Side::Left, -3);
+        assert_eq!(s.left.cursor.index, 0, "must not wrap past the start");
+    }
+
+    #[test]
+    fn cursor_scroll_side_moves_by_delta() {
+        let mut s = state_with(10);
+        s.cursor_scroll_side(Side::Left, 3);
+        assert_eq!(s.left.cursor.index, 3);
+        s.cursor_scroll_side(Side::Left, -1);
+        assert_eq!(s.left.cursor.index, 2);
+    }
+
+    /// An empty listing is a no-op rather than a panic.
+    #[test]
+    fn cursor_scroll_side_on_an_empty_list_is_a_noop() {
+        let mut s = state_with(0);
+        s.cursor_scroll_side(Side::Left, 5);
+        assert_eq!(s.left.cursor.index, 0);
     }
 }

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -100,12 +100,15 @@
 # restarting; `:mouse on` puts it back. spyc's mouse-free yank paths are
 # `^a u` (quick-select URLs / paths / SHAs) and `y` in the pager.
 #
-# `scroll_lines` (default 3): lines per wheel tick, for the surfaces spyc
-# scrolls itself. A pane forwarding to a mouse-aware child is unaffected —
-# the child gets one event per tick and picks its own step. Clamped to >= 1.
+# `scroll_lines` (default 1): lines per wheel tick, for the surfaces spyc
+# scrolls itself. 1, because trackpads and most modern terminals already send
+# one event per notional line — a multiplier there makes the list fly. Raise it
+# for a detented wheel that sends one event per physical click. A pane
+# forwarding to a mouse-aware child is unaffected — the child gets one event
+# per tick and picks its own step. Clamped to >= 1.
 [mouse]
 # capture = false
-# scroll_lines = 3
+# scroll_lines = 1
 
 # ── markdown ──────────────────────────────────────────────────────────
 # Default view for `.md` / `.markdown` files in the pager.

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -313,7 +313,7 @@ impl Default for MouseConfig {
     fn default() -> Self {
         Self {
             capture: false,
-            scroll_lines: 3,
+            scroll_lines: 1,
         }
     }
 }

--- a/src/ui/pager/scroll_search.rs
+++ b/src/ui/pager/scroll_search.rs
@@ -152,6 +152,21 @@ impl PagerView {
         self.clamp_scroll(viewport_height);
     }
 
+    /// Scroll by `delta`, stopping at the last line of *content* rather than at
+    /// [`Self::scroll_max`].
+    ///
+    /// `scroll_max` deliberately reserves one row past the last line so the
+    /// `[EOF]` / `~` end marker is reachable (vim/less parity). That's right for
+    /// ordinary scrolling and wrong while drag-selecting: there is nothing to
+    /// select on the marker row, so a drag held past the bottom scrolled into
+    /// empty space and showed a `~`.
+    pub fn scroll_by_within_content(&mut self, delta: i32, viewport_height: u16) {
+        let max = self.scroll_max_content(viewport_height);
+        let current = self.scroll as i64;
+        let new = (current + i64::from(delta)).clamp(0, max as i64);
+        self.scroll = usize::try_from(new).unwrap_or(0);
+    }
+
     pub const fn scroll_to_top(&mut self) {
         self.scroll = 0;
     }


### PR DESCRIPTION
Six dog-fooding reports against #226–#228. Two commits (a `fix` cluster and the codex `feat`); squash will collapse them, so the title covers both.

## The pointer's surface owns the event

Four of the six were the same theme — the thing under the pointer wasn't the thing receiving input.

- **Wheel over a split column scrolled the focused column**, not the pointed one: the sink went through `Action::Up/Down` → `cur()`. `MouseSink::ListCursor` now carries the `Side` the region names and moves that column's cursor *without* dragging keyboard focus across.
- **Clicking inside a pager also focused the pane behind it.** `FocusAndSelect` called `focus_region(region)`, and for a pager drawn over the pane's rect `region` **is** `Pane`. Focus now derives from the pager's slot; a `Modal` needs no move at all, since `recompute_focus` resolves a full-frame Overlay on its own and touching pane focus was exactly what leaked through.
- **Clicking beside a modal pager's box interacted with the pane underneath.** This **reverses a decision #228 shipped deliberately** — that you still see the list beside a centered overlay, so clicking there should reach it. In practice it let a click select content *under* the pager being read. A full-frame Overlay is now the only interacting surface while open, matching how `route_input` hands it every key including meta chords. Middle-click paste is kept (it targets the pager's own search/jump prompt). Scoped to `Overlay` — a non-modal pager stays confined to its own rect, with a test pinning each half, and the old test was flipped with a comment recording the reversal rather than deleted.

## Scroll speed had two causes, and the ×3 was the smaller one

`scroll_lines` defaulted to 3, but trackpads and most modern terminals already send one event per notional line — so it was 3× (a risk I flagged in #225 and then shipped anyway). The bigger one: `cursor_move_vertical` wraps via `rem_euclid`, correct for `j`/`k`, but a wheel that teleports from the bottom of the list to the top reads as the list flying away. The wheel now uses `cursor_scroll_side`, which **clamps**, and the default is 1.

## Drag past the bottom showed a `~`

`scroll_max` reserves one row past the last line so the `[EOF]` marker is reachable (vim/less parity) — right for scrolling, wrong mid-drag since there's nothing to select there. Edge-scroll now uses `scroll_by_within_content`.

## codex scrolls (this reverses my own "unfixable" claim)

I'd ruled out arrows by analogy: sending `Up` to a composer is what made the wheel recall history for claude under DEC 1007. Reading codex's keymap instead of reasoning from that precedent — `plain(Up)` is `editor.move_up` (draft cursor) and `pager.scroll_up`; history recall is `^R`/`Alt+Up`. So arrows scroll the `^T` transcript overlay (the only scrollable view codex has) and are a no-op on an empty draft outside it.

The alternatives were measured, not assumed:
- Forwarding can never work — `map_crossterm_event` maps only Key/Resize/Paste/Focus, so `Event::Mouse` is dropped.
- spyc-owned reverse-scroll has nothing to show — a real captured codex pty stream through vt100 yields **0 scrollback rows** (DECSTBM scroll region).
- Sending `^T` to open the overlay is a toggle spyc can't observe, so a second wheel-up would close it.

Byte-asserted (`\e[A` / `\e[B`), like agy's, because a binding that encodes to something the agent ignores is indistinguishable from no binding at all from outside.

## Verification

`make check` green, exit-code verified. New tests: modal exclusivity (and its non-modal counterpart), clamped `cursor_scroll_side` incl. empty-list, and the updated codex/agy `wheel_scroll` byte assertions. Docs updated: `CONFIGURATION.md`, `default.spycrc.toml`, `FEATURES.md`.

## Known-remaining (filed separately)

- `^a v` picks the **wrong** codex rollout: `pick_best_rollout` ranks by largest mtime with start-proximity only as a tie-break, so any actively-written session wins regardless of which pane owns it.
- Click-to-select inside codex's `^t` overlay needs spyc-side pane selection (`contents_between`).
