### PR TITLE
feat(mouse): drag to select file-list rows, click to copy the status line

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -548,6 +548,11 @@ end).
   reload (`:mouse auto` returns to following the config). Default off (`[mouse]
   capture`). `^a u` quick-select and `y` in the pager are the mouse-free yank
   paths.
+  **Drag in the file list to select rows; release copies their names** — hold
+  **Ctrl** while pressing to copy absolute paths instead. The highlight stays up
+  after the copy. Distinct from picks: a drag never changes what the next file
+  operation acts on. **Click the status line to copy it** (the text, not the
+  powerline separators or the logo).
   **Drag in a pager to select text; release copies it** and the pager title
   reports the line count. Works the same full-screen or popped-up, and copies the
   content only — never the line-number gutter, the whitespace/line-break markers,

--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -352,6 +352,13 @@ pub enum ClipMsg {
     /// `"yanked prompt: {preview}{…}"` — preview = `text.chars().take(60)`,
     /// `…` iff `text.len() > 60` (byte length).
     Prompt,
+    /// `"copied the status line"` — a click on the status bar. Carries no count:
+    /// it is always exactly one line, so a number would be noise.
+    StatusLine,
+    /// `"copied {count} name(s)"` / `"copied {count} path(s)"` — a file-list row
+    /// selection. `count` is carried because a name may contain a newline, so it
+    /// can't be recovered from `text`; `paths` distinguishes the modifier-held copy.
+    ListNames { count: usize, paths: bool },
 }
 
 impl ClipMsg {
@@ -367,6 +374,14 @@ impl ClipMsg {
                 format!("yanked path: {preview}{ellipsis}")
             }
             Self::MultiPath { count } => format!("yanked {count} paths"),
+            Self::StatusLine => "copied the status line".to_string(),
+            Self::ListNames { count, paths } => {
+                let unit = if *paths { "path" } else { "name" };
+                format!(
+                    "copied {count} {unit}{}",
+                    if *count == 1 { "" } else { "s" }
+                )
+            }
             Self::Prompt => {
                 let preview: String = text.chars().take(60).collect();
                 let ellipsis = if text.len() > 60 { "…" } else { "" };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -219,6 +219,42 @@ pub struct FrameLayout {
     vdivider: Option<ratatui::layout::Rect>,
 }
 
+/// The surface an in-flight mouse drag belongs to. See
+/// [`ViewState::mouse_selection`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseDragTarget {
+    /// A pager's charwise text selection, in this slot.
+    Pager(crate::app::pager_handler::PagerSlot),
+    /// A file-list row selection, in this column.
+    List(state::Side),
+}
+
+/// A file-list row selection.
+///
+/// `anchor`/`focus` rather than a sorted range so a backwards drag keeps its
+/// direction, and so extending never has to re-derive which end the user started
+/// from. Row *indices*, not paths: the copy resolves paths at release time from the
+/// live listing, so a selection can't outlive a refresh with stale paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListSelection {
+    pub side: state::Side,
+    pub anchor: usize,
+    pub focus: usize,
+    /// Copy absolute paths instead of bare names — the modifier held at press.
+    pub full_path: bool,
+}
+
+impl ListSelection {
+    /// Inclusive `(low, high)` row indices.
+    pub const fn range(&self) -> (usize, usize) {
+        if self.anchor <= self.focus {
+            (self.anchor, self.focus)
+        } else {
+            (self.focus, self.anchor)
+        }
+    }
+}
+
 /// Follow-up side effect a key handler asks the main loop to perform.
 ///
 /// Anything that needs to own the tty (editor, pager, shell-out) goes
@@ -872,11 +908,17 @@ pub struct ViewState {
     /// drag begun on a pager would fall through to the child-forwarding path and
     /// start typing mouse reports into the agent mid-selection.
     ///
-    /// Holds the SLOT so the drag keeps addressing the pager it started in even if
-    /// the pointer wanders over another region — a selection that retargeted
-    /// mid-drag would extend against the wrong buffer's line indices. A slot, not a
-    /// mount, because a mount can't tell `view.pager` from `view.right_pager`.
-    pub mouse_selection: Option<crate::app::pager_handler::PagerSlot>,
+    /// Which surface owns the in-flight drag.
+    ///
+    /// Holds the target so the drag keeps addressing the surface it STARTED in even
+    /// if the pointer wanders elsewhere — a selection that retargeted mid-drag would
+    /// extend against the wrong buffer's indices. For a pager that's the slot, not
+    /// the mount, because a mount can't tell `view.pager` from `view.right_pager`.
+    pub mouse_selection: Option<MouseDragTarget>,
+    /// A file-list row selection, kept after the drag ends so the highlight
+    /// persists and a follow-up yank can still find it (same contract as the
+    /// pager's charwise selection).
+    pub list_selection: Option<ListSelection>,
     /// Whether an agent-transcript scrollback (`^a v`) renders the agent's
     /// tool-use / tool-result lines. `t` toggles it; the transcript is
     /// re-rendered with the new value. Session-scoped (persists across
@@ -971,6 +1013,7 @@ impl ViewState {
             scroll_last: None,
             mouse_press_forwarded: false,
             mouse_selection: None,
+            list_selection: None,
             transcript_show_tool_calls: true,
             term_size: crossterm::terminal::size().unwrap_or((80, 24)),
         }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -19,7 +19,7 @@ use ratatui::layout::Rect;
 
 use super::modal::{Modal, ModalSnapshot, active_modal};
 use super::pager_handler::PagerSlot;
-use super::{Effect, FrameLayout};
+use super::{Effect, FrameLayout, MouseDragTarget};
 use crate::ui::pager::Mount;
 
 /// Which frame region the pointer is over. Resolved from the pointer's
@@ -91,6 +91,11 @@ pub(super) enum MouseSink {
     /// test asserting the sink still passed. A press that anchored without focusing
     /// would leave the pager's own keys (`y`, Esc) going somewhere else.
     FocusAndSelect(PagerSlot),
+    /// Give the keyboard to a file-list column AND anchor a row selection there.
+    /// Both halves in one variant, for the reason [`Self::FocusAndForward`] documents.
+    FocusAndSelectRows(crate::app::state::Side),
+    /// Copy the status line's text.
+    CopyStatus,
     /// Paste the system clipboard wherever a paste would land.
     Paste,
     /// Open the leader menu (right-click, from anywhere).
@@ -261,6 +266,19 @@ pub(super) const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseS
             if matches!(region, Region::Pane) && snap.can_forward_to_child() {
                 return MouseSink::FocusAndForward;
             }
+            // A bare list (no pager over it): focus the column and start a row
+            // selection, so drag-to-copy-filenames works where the names are.
+            if matches!(region, Region::List) {
+                return MouseSink::FocusAndSelectRows(crate::app::state::Side::Left);
+            }
+            if matches!(region, Region::RightColumn) {
+                return MouseSink::FocusAndSelectRows(crate::app::state::Side::Right);
+            }
+            // The status line is one line of text; a click copies all of it. It owns
+            // no keyboard focus, so there is nothing else a click there could mean.
+            if matches!(region, Region::Status) {
+                return MouseSink::CopyStatus;
+            }
             return MouseSink::FocusRegion;
         }
         Gesture::Wheel => {
@@ -396,13 +414,19 @@ impl super::App {
         // spyc's own selection owns the drag and the release — checked BEFORE the
         // forwarding paths below, which would otherwise deliver mouse reports into
         // the agent while the user is selecting text somewhere else entirely.
-        if self.view.mouse_selection.is_some() {
+        if let Some(target) = self.view.mouse_selection {
             match ev.kind {
                 MouseEventKind::Drag(MouseButton::Left) => {
-                    return self.extend_pager_selection(ev);
+                    return match target {
+                        MouseDragTarget::Pager(_) => self.extend_pager_selection(ev),
+                        MouseDragTarget::List(side) => self.extend_row_selection(ev, side),
+                    };
                 }
                 MouseEventKind::Up(MouseButton::Left) => {
-                    return self.finish_pager_selection(ev);
+                    return match target {
+                        MouseDragTarget::Pager(_) => self.finish_pager_selection(ev),
+                        MouseDragTarget::List(_) => self.finish_row_selection(ev),
+                    };
                 }
                 // Any other button mid-drag abandons the selection rather than
                 // interleaving two gestures.
@@ -507,6 +531,20 @@ impl super::App {
                 self.focus_region(region);
                 Vec::new()
             }
+            MouseSink::FocusAndSelectRows(side) => {
+                self.focus_region(region);
+                self.begin_row_selection(ev, side)
+            }
+            MouseSink::CopyStatus => {
+                let text = self.status_bar_plain_text();
+                if text.is_empty() {
+                    return Vec::new();
+                }
+                vec![Effect::CopyToClipboard {
+                    text,
+                    ok: super::effect::ClipMsg::StatusLine,
+                }]
+            }
             MouseSink::Paste => vec![Effect::PasteFromClipboard],
             MouseSink::LeaderMenu => {
                 self.state.resolver.enter_leader();
@@ -590,7 +628,7 @@ impl super::App {
             return Vec::new();
         };
         view.begin_char_selection(line, col);
-        self.view.mouse_selection = Some(slot);
+        self.view.mouse_selection = Some(MouseDragTarget::Pager(slot));
         Vec::new()
     }
 
@@ -604,7 +642,7 @@ impl super::App {
     /// of the box, or before the first render) into the same treatment: extend to
     /// the nearest edge rather than doing nothing.
     fn extend_pager_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
-        let Some(slot) = self.view.mouse_selection else {
+        let Some(MouseDragTarget::Pager(slot)) = self.view.mouse_selection else {
             return Vec::new();
         };
         let Some(view) = self.pager_in_slot_mut(slot) else {
@@ -638,7 +676,7 @@ impl super::App {
     /// release is the terminal-native "select, then it just sits there" contract,
     /// and it's what lets a follow-up `y` / `Y` / a fresh drag still find it.
     fn finish_pager_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
-        let Some(slot) = self.view.mouse_selection.take() else {
+        let Some(MouseDragTarget::Pager(slot)) = self.view.mouse_selection.take() else {
             return Vec::new();
         };
         let Some(view) = self.pager_in_slot_mut(slot) else {
@@ -671,6 +709,131 @@ impl super::App {
         // full-frame mount.
         let ok_msg = format!("copied {lines} line{}", if lines == 1 { "" } else { "s" });
         vec![Effect::CopyToPagerClipboard { text, ok_msg }]
+    }
+
+    /// The rect a column's list is drawn into, and a `ListView` over its cached
+    /// rows — the same pair the renderer builds, so a hit-test can't disagree with
+    /// what's on screen.
+    fn list_row_at(&self, side: crate::app::state::Side, ev: MouseEvent) -> Option<usize> {
+        use crate::app::state::Side;
+        let (cols, rows) = self.view.term_size;
+        let layout = self.frame_layout(Rect::new(0, 0, cols, rows));
+        let (area, cached, commander) = match side {
+            Side::Left => (layout.list, &self.view.cached_rows, &self.state.left),
+            Side::Right => (
+                layout.right?,
+                &self.view.right_cached_rows,
+                self.state.right.as_ref()?,
+            ),
+        };
+        crate::ui::list_view::ListView {
+            rows: cached,
+            cursor: commander.cursor.index,
+            view_top: commander.cursor.view_top,
+            empty_marker: false,
+            focused: true,
+            theme: &self.view.theme,
+            selection: None,
+        }
+        .row_at(area, ev.column, ev.row)
+    }
+
+    /// Anchor a row selection where the pointer pressed, and move the cursor there.
+    ///
+    /// Moving the cursor is deliberate: clicking a file should put the cursor on it,
+    /// which is what makes the click useful on its own rather than only as the start
+    /// of a drag. Claims the drag only if the press landed on a row, so a press in
+    /// the gutter between columns leaves forwarding and focus untouched.
+    ///
+    /// The modifier is read HERE rather than carried in the sink because it selects
+    /// the copy's *content*, not its routing. Ctrl, not Shift — Shift is the
+    /// terminal's own selection-bypass and is frequently consumed before spyc sees
+    /// it.
+    fn begin_row_selection(
+        &mut self,
+        ev: MouseEvent,
+        side: crate::app::state::Side,
+    ) -> Vec<Effect> {
+        let Some(idx) = self.list_row_at(side, ev) else {
+            return Vec::new();
+        };
+        let full_path = ev
+            .modifiers
+            .contains(crossterm::event::KeyModifiers::CONTROL);
+        self.state.col_mut(side).cursor.index = idx;
+        self.view.list_selection = Some(super::ListSelection {
+            side,
+            anchor: idx,
+            focus: idx,
+            full_path,
+        });
+        self.view.mouse_selection = Some(MouseDragTarget::List(side));
+        Vec::new()
+    }
+
+    /// Extend the row selection to the pointer, dragging the cursor with it.
+    ///
+    /// A pointer off the rows holds the selection where it was, matching the pager:
+    /// drifting a few pixels past the last row mid-drag is normal, and collapsing
+    /// there would read as a bug.
+    fn extend_row_selection(
+        &mut self,
+        ev: MouseEvent,
+        side: crate::app::state::Side,
+    ) -> Vec<Effect> {
+        if let Some(idx) = self.list_row_at(side, ev) {
+            if let Some(sel) = self.view.list_selection.as_mut() {
+                sel.focus = idx;
+            }
+            self.state.col_mut(side).cursor.index = idx;
+        }
+
+        Vec::new()
+    }
+
+    /// Copy the selected rows' names (or absolute paths) and keep the highlight.
+    ///
+    /// Paths are resolved from the LIVE listing here rather than captured at press
+    /// time, so a selection can't paste stale paths after a refresh. A single row is
+    /// still a copy — unlike the pager, where a click that never moved is just a
+    /// click, clicking one filename to copy it is the obvious gesture.
+    fn finish_row_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        self.view.mouse_selection = None;
+        let Some(sel) = self.view.list_selection else {
+            return Vec::new();
+        };
+        if let Some(idx) = self.list_row_at(sel.side, ev)
+            && let Some(s) = self.view.list_selection.as_mut()
+        {
+            s.focus = idx;
+        }
+        let sel = self.view.list_selection.expect("checked above");
+        let (lo, hi) = sel.range();
+        let commander = self.state.col(sel.side);
+        let picked: Vec<String> = commander
+            .rows
+            .iter()
+            .skip(lo)
+            .take(hi.saturating_sub(lo) + 1)
+            .map(|r| {
+                if sel.full_path {
+                    r.path.display().to_string()
+                } else {
+                    r.display.clone()
+                }
+            })
+            .collect();
+        if picked.is_empty() {
+            return Vec::new();
+        }
+        let count = picked.len();
+        vec![Effect::CopyToClipboard {
+            text: picked.join("\n"),
+            ok: super::effect::ClipMsg::ListNames {
+                count,
+                paths: sel.full_path,
+            },
+        }]
     }
 
     /// Encode `ev` in the child's own protocol and send it to the active pane.
@@ -986,13 +1149,18 @@ mod tests {
         }
     }
 
-    /// With no pager mounted there is no text to select, so a left press stays a
-    /// plain focus click on the file list.
+    /// With no pager over it, a left press on the list focuses the column AND
+    /// anchors a row selection — that's how drag-to-copy-filenames starts. The
+    /// side comes from the region, so `b` never selects in `a`.
     #[test]
-    fn left_press_on_the_bare_list_only_focuses() {
+    fn left_press_on_the_bare_list_selects_rows_in_that_column() {
         assert_eq!(
             route_mouse(snap(Some(Region::List)), Gesture::Left),
-            MouseSink::FocusRegion
+            MouseSink::FocusAndSelectRows(Side::Left)
+        );
+        assert_eq!(
+            route_mouse(snap(Some(Region::RightColumn)), Gesture::Left),
+            MouseSink::FocusAndSelectRows(Side::Right)
         );
     }
 
@@ -1157,10 +1325,15 @@ mod tests {
         let unaware = snap(Some(Region::Pane));
         assert_eq!(route_mouse(unaware, Gesture::Left), MouseSink::FocusRegion);
 
-        for region in [Region::List, Region::RightColumn] {
+        // A list press focuses AND starts a row selection; see
+        // `left_press_on_the_bare_list_selects_rows_in_that_column`.
+        for (region, side) in [
+            (Region::List, Side::Left),
+            (Region::RightColumn, Side::Right),
+        ] {
             assert_eq!(
                 route_mouse(snap(Some(region)), Gesture::Left),
-                MouseSink::FocusRegion,
+                MouseSink::FocusAndSelectRows(side),
                 "{region:?}"
             );
         }
@@ -1291,9 +1464,12 @@ mod tests {
 
     /// Clicking chrome or off-frame moves nothing — but middle/right still act,
     /// since they aren't about the region.
+    ///
+    /// `Status` is excluded: it holds one line of text and no keyboard focus, so a
+    /// left click there copies it (`copying_the_status_line_needs_no_focus`).
     #[test]
     fn chrome_focuses_nothing_but_still_pastes_and_opens_the_menu() {
-        for region in [Region::Divider, Region::Status, Region::Prompt] {
+        for region in [Region::Divider, Region::Prompt] {
             assert_eq!(
                 route_mouse(snap(Some(region)), Gesture::Left),
                 MouseSink::FocusRegion,
@@ -1705,5 +1881,155 @@ mod tests {
             ..snap(Some(Region::Pane))
         };
         assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::PaneForward);
+    }
+    // ── file list + status bar selection ─────────────────────────────────
+
+    /// The status line owns no keyboard focus, so a left click there can only mean
+    /// "copy this". Kept out of the chrome test above for that reason.
+    #[test]
+    fn copying_the_status_line_needs_no_focus() {
+        assert_eq!(
+            route_mouse(snap(Some(Region::Status)), Gesture::Left),
+            MouseSink::CopyStatus
+        );
+    }
+
+    /// A pager over the list still wins: `covering_pager` is checked before the
+    /// row-selection arm, so clicking a pager never selects filenames behind it.
+    #[test]
+    fn a_covering_pager_outranks_row_selection() {
+        let s = MouseSnapshot {
+            covering_pager: Some(PagerSlot::Top),
+            ..snap(Some(Region::List))
+        };
+        assert_eq!(
+            route_mouse(s, Gesture::Left),
+            MouseSink::FocusAndSelect(PagerSlot::Top)
+        );
+    }
+
+    /// The `Row`s the renderer would have cached for `rows`. Built here rather than
+    /// via `build_rows` (scoped to `app::render`) so the test doesn't widen
+    /// production visibility; `row_at` only reads `len` and `display`.
+    fn cached_for(rows: &[crate::app::RowData]) -> Vec<crate::ui::list_view::Row> {
+        rows.iter()
+            .map(|rd| crate::ui::list_view::Row {
+                display: rd.display.clone(),
+                kind: rd.kind,
+                picked: false,
+                taken: false,
+                deleted: false,
+                git_status: crate::ui::list_view::GitFileStatus::clean(),
+                pending_delete: false,
+            })
+            .collect()
+    }
+
+    /// A list drag copies the dragged rows' NAMES, and with Ctrl held their absolute
+    /// PATHS — the modifier is read at press time because it selects the copy's
+    /// content, not its routing.
+    ///
+    /// Ctrl and not Shift: Shift is the terminal's own selection-bypass modifier and
+    /// is frequently consumed before spyc ever sees the event.
+    #[test]
+    fn a_list_drag_copies_names_or_full_paths_with_ctrl() {
+        use crate::app::state::Side;
+        use crossterm::event::KeyModifiers;
+
+        for (mods, want_paths) in [(KeyModifiers::NONE, false), (KeyModifiers::CONTROL, true)] {
+            let tmp = tempfile::tempdir().expect("tempdir").keep();
+            let effects = crate::state::with_state_root(&tmp, || {
+                let mut app = App::test_app(tmp.clone());
+                app.state.left.rows = ["alpha.rs", "beta.rs", "gamma.rs"]
+                    .iter()
+                    .map(|n| crate::app::RowData {
+                        path: tmp.join(n),
+                        display: (*n).to_string(),
+                        kind: crate::fs::EntryKind::File,
+                        deleted: false,
+                    })
+                    .collect();
+                // Geometry the renderer would have settled.
+                app.view.term_size = (80, 24);
+                app.view.cached_rows = cached_for(&app.state.left.rows);
+
+                let at = |kind, row, m| MouseEvent {
+                    kind,
+                    column: 0,
+                    row,
+                    modifiers: m,
+                };
+                app.begin_row_selection(
+                    at(MouseEventKind::Down(MouseButton::Left), 1, mods),
+                    Side::Left,
+                );
+                app.extend_row_selection(
+                    at(MouseEventKind::Drag(MouseButton::Left), 3, mods),
+                    Side::Left,
+                );
+                app.finish_row_selection(at(MouseEventKind::Up(MouseButton::Left), 3, mods))
+            });
+
+            let [Effect::CopyToClipboard { text, .. }] = effects.as_slice() else {
+                panic!("expected one clipboard copy, got {effects:?}");
+            };
+            let lines: Vec<&str> = text.lines().collect();
+            if want_paths {
+                assert!(
+                    lines.iter().all(|l| l.starts_with('/')),
+                    "Ctrl held must copy absolute paths, got {lines:?}"
+                );
+                assert!(lines.iter().any(|l| l.ends_with("alpha.rs")));
+            } else {
+                assert!(
+                    lines.iter().all(|l| !l.contains('/')),
+                    "without Ctrl must copy bare names, got {lines:?}"
+                );
+            }
+            assert!(lines.len() > 1, "a drag across rows selects a range");
+        }
+    }
+
+    /// The highlight survives the copy, so it's visible and a follow-up yank can
+    /// still find it — the same contract the pager's selection has.
+    #[test]
+    fn a_list_selection_persists_after_the_copy() {
+        use crate::app::state::Side;
+        use crossterm::event::KeyModifiers;
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        crate::state::with_state_root(&tmp, || {
+            let mut app = App::test_app(tmp.clone());
+            app.state.left.rows = (0..4)
+                .map(|i| crate::app::RowData {
+                    path: tmp.join(format!("f{i}")),
+                    display: format!("f{i}"),
+                    kind: crate::fs::EntryKind::File,
+                    deleted: false,
+                })
+                .collect();
+            app.view.term_size = (80, 24);
+            app.view.cached_rows = cached_for(&app.state.left.rows);
+            let at = |kind, row| MouseEvent {
+                kind,
+                column: 0,
+                row,
+                modifiers: KeyModifiers::NONE,
+            };
+            // Screen row 1 is the list's first row — row 0 is the status bar, which
+            // `row_at` correctly refuses.
+            app.begin_row_selection(at(MouseEventKind::Down(MouseButton::Left), 1), Side::Left);
+            app.extend_row_selection(at(MouseEventKind::Drag(MouseButton::Left), 3), Side::Left);
+            let _ = app.finish_row_selection(at(MouseEventKind::Up(MouseButton::Left), 3));
+
+            let sel = app
+                .view
+                .list_selection
+                .expect("highlight must survive the copy");
+            assert_eq!(sel.range(), (0, 2));
+            assert!(
+                app.view.mouse_selection.is_none(),
+                "the drag itself must end, even though the selection stays"
+            );
+        });
     }
 }

--- a/src/app/render/inner.rs
+++ b/src/app/render/inner.rs
@@ -345,6 +345,31 @@ impl App {
     /// single top row, per `compute_layout`'s `pane_pct >= 100` branch). Called
     /// by the default draw and — when a vsplit keeps the status row free above a
     /// column-scoped overlay — by the overlay / TopPane-pager branches.
+    /// The status line as plain text — what a click on the status bar copies.
+    ///
+    /// Builds the same `StatusBar` the renderer does, from the same accessors, so
+    /// the copy can't drift from what's on screen.
+    pub(in crate::app) fn status_bar_plain_text(&self) -> String {
+        let (path, suffix) = self.header_parts();
+        let project_label = self
+            .state
+            .project_home
+            .as_deref()
+            .map(path_basename_display);
+        let agent_info = self.active_agent_status();
+        StatusBar {
+            project_home: project_label.as_deref(),
+            session_name: self.state.session_name.as_deref(),
+            path: &path,
+            suffix: &suffix,
+            git_info: self.state.cur().git.info.as_deref(),
+            agent_info: agent_info.as_deref(),
+            theme: &self.view.theme,
+            plain_logo: false,
+        }
+        .plain_text()
+    }
+
     fn render_status_bar(&self, frame: &mut Frame, rect: ratatui::layout::Rect) {
         let prompt_row_occupied = matches!(self.state.mode, Mode::Prompting(_))
             || self.state.flash.is_some()
@@ -373,6 +398,16 @@ impl App {
         .render(frame, rect);
     }
 
+    /// The inclusive row range to highlight in `side`'s list, if a mouse row
+    /// selection is active there. `None` for the other column, so a selection in `a`
+    /// never paints in `b`.
+    fn list_selection_for(&self, side: state::Side) -> Option<(usize, usize)> {
+        self.view
+            .list_selection
+            .filter(|s| s.side == side)
+            .map(|s| s.range())
+    }
+
     /// Paint the left column's file list into `rect`. The bright/focused column
     /// only when the file-pane row owns the keyboard and the right column isn't
     /// the active one (the `ListView` fades on `!focused`); always bright with
@@ -392,6 +427,7 @@ impl App {
                 empty_marker: self.state.left.view == View::Dir,
                 focused: list_focused,
                 theme: &self.view.theme,
+                selection: self.list_selection_for(state::Side::Left),
             },
             rect,
         );
@@ -463,6 +499,7 @@ impl App {
                         empty_marker: right.view == View::Dir,
                         focused,
                         theme: &self.view.theme,
+                        selection: self.list_selection_for(state::Side::Right),
                     },
                     rect,
                 );

--- a/src/app/render/mod.rs
+++ b/src/app/render/mod.rs
@@ -741,6 +741,7 @@ fn stabilize_grid(
             empty_marker: commander.view == View::Dir,
             focused,
             theme,
+            selection: None,
         };
         commander.grid_dims = probe.grid(rect).dims();
         let old_vt = commander.cursor.view_top;
@@ -782,6 +783,7 @@ fn stabilize_grid(
                 empty_marker: commander.view == View::Dir,
                 focused,
                 theme,
+                selection: None,
             };
             commander.grid_dims = probe.grid(rect).dims();
             spyc_debug!(

--- a/src/ui/list_view.rs
+++ b/src/ui/list_view.rs
@@ -98,6 +98,13 @@ pub struct ListView<'a> {
     pub empty_marker: bool,
     pub focused: bool,
     pub theme: &'a Theme,
+    /// Inclusive row-index range of a mouse text selection, if any.
+    ///
+    /// Lives here rather than as a `Row` flag because `Row`s are cached against
+    /// `list_generation`: a per-row flag would need the generation bumped on every
+    /// drag motion, defeating the cache the field exists to protect. `cursor` is
+    /// styled the same way for the same reason.
+    pub selection: Option<(usize, usize)>,
 }
 
 /// Geometry of the rendered grid for the currently visible page.
@@ -161,6 +168,39 @@ const MARKER_W: u16 = 2;
 const MIN_NAME_WIDTH: u16 = 8;
 
 impl ListView<'_> {
+    /// Map a pointer position to the row index under it, or `None` when it names
+    /// no row (past the last entry, or in the gap between columns).
+    ///
+    /// Lives here, next to `grid` / `col_x_offsets` / `COL_GAP`, so the hit-test and
+    /// the renderer derive the grid the same way. The pager learned this the hard
+    /// way: a second, independent geometry derivation is how the highlight and the
+    /// copied text come to disagree about what was selected.
+    pub fn row_at(&self, area: Rect, col: u16, row: u16) -> Option<usize> {
+        if self.rows.is_empty()
+            || col < area.x
+            || row < area.y
+            || col >= area.x.saturating_add(area.width)
+            || row >= area.y.saturating_add(area.height)
+        {
+            return None;
+        }
+        let grid = self.grid(area);
+        let rel_x = col - area.x;
+        let rel_y = usize::from(row - area.y);
+        if rel_y >= usize::from(grid.rows) {
+            return None;
+        }
+        // Which on-screen column the pointer is in. The gap between columns belongs
+        // to neither, so a pointer there selects nothing rather than guessing.
+        let offsets = grid.col_x_offsets(COL_GAP);
+        let which = offsets
+            .iter()
+            .zip(grid.col_widths.iter())
+            .position(|(&x, &w)| rel_x >= x && rel_x < x.saturating_add(w))?;
+        let idx = self.view_top + which * usize::from(grid.rows) + rel_y;
+        (idx < self.rows.len()).then_some(idx)
+    }
+
     /// Compute the grid for the page that starts at `self.view_top`.
     pub fn grid(&self, area: Rect) -> Grid {
         let height = area.height.max(1) as usize;
@@ -293,7 +333,11 @@ impl Widget for ListView<'_> {
             };
 
             let name_style = row_style(row.kind, row.git_status, self.theme);
-            let highlighted = (start + i) == self.cursor;
+            let abs_idx = start + i;
+            let highlighted = abs_idx == self.cursor;
+            let selected = self
+                .selection
+                .is_some_and(|(lo, hi)| abs_idx >= lo && abs_idx <= hi);
 
             // Cursor row — force the bright bar bg + fg over both
             // marker cells and the filename. DIM doesn't apply to the
@@ -306,6 +350,12 @@ impl Widget for ListView<'_> {
             // The warning wins even when the row is also the cursor.
             let (cursor_bg, cursor_bold) = if row.pending_delete {
                 (Some(self.theme.delete_warning), Modifier::BOLD)
+            } else if selected && !highlighted {
+                // A selected row that isn't the cursor. Uses the dim cursor bg so a
+                // selection reads as a contiguous band with the cursor as its bright
+                // end — and so it stays distinct from the delete warning above it in
+                // this ladder, which must keep winning.
+                (Some(self.theme.cursor_bg_dim), Modifier::empty())
             } else if highlighted {
                 let bg = if self.focused {
                     self.theme.cursor_bg
@@ -463,6 +513,7 @@ mod tests {
             empty_marker: false,
             focused: true,
             theme: &theme,
+            selection: None,
         };
         lv.grid(Rect {
             x: 0,
@@ -560,6 +611,7 @@ mod tests {
                     empty_marker: true,
                     focused,
                     theme: &theme,
+                    selection: None,
                 };
                 f.render_widget(lv, area);
             })
@@ -659,6 +711,7 @@ mod tests {
                     empty_marker: true,
                     focused: true,
                     theme: &theme,
+                    selection: None,
                 };
                 f.render_widget(lv, Rect::new(0, 0, 30, 4));
             })
@@ -679,5 +732,99 @@ mod tests {
         for x in 12u16..30 {
             assert!(!crossed(x), "pad cell {x} must not be struck through");
         }
+    }
+}
+
+#[cfg(test)]
+mod row_at_tests {
+    use super::{ListView, Row};
+    use crate::fs::EntryKind;
+    use crate::ui::list_view::GitFileStatus;
+    use crate::ui::theme::Theme;
+    use ratatui::layout::Rect;
+
+    fn rows(n: usize) -> Vec<Row> {
+        (0..n)
+            .map(|i| Row {
+                display: format!("file{i}"),
+                kind: EntryKind::File,
+                picked: false,
+                taken: false,
+                deleted: false,
+                git_status: GitFileStatus::clean(),
+                pending_delete: false,
+            })
+            .collect()
+    }
+
+    fn lv<'a>(rows: &'a [Row], theme: &'a Theme, view_top: usize) -> ListView<'a> {
+        ListView {
+            rows,
+            cursor: 0,
+            view_top,
+            empty_marker: false,
+            focused: true,
+            theme,
+            selection: None,
+        }
+    }
+
+    /// The top-left cell of the area is the first visible row, and each screen row
+    /// down is the next entry.
+    #[test]
+    fn row_at_maps_screen_rows_to_entries() {
+        let (r, t) = (rows(6), Theme::default());
+        let area = Rect::new(0, 0, 40, 6);
+        let v = lv(&r, &t, 0);
+        assert_eq!(v.row_at(area, 0, 0), Some(0));
+        assert_eq!(v.row_at(area, 0, 3), Some(3));
+    }
+
+    /// Offsets follow `view_top`, so a scrolled list doesn't report stale indices.
+    #[test]
+    fn row_at_follows_view_top() {
+        let (r, t) = (rows(20), Theme::default());
+        let area = Rect::new(0, 0, 40, 5);
+        assert_eq!(lv(&r, &t, 5).row_at(area, 0, 0), Some(5));
+        assert_eq!(lv(&r, &t, 5).row_at(area, 0, 2), Some(7));
+    }
+
+    /// Past the last entry names no row, so a press below the listing can't anchor
+    /// a selection on a file the user didn't point at.
+    #[test]
+    fn row_at_returns_none_past_the_last_entry() {
+        let (r, t) = (rows(3), Theme::default());
+        let area = Rect::new(0, 0, 40, 10);
+        let v = lv(&r, &t, 0);
+        assert_eq!(v.row_at(area, 0, 3), None);
+        assert_eq!(v.row_at(area, 0, 9), None);
+    }
+
+    #[test]
+    fn row_at_returns_none_outside_the_area() {
+        let (r, t) = (rows(6), Theme::default());
+        let area = Rect::new(10, 5, 20, 4);
+        let v = lv(&r, &t, 0);
+        for (c, rw) in [(9, 5), (10, 4), (30, 5), (10, 9)] {
+            assert_eq!(v.row_at(area, c, rw), None, "({c},{rw})");
+        }
+        assert_eq!(v.row_at(area, 10, 5), Some(0), "the area's own origin");
+    }
+
+    /// A multi-column grid walks the listing column-major, matching how it's drawn —
+    /// so the second on-screen column continues the listing rather than restarting.
+    #[test]
+    fn row_at_resolves_the_second_column() {
+        let (r, t) = (rows(12), Theme::default());
+        // Wide + short forces more than one column.
+        let area = Rect::new(0, 0, 120, 4);
+        let v = lv(&r, &t, 0);
+        let grid = v.grid(area);
+        assert!(
+            grid.cols > 1,
+            "test needs a multi-column grid, got {grid:?}"
+        );
+        let x = grid.col_x_offsets(2)[1];
+        assert_eq!(v.row_at(area, x, 0), Some(usize::from(grid.rows)));
     }
 }

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -45,6 +45,32 @@ fn push_segment(spans: &mut Vec<Span>, text: &str, fg: Color, bg: Color, next_bg
 }
 
 impl StatusBar<'_> {
+    /// The status line's **content** as plain text, for a mouse copy.
+    ///
+    /// Joins the semantic segments and deliberately omits the powerline separators
+    /// and the logo: those are chrome, and a copy that included them would paste
+    /// Nerd-Font glyphs into a bug report. Same rule the pager's selection follows —
+    /// copy what the line says, not what draws it.
+    ///
+    /// Not derived from the rendered spans, because those are truncated to the
+    /// terminal width; the copy should carry the full path even when the bar
+    /// elided it.
+    pub fn plain_text(&self) -> String {
+        [
+            self.project_home,
+            self.session_name,
+            Some(self.path),
+            self.git_info,
+            self.agent_info,
+            (!self.suffix.is_empty()).then_some(self.suffix),
+        ]
+        .into_iter()
+        .flatten()
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join(" | ")
+    }
+
     #[allow(clippy::similar_names)]
     pub fn render(&self, frame: &mut Frame, area: Rect) {
         if self.theme.mono {


### PR DESCRIPTION
The remaining two surfaces of the selection spec — the pager landed in #227/#228. Selection now works in all three places spyc draws its own text.

## File list

A left press anchors a row selection and moves the cursor there; drag extends; release copies the selected rows' **names**, or their **absolute paths** when **Ctrl** was held at press. The highlight persists after the copy, matching the pager.

Ctrl and not Shift: Shift is the terminal's own selection-bypass modifier and is frequently consumed before spyc ever sees the event.

**Deliberately not the pick mechanism** (owner-confirmed: clipboard-only). Picks persist and drive file operations; a selection is transient and only feeds the clipboard. Keeping them separate is what stops a drag from silently changing what the next `R` / copy / move acts on.

Paths resolve from the **live** listing at release rather than being captured at press, so a selection can't paste stale paths across a refresh.

## Status line

A click copies it. That region owns no keyboard focus, so a click there couldn't previously mean anything — which is why it's a click rather than a drag, and why `Region::Status` comes out of the "chrome focuses nothing" test.

`StatusBar::plain_text` joins the semantic segments and omits the powerline separators and the logo: chrome, not content, the same rule the pager's selection follows. It's built from the segment **fields** rather than the rendered spans, so the copy carries the full path even when the bar elided it to fit.

## Two placement decisions worth keeping

- **`row_at` lives in `list_view.rs`**, beside `grid` / `col_x_offsets` / `COL_GAP`, so the hit-test and the renderer derive the grid identically. The pager learned this the hard way — a second, independent geometry derivation is how the highlight and the copied text come to disagree about what was selected.
- **The selection is a `ListView` field, not a `Row` flag.** `Row`s are cached against `list_generation`, so a per-row flag would need the generation bumped on every drag motion, defeating the cache it exists to protect. `cursor` is styled the same way, for the same reason.

## Verification

`make check` green (exit-code verified), 1738 tests pass.

New: `row_at` across view-top offset, past-the-last-entry, outside-the-area, and a **multi-column** grid (the second on-screen column must continue the listing, not restart); App-level tests that a drag copies names vs. Ctrl-held paths and that the highlight survives the copy; routing tests that the status click needs no focus and that a **covering pager still outranks** row selection.

Three existing routing tests asserted `FocusRegion` for a list or status press. Updated to the new contract rather than deleted, with the reason recorded in each — same as #229's reversal.

## Note for future worktrees

This branch initially came up missing all of #229: `git fetch origin main` updates `origin/main` but **not** the local `main` ref, and worktree creation branches off local `main`. Rebased onto `7b3a551` and verified both changesets are intact. Worth a `pull --ff-only` before creating a worktree.
