### PR TITLE
feat(mouse): drag to select text in a pane whose child ignores the mouse

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -201,7 +201,7 @@ without waiting for a real agent transition.
 
 ```toml
 [mouse]
-capture = false      # real mouse reporting (wheel + buttons). Default off.
+capture = true       # real mouse reporting (wheel + buttons). Default ON.
 scroll_lines = 1     # lines per wheel tick, for surfaces spyc scrolls itself
 pane_scroll_lines = 3 # lines per tick for a pane spyc drives with synthesized keys
 pane_scroll_view = "native" # native | off | spyc_history
@@ -234,7 +234,7 @@ arrow keys (which a focused pane receives as history navigation).
 > |---|---|
 > | **Bypass modifier** (per-drag) | Hold **Shift** — Ghostty, WezTerm, kitty, Alacritty, most others. **Option** or **Fn** on iTerm2. |
 > | **`:mouse off`** (per-session) | Immediate, no restart, no file edit. `:mouse on` to re-enable, `:mouse auto` to follow the config again. Survives a config reload — it is scoped to the session, not written to a file. |
-> | **`capture = false`** (permanent) | The default. |
+> | **`capture = false`** (permanent) | Turn it off entirely — the pre-#226 behavior. |
 >
 > spyc's mouse-free yank paths: **`^a u`** quick-select (URLs / paths / SHAs) and
 > **`y`** in the pager.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -181,6 +181,7 @@ without waiting for a real agent transition.
 [mouse]
 capture = false      # real mouse reporting (wheel + buttons). Default off.
 scroll_lines = 1     # lines per wheel tick, for surfaces spyc scrolls itself
+pane_scroll_lines = 3 # lines per tick for a pane spyc drives with synthesized keys
 ```
 
 `capture` asks the terminal for real mouse reporting so spyc can scroll whatever

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -96,6 +96,28 @@ looking intentional rather than broken.
 
 ---
 
+## `[clipboard]`
+
+```toml
+[clipboard]
+via = "auto"   # auto | system | osc52 | both
+```
+
+Where a yank lands. `auto` uses an **OSC-52 terminal escape when spyc is over SSH**
+and the local helper (`pbcopy` / `wl-copy` / `xclip`) otherwise.
+
+This matters more than it sounds: the local helpers set the clipboard of the machine
+spyc *runs on*. Over SSH that's the server, so a yank silently succeeds somewhere you
+can never paste from. OSC 52 travels back up the same connection the UI is drawn on,
+so it reaches the terminal you're typing at.
+
+Locally it stays helper-first deliberately — OSC 52 is write-only with no reply, so
+spyc can't confirm the terminal honored it, and some terminals disable it on purpose
+(a remote host writing your clipboard is a real risk). Inside tmux it needs
+`set -g set-clipboard on`; spyc DCS-wraps the escape so tmux forwards it to the outer
+terminal. A selection too large for the escape falls back to the helper rather than
+risk a terminal truncating it silently.
+
 ## Notifications — `[notify]`
 
 The "which agent needs me" signal. When an agent pane changes status, spyc fires

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -204,7 +204,22 @@ without waiting for a real agent transition.
 capture = false      # real mouse reporting (wheel + buttons). Default off.
 scroll_lines = 1     # lines per wheel tick, for surfaces spyc scrolls itself
 pane_scroll_lines = 3 # lines per tick for a pane spyc drives with synthesized keys
+pane_scroll_view = "native" # native | off | spyc_history
 ```
+
+`pane_scroll_view` decides what a wheel tick does the FIRST time it hits an agent
+pane whose own scrollback view spyc can drive but that view isn't open yet — today,
+codex's `^T` transcript. `native` (default) opens it and scrolls; `off` leaves it
+closed and only scrolls if it happens to already be open; `spyc_history` opens
+spyc's own `^a v` scrollback pager instead. Doesn't affect an already-open view
+(always scrolled) or an agent with no such view (agy scrolls its live content
+directly via Shift+Arrow, with nothing to open).
+
+A sustained same-direction wheel gesture — past ~1 second — escalates from the
+per-line step to a page-sized one, for an agent with a verified fast key (codex's
+`^T` documents `pgup/pgdn to page` in its own footer). `pane_scroll_lines` is the
+line-scroll floor under that escalation, and the only knob agy uses (it has no
+page-sized equivalent).
 
 `capture` asks the terminal for real mouse reporting so spyc can scroll whatever
 is under the pointer, instead of DEC 1007's trick of translating the wheel into

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -569,9 +569,12 @@ end).
   **claude** requests mouse reporting, so the event is forwarded and claude
   scrolls itself; **agy** ignores mouse reports but scrolls on Shift+Arrow, so
   spyc sends those instead; **codex** discards mouse events and its main chat view
-  doesn't scroll, so the wheel sends plain arrows — those scroll its `^T`
-  transcript overlay, and outside it they only move the draft cursor (codex keeps
-  history recall on `^R`, so the wheel can't recall a past prompt).
+  doesn't scroll, so the wheel drives its `^T` transcript overlay instead — opening
+  it on the first tick (`[mouse] pane_scroll_view`, configurable to stay closed or
+  to use spyc's own `^a v` history instead), then scrolling by line, escalating to
+  a page jump under a sustained gesture. Outside the transcript, the same keys only
+  move the draft cursor (codex keeps history recall on `^R`, so the wheel can't
+  recall a past prompt).
 - **`:limit <glob>`** — temporary filter (e.g. `:limit *.rs`)
 - **`:limit !`** — show only picked files
 - **`:limit git`** / **`:limit g`** — show only files in `git status`

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -545,9 +545,9 @@ end).
   agent), middle-click pastes, right-click opens the leader menu. **Costs native click-drag text
   selection while on** (hold Shift to select anyway — Option/Fn on iTerm2);
   `:mouse off` gives it back immediately, no restart, and survives a config
-  reload (`:mouse auto` returns to following the config). Default off (`[mouse]
-  capture`). `^a u` quick-select and `y` in the pager are the mouse-free yank
-  paths.
+  reload (`:mouse auto` returns to following the config). Default **on**
+  (`[mouse] capture`; `capture = false` turns it off permanently). `^a u`
+  quick-select and `y` in the pager are the mouse-free yank paths.
   **Drag in a pane whose agent ignores the mouse to select its text** (codex —
   including inside its `^T` transcript — and plain shells); release copies it. A
   child that speaks mouse (claude, vim) keeps doing its own selection instead. The
@@ -572,9 +572,10 @@ end).
   doesn't scroll, so the wheel drives its `^T` transcript overlay instead — opening
   it on the first tick (`[mouse] pane_scroll_view`, configurable to stay closed or
   to use spyc's own `^a v` history instead), then scrolling by line, escalating to
-  a page jump under a sustained gesture. Outside the transcript, the same keys only
-  move the draft cursor (codex keeps history recall on `^R`, so the wheel can't
-  recall a past prompt).
+  a page jump under a sustained gesture. Scrolling down while already at the
+  bottom exits the transcript (`q`) instead of no-op'ing. Outside the transcript,
+  the same keys only move the draft cursor (codex keeps history recall on `^R`,
+  so the wheel can't recall a past prompt).
 - **`:limit <glob>`** — temporary filter (e.g. `:limit *.rs`)
 - **`:limit !`** — show only picked files
 - **`:limit git`** / **`:limit g`** — show only files in `git status`

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -548,6 +548,10 @@ end).
   reload (`:mouse auto` returns to following the config). Default off (`[mouse]
   capture`). `^a u` quick-select and `y` in the pager are the mouse-free yank
   paths.
+  **Drag in a pane whose agent ignores the mouse to select its text** (codex —
+  including inside its `^T` transcript — and plain shells); release copies it. A
+  child that speaks mouse (claude, vim) keeps doing its own selection instead. The
+  highlight clears when the child paints, since it's anchored to the visible grid.
   **Drag in the file list to select rows; release copies their names** — hold
   **Ctrl** while pressing to copy absolute paths instead. The highlight stays up
   after the copy. Distinct from picks: a drag never changes what the next file

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -555,8 +555,11 @@ end).
   **Drag in the file list to select rows; release copies their names** — hold
   **Ctrl** while pressing to copy absolute paths instead. The highlight stays up
   after the copy. Distinct from picks: a drag never changes what the next file
-  operation acts on. **Click the status line to copy it** (the text, not the
-  powerline separators or the logo).
+  operation acts on.
+  **Drag across the status line or the divider/tab line to select part of it** —
+  release copies exactly those columns, so you can take just a branch name, an
+  agent session id, or a custom tab name without the rest of the line. A click
+  that doesn't move copies nothing.
   **Drag in a pager to select text; release copies it** and the pager title
   reports the line count. Works the same full-screen or popped-up, and copies the
   content only — never the line-number gutter, the whitespace/line-break markers,

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -222,11 +222,46 @@ pub trait AgentProfile: Sync {
     fn wheel_scroll(&self) -> Option<WheelScroll> {
         None
     }
+
+    /// Screen-scrape marker confirming this agent's OWN scrollback view is
+    /// currently open — checked against [`crate::pane::Pane::visible_lines`]
+    /// before deciding to auto-open it or escalate to [`Self::fast_wheel_scroll`].
+    /// `None` for an agent with no such view (agy's Shift+Arrow scrolls the live
+    /// content directly; there's nothing to open).
+    ///
+    /// A plain substring, not the `Region`/`Matcher` machinery in
+    /// `detect_rules` — that module's rules are specifically about
+    /// self-report-fallback semantics (`AgentActivity`), a different question
+    /// ("is this agent blocked?") from this one ("is this VIEW open?").
+    fn transcript_open_marker(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// The key that OPENS this agent's own scrollback view — sent once, only
+    /// while [`Self::transcript_open_marker`] confirms it's closed. `None` when
+    /// there's nothing for spyc to toggle. Not necessarily the same key that
+    /// CLOSES it, though today it is (codex's `^T` is a genuine toggle).
+    fn transcript_toggle_key(
+        &self,
+    ) -> Option<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)> {
+        None
+    }
+
+    /// The keys that PAGE (rather than line-scroll) this agent's own view —
+    /// substituted for [`Self::wheel_scroll`]'s keys once a sustained same-
+    /// direction wheel gesture has run long enough to justify a bigger jump.
+    /// `None` when unverified: an agent's own line-scroll and page keys can
+    /// differ in which contexts they're safe (see `CodexProfile`'s doc), so
+    /// this is a distinct, separately-verified opt-in rather than assumed from
+    /// `wheel_scroll` existing.
+    fn fast_wheel_scroll(&self) -> Option<WheelScroll> {
+        None
+    }
 }
 
 /// The keys that scroll a non-mouse agent's own view one line, sent by spyc in
 /// place of a wheel event it cannot forward. See
-/// [`AgentProfile::wheel_scroll`].
+/// [`AgentProfile::wheel_scroll`] / [`AgentProfile::fast_wheel_scroll`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WheelScroll {
     pub up: (crossterm::event::KeyCode, crossterm::event::KeyModifiers),
@@ -356,6 +391,45 @@ impl AgentProfile for CodexProfile {
         Some(WheelScroll {
             up: (KeyCode::Up, M::NONE),
             down: (KeyCode::Down, M::NONE),
+        })
+    }
+
+    /// Confirmed by a live pty capture: codex's `^T` transcript renders a
+    /// tiled banner reading `T R A N S C R I P T` across its top row (a
+    /// letter-spaced watermark, not a plain title), which does not appear
+    /// anywhere in the composer/chat view. Checked as a plain substring — the
+    /// banner repeats across the full row width, so even a narrow terminal
+    /// shows an occurrence.
+    fn transcript_open_marker(&self) -> Option<&'static str> {
+        Some("T R A N S C R I P T")
+    }
+
+    /// `^T`: bound to BOTH `global.open_transcript` and, inside the pager,
+    /// `pager.close_transcript` — a genuine same-key toggle, confirmed in
+    /// `codex-rs/tui/src/keymap.rs`.
+    fn transcript_toggle_key(
+        &self,
+    ) -> Option<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)> {
+        use crossterm::event::{KeyCode, KeyModifiers as M};
+        Some((KeyCode::Char('t'), M::CONTROL))
+    }
+
+    /// codex's own footer, visible while the transcript is open, spells out
+    /// `pgup/pgdn to page` — these are the agent's OWN documented fast-scroll
+    /// keys for this exact view (`pager.page_up` / `pager.page_down` in
+    /// `codex-rs/tui/src/keymap.rs`), not a guess at what might work faster.
+    ///
+    /// Confirmed harmless outside the transcript too: a live probe typed a
+    /// two-line draft, sent PageUp/PageDown four times, and the draft was
+    /// still sitting there untouched — codex's `list` keymap namespace also
+    /// binds PageUp/PageDown (for slash-command / picker menus), but that
+    /// namespace isn't active in the plain composer, and `transcript_open_marker`
+    /// gates this to the transcript specifically regardless.
+    fn fast_wheel_scroll(&self) -> Option<WheelScroll> {
+        use crossterm::event::{KeyCode, KeyModifiers as M};
+        Some(WheelScroll {
+            up: (KeyCode::PageUp, M::NONE),
+            down: (KeyCode::PageDown, M::NONE),
         })
     }
     fn resolve_resume_target(
@@ -690,6 +764,38 @@ mod tests {
 
         // A plain process is not an agent: its scrollback belongs to spyc.
         assert!(detect("bash -lc 'make'").wheel_scroll().is_none());
+    }
+
+    /// codex's toggleable `^T` view — the marker, the toggle, and the fast key —
+    /// measured against a live pty capture, not assumed.
+    #[test]
+    fn codex_transcript_view_is_fully_specified() {
+        let enc = |(code, mods)| {
+            crate::pane::input::encode_key(crossterm::event::KeyEvent::new(code, mods))
+        };
+        let codex = detect("codex");
+
+        // The tiled banner a live capture showed across row 0 of the open `^T`
+        // view. Doesn't appear anywhere in the composer/chat view.
+        assert_eq!(codex.transcript_open_marker(), Some("T R A N S C R I P T"));
+
+        // ^T: bound to BOTH global.open_transcript and pager.close_transcript in
+        // codex's own keymap.rs — a genuine same-key toggle.
+        let (code, mods) = codex.transcript_toggle_key().expect("codex has a toggle");
+        assert_eq!(enc((code, mods)), b"\x14"); // Ctrl+T
+
+        // codex's own footer, visible only while `^T` is open, spells out
+        // "pgup/pgdn to page" — its own documented fast-scroll keys for this view.
+        let fast = codex.fast_wheel_scroll().expect("codex has a fast scroll");
+        assert_eq!(enc(fast.up), b"\x1b[5~"); // PageUp
+        assert_eq!(enc(fast.down), b"\x1b[6~"); // PageDown
+
+        // agy has no dedicated toggleable view — its Shift+Arrow scrolls the live
+        // content directly, with nothing to open or page through.
+        let agy = detect("agy");
+        assert!(agy.transcript_open_marker().is_none());
+        assert!(agy.transcript_toggle_key().is_none());
+        assert!(agy.fast_wheel_scroll().is_none());
     }
 
     #[test]

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -257,6 +257,32 @@ pub trait AgentProfile: Sync {
     fn fast_wheel_scroll(&self) -> Option<WheelScroll> {
         None
     }
+
+    /// Whether this agent's own scrollback view, if open, is confirmed at (or
+    /// past) its bottom — checked before closing it on a further "scroll down"
+    /// tick that has nowhere left to go. `visible_lines` is the pane's CURRENT
+    /// viewport (same source `transcript_open_marker` is checked against).
+    ///
+    /// Default `false` — never confirmed, so spyc never closes speculatively.
+    /// Each agent's "nothing more to scroll" indicator (if it has one at all)
+    /// is specific enough to need its own verified reading rather than a
+    /// shared "look for 100%" heuristic that might not mean the same thing
+    /// elsewhere.
+    fn transcript_at_bottom(&self, visible_lines: &[String]) -> bool {
+        let _ = visible_lines;
+        false
+    }
+
+    /// The key that CLOSES this agent's own scrollback view — distinct from
+    /// [`Self::transcript_toggle_key`] (which also OPENS it): closing via a
+    /// dedicated key rather than the toggle means a stale "still open" read
+    /// during the close settle window sends the *same* safe key again, rather
+    /// than the toggle risking a reopen. `None` when there's nothing to close.
+    fn transcript_close_key(
+        &self,
+    ) -> Option<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)> {
+        None
+    }
 }
 
 /// The keys that scroll a non-mouse agent's own view one line, sent by spyc in
@@ -431,6 +457,45 @@ impl AgentProfile for CodexProfile {
             up: (KeyCode::PageUp, M::NONE),
             down: (KeyCode::PageDown, M::NONE),
         })
+    }
+
+    /// Confirmed against `codex-rs/tui/src/pager_overlay.rs`: `percent` is
+    /// computed directly from `scroll_offset` clamped to `max_scroll`
+    /// (`total_len - viewport_height`), so 100% means the view is genuinely AT
+    /// its bottom, not merely close to it — a further scroll-down tick has
+    /// nowhere left to go. The percentage is rendered as ` NNN% ` (both
+    /// spaces literal) right-aligned on the dash-filled separator row directly
+    /// above the footer hints.
+    ///
+    /// Anchored to that row specifically — the LAST visible line containing
+    /// `─` — rather than a blind whole-screen substring search: bare "100%"
+    /// could appear as ordinary transcript prose (a coding assistant's reply
+    /// mentioning test coverage, say), but " 100% " embedded in a row that's
+    /// otherwise almost entirely dashes is not a coincidence.
+    ///
+    /// Also correctly reads "unknown" (via no line matching): codex hides this
+    /// indicator entirely while more history remains unloaded
+    /// (`scroll_percentage_visible = !state.has_unloaded_history()`), which is
+    /// exactly the case where "100%" would be misleading — there's more below
+    /// what's loaded. No matching row falls through to `false` (never close),
+    /// which is the same safe default this method's whole design commits to.
+    fn transcript_at_bottom(&self, visible_lines: &[String]) -> bool {
+        visible_lines
+            .iter()
+            .rev()
+            .find(|l| l.contains('─'))
+            .is_some_and(|l| l.contains(" 100% "))
+    }
+
+    /// `q`: codex's OWN footer hint reads "q to quit" — the dedicated close
+    /// action (`pager.close`), distinct from the `^T` toggle used to open. See
+    /// `AgentProfile::transcript_close_key`'s doc for why closing via a
+    /// dedicated key rather than re-sending the toggle matters here.
+    fn transcript_close_key(
+        &self,
+    ) -> Option<(crossterm::event::KeyCode, crossterm::event::KeyModifiers)> {
+        use crossterm::event::{KeyCode, KeyModifiers as M};
+        Some((KeyCode::Char('q'), M::NONE))
     }
     fn resolve_resume_target(
         &self,
@@ -796,6 +861,54 @@ mod tests {
         assert!(agy.transcript_open_marker().is_none());
         assert!(agy.transcript_toggle_key().is_none());
         assert!(agy.fast_wheel_scroll().is_none());
+        assert!(agy.transcript_close_key().is_none());
+        assert!(!agy.transcript_at_bottom(&["100%".to_string()]));
+    }
+
+    /// `transcript_at_bottom`: anchored to the dash-filled separator row, not a
+    /// blind whole-screen search — measured against `pager_overlay.rs`'s
+    /// literal `format!(" {percent}% ")`.
+    #[test]
+    fn codex_at_bottom_is_anchored_to_the_separator_row() {
+        let codex = detect("codex");
+
+        let open_at_bottom = vec![
+            "some reply text".to_string(),
+            "─────────────────────────────────────────── 100% ─".to_string(),
+            " ↑/↓ to scroll   pgup/pgdn to page   home/end to jump".to_string(),
+            " q to quit   esc to edit prev".to_string(),
+        ];
+        assert!(codex.transcript_at_bottom(&open_at_bottom));
+
+        let open_not_at_bottom = vec![
+            "some reply text".to_string(),
+            "─────────────────────────────────────────────── 42% ─".to_string(),
+            " ↑/↓ to scroll   pgup/pgdn to page   home/end to jump".to_string(),
+            " q to quit   esc to edit prev".to_string(),
+        ];
+        assert!(!codex.transcript_at_bottom(&open_not_at_bottom));
+
+        // codex hides the indicator entirely while more history is unloaded —
+        // no matching row must read as "unknown", never as "at bottom".
+        let indicator_hidden = vec![
+            "some reply text".to_string(),
+            "───────────────────────────────────────────────────".to_string(),
+            " ↑/↓ to scroll   pgup/pgdn to page   home/end to jump".to_string(),
+        ];
+        assert!(!codex.transcript_at_bottom(&indicator_hidden));
+
+        // Ordinary transcript prose that happens to mention a percentage must
+        // NOT be mistaken for the indicator — it isn't on a dash-filled row.
+        let prose_mentions_percent = vec![
+            "test coverage is now 100% across the module".to_string(),
+            "─────────────────────────────────────────────── 42% ─".to_string(),
+        ];
+        assert!(!codex.transcript_at_bottom(&prose_mentions_percent));
+
+        assert_eq!(
+            codex.transcript_close_key().unwrap().0,
+            crossterm::event::KeyCode::Char('q')
+        );
     }
 
     #[test]

--- a/src/app/clipboard.rs
+++ b/src/app/clipboard.rs
@@ -385,3 +385,111 @@ mod tests {
         }
     }
 }
+
+/// Which delivery mechanisms a copy should use, given `[clipboard] via` and whether
+/// spyc is running over SSH. Returns `(local_helper, osc52)`.
+///
+/// Pure, and the exact counterpart of `agent_status::desktop_delivery` — the same
+/// question ("does this belong on the client or the host?") with the same answer
+/// shape, so the two can be reasoned about together.
+///
+/// `Auto` is the whole point: `pbcopy`/`xclip` set the clipboard of the machine spyc
+/// runs on, which over SSH is the *server* — text the user can never paste. OSC 52
+/// travels back up the connection to the terminal they're actually typing at.
+pub(super) const fn clipboard_delivery(
+    via: crate::config::ClipboardVia,
+    is_ssh: bool,
+) -> (bool, bool) {
+    use crate::config::ClipboardVia as V;
+    match via {
+        // Over SSH the local helper is worse than useless (it silently succeeds on
+        // the wrong machine), so Auto swaps to the escape rather than adding it.
+        V::Auto => {
+            if is_ssh {
+                (false, true)
+            } else {
+                (true, false)
+            }
+        }
+        V::System => (true, false),
+        V::Osc52 => (false, true),
+        V::Both => (true, true),
+    }
+}
+
+impl super::App {
+    /// Deliver `text` to the clipboard per `[clipboard] via`.
+    ///
+    /// Succeeds if ANY enabled mechanism succeeded — with `Both`, a terminal that
+    /// ignores OSC 52 shouldn't make a working local copy look like a failure. The
+    /// error carries every attempt's reason, since "yank failed" with no cause is
+    /// the report that wastes an afternoon.
+    ///
+    /// OSC 52 is attempted first under `Both`: it can fail *knowably* (payload over
+    /// the size limit), and a real error beats the local helper's silent
+    /// success-on-the-wrong-machine.
+    pub(super) fn deliver_clipboard(&self, text: &str) -> Result<(), String> {
+        let (local, osc52) = clipboard_delivery(self.state.config.clipboard.via, self.view.is_ssh);
+        let mut errs: Vec<String> = Vec::new();
+        let mut ok = false;
+        if osc52 {
+            match crate::clipboard::copy_osc52(text) {
+                Ok(()) => ok = true,
+                Err(e) => errs.push(e),
+            }
+        }
+        if local {
+            match crate::clipboard::copy(text) {
+                Ok(()) => ok = true,
+                Err(e) => errs.push(format!("{e:#}")),
+            }
+        }
+        if ok {
+            return Ok(());
+        }
+        Err(if errs.is_empty() {
+            "no clipboard mechanism enabled ([clipboard] via)".to_string()
+        } else {
+            errs.join("; ")
+        })
+    }
+}
+
+#[cfg(test)]
+mod delivery_tests {
+    use super::clipboard_delivery;
+    use crate::config::ClipboardVia as V;
+
+    /// The headline: over SSH, `Auto` must NOT use the local helper. `pbcopy` on the
+    /// server succeeds and puts the text somewhere the user can never paste from,
+    /// which is worse than an error.
+    #[test]
+    fn auto_routes_to_the_client_terminal_over_ssh() {
+        assert_eq!(clipboard_delivery(V::Auto, true), (false, true));
+    }
+
+    /// Locally, `Auto` stays on the helper: OSC 52 is unverifiable (no reply) and
+    /// some terminals disable it, and there's no SSH problem to trade that for.
+    #[test]
+    fn auto_stays_local_without_ssh() {
+        assert_eq!(clipboard_delivery(V::Auto, false), (true, false));
+    }
+
+    /// The explicit modes ignore SSH entirely — that's what makes them an override.
+    #[test]
+    fn explicit_modes_do_not_depend_on_ssh() {
+        for ssh in [false, true] {
+            assert_eq!(
+                clipboard_delivery(V::System, ssh),
+                (true, false),
+                "ssh={ssh}"
+            );
+            assert_eq!(
+                clipboard_delivery(V::Osc52, ssh),
+                (false, true),
+                "ssh={ssh}"
+            );
+            assert_eq!(clipboard_delivery(V::Both, ssh), (true, true), "ssh={ssh}");
+        }
+    }
+}

--- a/src/app/codex_pin.rs
+++ b/src/app/codex_pin.rs
@@ -62,6 +62,19 @@ fn assign_codex_sessions(
     out
 }
 
+/// Whether a codex tab is recent enough to keep trying to pin: within
+/// [`PIN_WINDOW`] of its last output, or of its spawn if it hasn't emitted yet.
+///
+/// Pure so the spawn-vs-output distinction is testable without a live pane — it is
+/// the fix for the wrong-transcript bug and deserves to be pinned by a test rather
+/// than inferred from a timer.
+fn codex_pin_window_open(
+    last_output_at: Option<std::time::Instant>,
+    spawn_at: std::time::Instant,
+) -> bool {
+    last_output_at.unwrap_or(spawn_at).elapsed() < PIN_WINDOW
+}
+
 /// Same-directory check tolerating the macOS `/private` symlink, in either
 /// direction (the rollout's `session_meta` cwd vs the tab's canonicalized cwd).
 fn cwd_eq(session_cwd: &str, tab_cwd: &str) -> bool {
@@ -71,14 +84,27 @@ fn cwd_eq(session_cwd: &str, tab_cwd: &str) -> bool {
 }
 
 impl App {
-    /// Whether any codex tab is still unpinned and recently spawned — i.e. worth
-    /// a scan. Past [`PIN_WINDOW`] we stop (the resolver heuristic takes over),
-    /// so the scan loop naturally quiesces once codex has written its rollout.
+    /// Whether any codex tab is still unpinned and recently ACTIVE — i.e. worth a
+    /// scan.
+    ///
+    /// The window runs from the pane's last output, not its spawn, and that
+    /// distinction is the whole bug it fixes. codex writes its rollout when it first
+    /// does something, not when it starts; a spawn-anchored window closed 30s after
+    /// launch, so a tab you opened and read for a minute before typing was never
+    /// pinned — permanently. `^a v` then fell through to the mtime heuristic, which
+    /// hands every pane in a cwd to whichever codex session is *busiest*, including
+    /// another spyc instance's. That is exactly how it came to show the wrong
+    /// conversation.
+    ///
+    /// Still quiesces, on two independent conditions: a pinned tab drops out
+    /// immediately (`codex_session_id` is set), and an idle one drops out
+    /// [`PIN_WINDOW`] after it stops emitting. So a codex that never writes a
+    /// rollout costs one scan per output burst while it is active, not forever.
     fn needs_codex_pin(&self) -> bool {
         self.runtime.pane_tabs.as_ref().is_some_and(|tabs| {
             tabs.tabs().iter().any(|e| {
                 e.info.codex_session_id.is_none()
-                    && e.info.spawn_at.elapsed() < PIN_WINDOW
+                    && codex_pin_window_open(e.info.last_output_at, e.info.spawn_at)
                     && crate::agent::detect(&e.info.command).kind() == AgentKind::Codex
             })
         })
@@ -232,5 +258,48 @@ mod tests {
         assert!(cwd_eq("/private/var/x", "/var/x"));
         assert!(cwd_eq("/var/x", "/private/var/x"));
         assert!(!cwd_eq("/a", "/b"));
+    }
+    /// **The wrong-transcript bug (#230).** codex writes its rollout when it first
+    /// does something, not at spawn. A window anchored to spawn therefore closed on
+    /// a tab you opened and read for a while before typing — leaving it permanently
+    /// unpinned, so `^a v` fell through to the mtime heuristic and showed whichever
+    /// codex session was busiest (possibly another spyc instance's).
+    #[test]
+    fn the_pin_window_follows_output_not_spawn() {
+        use std::time::{Duration, Instant};
+        // `checked_sub`: an `Instant` can sit near the monotonic clock's origin on a
+        // freshly booted machine, where subtracting would underflow.
+        let long_ago = Instant::now()
+            .checked_sub(PIN_WINDOW + Duration::from_secs(5))
+            .expect("monotonic clock is past PIN_WINDOW in any real run");
+
+        // Spawned well outside the window and never emitted: nothing to pin against
+        // yet, and no reason to keep scanning.
+        assert!(
+            !codex_pin_window_open(None, long_ago),
+            "an idle, never-active tab should not hold the scan open"
+        );
+
+        // Same old spawn, but it just emitted — its rollout exists NOW, which is
+        // precisely when a pin becomes possible. The old spawn-anchored check gave
+        // up here, which is the bug.
+        assert!(
+            codex_pin_window_open(Some(Instant::now()), long_ago),
+            "recent output must re-open the window regardless of spawn age"
+        );
+
+        // Output that has itself gone stale closes it again, so the scan quiesces
+        // instead of running forever against a codex that never writes a rollout.
+        let a_window_ago = Instant::now()
+            .checked_sub(PIN_WINDOW)
+            .expect("monotonic clock is past PIN_WINDOW in any real run");
+        assert!(!codex_pin_window_open(Some(long_ago), a_window_ago));
+    }
+
+    /// A freshly spawned tab that hasn't emitted yet is still worth scanning — the
+    /// common case, and the one the original window was written for.
+    #[test]
+    fn a_fresh_tab_is_scannable_before_any_output() {
+        assert!(codex_pin_window_open(None, std::time::Instant::now()));
     }
 }

--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -352,8 +352,9 @@ pub enum ClipMsg {
     /// `"yanked prompt: {preview}{…}"` — preview = `text.chars().take(60)`,
     /// `…` iff `text.len() > 60` (byte length).
     Prompt,
-    /// `"copied the status line"` — a click on the status bar. Carries no count:
-    /// it is always exactly one line, so a number would be noise.
+    /// `"copied: {preview}{…}"` — a drag-selected substring of a single-line chrome
+    /// surface (status bar, pane divider). Echoes what was taken, because the whole
+    /// point is picking one item out of the line and the user should see which.
     StatusLine,
     /// `"copied {count} name(s)"` / `"copied {count} path(s)"` — a file-list row
     /// selection. `count` is carried because a name may contain a newline, so it
@@ -374,7 +375,11 @@ impl ClipMsg {
                 format!("yanked path: {preview}{ellipsis}")
             }
             Self::MultiPath { count } => format!("yanked {count} paths"),
-            Self::StatusLine => "copied the status line".to_string(),
+            Self::StatusLine => {
+                let preview: String = text.chars().take(60).collect();
+                let ellipsis = if text.chars().count() > 60 { "…" } else { "" };
+                format!("copied: {preview}{ellipsis}")
+            }
             Self::ListNames { count, paths } => {
                 let unit = if *paths { "path" } else { "name" };
                 format!(

--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -472,8 +472,12 @@ impl App {
                 // and the loop survives (unlike the former inline sites,
                 // which were not in `?` scope, this arm must not abort the
                 // run loop on a transient backend failure).
-                Effect::CopyToClipboard { text, ok } => match crate::clipboard::copy(&text) {
+                Effect::CopyToClipboard { text, ok } => match self.deliver_clipboard(&text) {
                     Ok(()) => self.state.flash_info(ok.success(&text)),
+                    // `{e:#}` even though `deliver_clipboard` returns a String: it is
+                    // a no-op for Display, and the guard that requires it here is
+                    // worth more than the one saved character. `deliver_clipboard`
+                    // has already rendered each backend's own chain with `{e:#}`.
                     Err(e) => self.state.flash_error(format!("yank failed: {e:#}")),
                 },
                 // A-class: copy + flash the ACTIVE PAGER's title (not the status
@@ -481,7 +485,7 @@ impl App {
                 // looking — the former inline `view.flash` behavior, now after a
                 // copy that runs in the executor.
                 Effect::CopyToPagerClipboard { text, ok_msg } => {
-                    let msg = match crate::clipboard::copy(&text) {
+                    let msg = match self.deliver_clipboard(&text) {
                         Ok(()) => ok_msg,
                         Err(e) => format!("yank failed: {e}"),
                     };

--- a/src/app/key_dispatch/mod.rs
+++ b/src/app/key_dispatch/mod.rs
@@ -123,6 +123,7 @@ impl App {
         // modal by request (vim-consistent), so `j`/`k` extend it and `Esc` cancels.
         self.view.list_selection = None;
         self.view.pane_selection = None;
+        self.view.chrome_selection = None;
 
         // Per-key dispatch trace, opt-in via `--key-trace` / SPYC_KEY_TRACE.
         // Captures the input as it arrives so a user reproducing an

--- a/src/app/key_dispatch/mod.rs
+++ b/src/app/key_dispatch/mod.rs
@@ -112,6 +112,18 @@ const fn capture_key_action(key: KeyEvent) -> CaptureKeyAction {
 
 impl App {
     pub fn handle_key(&mut self, key: KeyEvent) -> Result<Vec<Effect>> {
+        // A mouse text selection is a transient, pointer-made thing: the next
+        // keyboard action retires it, the way a terminal's own selection clears when
+        // you type. Both of these hold POSITIONS (list row indices, pane screen
+        // cells) rather than content, so leaving one up after the content moves
+        // highlights whatever now occupies those positions — a stale band on an
+        // unrelated file after a chdir, which is how this was reported.
+        //
+        // The pager's `visual` selection is deliberately NOT cleared here: it is
+        // modal by request (vim-consistent), so `j`/`k` extend it and `Esc` cancels.
+        self.view.list_selection = None;
+        self.view.pane_selection = None;
+
         // Per-key dispatch trace, opt-in via `--key-trace` / SPYC_KEY_TRACE.
         // Captures the input as it arrives so a user reproducing an
         // "input doesn't work" issue can ship a log. We re-trace the

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -219,74 +219,6 @@ pub struct FrameLayout {
     vdivider: Option<ratatui::layout::Rect>,
 }
 
-/// The surface an in-flight mouse drag belongs to. See
-/// [`ViewState::mouse_selection`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MouseDragTarget {
-    /// A pager's charwise text selection, in this slot.
-    Pager(crate::app::pager_handler::PagerSlot),
-    /// A file-list row selection, in this column.
-    List(state::Side),
-    /// A spyc-side text selection over the pty pane's visible grid.
-    Pane,
-    /// A charwise selection over a single-line chrome surface.
-    Chrome,
-}
-
-/// A file-list row selection.
-///
-/// `anchor`/`focus` rather than a sorted range so a backwards drag keeps its
-/// direction, and so extending never has to re-derive which end the user started
-/// from. Row *indices*, not paths: the copy resolves paths at release time from the
-/// live listing, so a selection can't outlive a refresh with stale paths.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ListSelection {
-    pub side: state::Side,
-    pub anchor: usize,
-    pub focus: usize,
-    /// Copy absolute paths instead of bare names — the modifier held at press.
-    pub full_path: bool,
-}
-
-impl ListSelection {
-    /// Inclusive `(low, high)` row indices.
-    pub const fn range(&self) -> (usize, usize) {
-        if self.anchor <= self.focus {
-            (self.anchor, self.focus)
-        } else {
-            (self.focus, self.anchor)
-        }
-    }
-}
-
-/// A charwise selection over a single-line chrome surface.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ChromeSelection {
-    /// Screen row of the chrome line — its identity, since each is one row.
-    pub y: u16,
-    pub anchor_col: u16,
-    pub focus_col: u16,
-}
-
-impl ChromeSelection {
-    /// Inclusive `(low, high)` columns, relative to the row's own left edge.
-    pub const fn range(self) -> (u16, u16) {
-        if self.anchor_col <= self.focus_col {
-            (self.anchor_col, self.focus_col)
-        } else {
-            (self.focus_col, self.anchor_col)
-        }
-    }
-}
-
-/// One chrome line as drawn, recorded by the renderer for a later mouse copy.
-#[derive(Debug, Clone)]
-pub struct ChromeRow {
-    pub y: u16,
-    pub x: u16,
-    pub line: ratatui::text::Line<'static>,
-}
-
 /// Follow-up side effect a key handler asks the main loop to perform.
 ///
 /// Anything that needs to own the tty (editor, pager, shell-out) goes
@@ -946,11 +878,11 @@ pub struct ViewState {
     /// if the pointer wanders elsewhere — a selection that retargeted mid-drag would
     /// extend against the wrong buffer's indices. For a pager that's the slot, not
     /// the mount, because a mount can't tell `view.pager` from `view.right_pager`.
-    pub mouse_selection: Option<MouseDragTarget>,
+    pub mouse_selection: Option<mouse::MouseDragTarget>,
     /// A file-list row selection, kept after the drag ends so the highlight
     /// persists and a follow-up yank can still find it (same contract as the
     /// pager's charwise selection).
-    pub list_selection: Option<ListSelection>,
+    pub list_selection: Option<mouse::ListSelection>,
     /// A spyc-side charwise selection over the pane's visible grid, for a child
     /// that ignores mouse reports — `(anchor, focus)` in SCREEN coordinates,
     /// unordered so a backwards drag keeps its direction.
@@ -964,7 +896,7 @@ pub struct ViewState {
     pub pane_selection: Option<((u16, u16), (u16, u16))>,
     /// A charwise selection over one of the single-line chrome surfaces (the status
     /// bar, the pane divider/tab line) — the row and an unordered column pair.
-    pub chrome_selection: Option<ChromeSelection>,
+    pub chrome_selection: Option<mouse::ChromeSelection>,
     /// What each chrome row actually rendered this frame, for a mouse copy.
     ///
     /// `RefCell` because the draw pass is `&self` and this is the renderer recording
@@ -972,7 +904,18 @@ pub struct ViewState {
     /// `last_content_area` / `last_body_w` `Cell`s. It holds the DRAWN line, not the
     /// semantic segments: a selection maps screen COLUMNS back to characters, and
     /// only the drawn line has the width-driven truncation the user is looking at.
-    pub chrome_rows: std::cell::RefCell<Vec<ChromeRow>>,
+    pub chrome_rows: std::cell::RefCell<Vec<mouse::ChromeRow>>,
+    /// A sustained same-direction wheel-scroll gesture over an agent's own view
+    /// (today: codex's `^T`), tracked so it can escalate to a page-sized step —
+    /// see `App::send_agent_view_scroll_keys`. `None` outside a gesture.
+    pub pane_scroll_streak: Option<mouse::PaneScrollStreak>,
+    /// Set right after spyc sends an agent's `transcript_toggle_key`, so a fast
+    /// follow-up wheel tick — arriving before the child has redrawn — doesn't see
+    /// the OLD (still-closed) screen and send the toggle again, which would close
+    /// what the first tick just opened. Cleared once a scrape confirms the view is
+    /// open, or after `TOGGLE_SETTLE` if it never does (self-healing rather than
+    /// stuck refusing to retry).
+    pub pane_toggle_sent_at: Option<std::time::Instant>,
     /// Whether an agent-transcript scrollback (`^a v`) renders the agent's
     /// tool-use / tool-result lines. `t` toggles it; the transcript is
     /// re-rendered with the new value. Session-scoped (persists across
@@ -1071,6 +1014,8 @@ impl ViewState {
             pane_selection: None,
             chrome_selection: None,
             chrome_rows: std::cell::RefCell::new(Vec::new()),
+            pane_scroll_streak: None,
+            pane_toggle_sent_at: None,
             transcript_show_tool_calls: true,
             term_size: crossterm::terminal::size().unwrap_or((80, 24)),
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -229,6 +229,8 @@ pub enum MouseDragTarget {
     List(state::Side),
     /// A spyc-side text selection over the pty pane's visible grid.
     Pane,
+    /// A charwise selection over a single-line chrome surface.
+    Chrome,
 }
 
 /// A file-list row selection.
@@ -255,6 +257,34 @@ impl ListSelection {
             (self.focus, self.anchor)
         }
     }
+}
+
+/// A charwise selection over a single-line chrome surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChromeSelection {
+    /// Screen row of the chrome line — its identity, since each is one row.
+    pub y: u16,
+    pub anchor_col: u16,
+    pub focus_col: u16,
+}
+
+impl ChromeSelection {
+    /// Inclusive `(low, high)` columns, relative to the row's own left edge.
+    pub const fn range(self) -> (u16, u16) {
+        if self.anchor_col <= self.focus_col {
+            (self.anchor_col, self.focus_col)
+        } else {
+            (self.focus_col, self.anchor_col)
+        }
+    }
+}
+
+/// One chrome line as drawn, recorded by the renderer for a later mouse copy.
+#[derive(Debug, Clone)]
+pub struct ChromeRow {
+    pub y: u16,
+    pub x: u16,
+    pub line: ratatui::text::Line<'static>,
 }
 
 /// Follow-up side effect a key handler asks the main loop to perform.
@@ -932,6 +962,17 @@ pub struct ViewState {
     /// simple half of the tradeoff recorded in
     /// `docs/drafts/mouse_selection_plan.md`.
     pub pane_selection: Option<((u16, u16), (u16, u16))>,
+    /// A charwise selection over one of the single-line chrome surfaces (the status
+    /// bar, the pane divider/tab line) — the row and an unordered column pair.
+    pub chrome_selection: Option<ChromeSelection>,
+    /// What each chrome row actually rendered this frame, for a mouse copy.
+    ///
+    /// `RefCell` because the draw pass is `&self` and this is the renderer recording
+    /// what it drew — the same role (and the same reason) as `PagerView`'s
+    /// `last_content_area` / `last_body_w` `Cell`s. It holds the DRAWN line, not the
+    /// semantic segments: a selection maps screen COLUMNS back to characters, and
+    /// only the drawn line has the width-driven truncation the user is looking at.
+    pub chrome_rows: std::cell::RefCell<Vec<ChromeRow>>,
     /// Whether an agent-transcript scrollback (`^a v`) renders the agent's
     /// tool-use / tool-result lines. `t` toggles it; the transcript is
     /// re-rendered with the new value. Session-scoped (persists across
@@ -1028,6 +1069,8 @@ impl ViewState {
             mouse_selection: None,
             list_selection: None,
             pane_selection: None,
+            chrome_selection: None,
+            chrome_rows: std::cell::RefCell::new(Vec::new()),
             transcript_show_tool_calls: true,
             term_size: crossterm::terminal::size().unwrap_or((80, 24)),
         }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -227,6 +227,8 @@ pub enum MouseDragTarget {
     Pager(crate::app::pager_handler::PagerSlot),
     /// A file-list row selection, in this column.
     List(state::Side),
+    /// A spyc-side text selection over the pty pane's visible grid.
+    Pane,
 }
 
 /// A file-list row selection.
@@ -919,6 +921,17 @@ pub struct ViewState {
     /// persists and a follow-up yank can still find it (same contract as the
     /// pager's charwise selection).
     pub list_selection: Option<ListSelection>,
+    /// A spyc-side charwise selection over the pane's visible grid, for a child
+    /// that ignores mouse reports — `(anchor, focus)` in SCREEN coordinates,
+    /// unordered so a backwards drag keeps its direction.
+    ///
+    /// Screen coordinates, so it is only meaningful for the frame it was made in:
+    /// [`App::drain_pane_output`] clears it when the child paints, because the grid
+    /// scrolls out from under a selection anchored this way. That is fine for the
+    /// case it exists to serve — reading a static transcript overlay — and is the
+    /// simple half of the tradeoff recorded in
+    /// `docs/drafts/mouse_selection_plan.md`.
+    pub pane_selection: Option<((u16, u16), (u16, u16))>,
     /// Whether an agent-transcript scrollback (`^a v`) renders the agent's
     /// tool-use / tool-result lines. `t` toggles it; the transcript is
     /// re-rendered with the new value. Session-scoped (persists across
@@ -1014,6 +1027,7 @@ impl ViewState {
             mouse_press_forwarded: false,
             mouse_selection: None,
             list_selection: None,
+            pane_selection: None,
             transcript_show_tool_calls: true,
             term_size: crossterm::terminal::size().unwrap_or((80, 24)),
         }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -625,7 +625,14 @@ impl super::App {
         if per_press.is_empty() {
             return Vec::new();
         }
-        let repeats = delta.unsigned_abs().max(1) as usize;
+        // The PANE's own step, not `scroll_lines`. Those are different jobs: the list
+        // and pagers want 1 line per wheel event, because a trackpad already emits
+        // one event per notional line (owner-confirmed: "the file list speed is
+        // great"). But here spyc is driving somebody ELSE's pager by synthesizing
+        // arrows, and that pager moves one line per key with no safe way to ask it
+        // for a page — so at 1 the wheel couldn't traverse a long `^T` history.
+        // Only `delta`'s SIGN is used here (resolved into `code` above).
+        let repeats = self.state.config.mouse.pane_scroll_lines.max(1);
         let mut bytes = Vec::with_capacity(per_press.len() * repeats);
         for _ in 0..repeats {
             bytes.extend_from_slice(&per_press);
@@ -2177,5 +2184,53 @@ mod tests {
                 "closed={closed} covered={covered}"
             );
         }
+    }
+    /// A mouse selection holds POSITIONS, not content, so the next keyboard action
+    /// must retire it — otherwise navigating away leaves a highlight band sitting on
+    /// whatever file now occupies those row indices, which is how this was reported.
+    ///
+    /// The pager's `visual` selection is exempt: it's modal by request, so `j`/`k`
+    /// extend it and `Esc` cancels.
+    #[test]
+    fn a_key_retires_a_mouse_selection_but_not_the_pagers_visual_mode() {
+        use crate::app::state::Side;
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        crate::state::with_state_root(&tmp, || {
+            let mut app = App::test_app(tmp.clone());
+            app.view.list_selection = Some(crate::app::ListSelection {
+                side: Side::Left,
+                anchor: 1,
+                focus: 3,
+                full_path: false,
+            });
+            app.view.pane_selection = Some(((0, 0), (2, 4)));
+
+            let mut pager = PagerView::new_plain("p", vec!["a".into(), "b".into()]);
+            pager.visual = Some(crate::ui::pager::VisualSelection {
+                anchor: 0,
+                cursor: 1,
+                anchor_col: 0,
+                cursor_col: 0,
+                kind: VisualKind::Char,
+            });
+            app.view.pager = Some(pager);
+
+            let _ = app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+
+            assert!(
+                app.view.list_selection.is_none(),
+                "a keypress must retire the list selection"
+            );
+            assert!(
+                app.view.pane_selection.is_none(),
+                "a keypress must retire the pane selection"
+            );
+            assert!(
+                app.view.pager.as_ref().and_then(|v| v.visual).is_some(),
+                "the pager's visual mode is modal and must survive"
+            );
+        });
     }
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -353,34 +353,59 @@ fn scroll_streak_step(
 enum AgentViewAction {
     /// Send the toggle key once, and start the settle guard.
     Toggle,
-    /// Nothing this tick — `Off` mode while closed, or a toggle already sent and
-    /// still settling.
+    /// Nothing this tick — `Off` mode while closed, or a toggle/close already
+    /// sent and still settling.
     Nothing,
     /// Mount spyc's own `^a v` scrollback pager instead.
     UseSpycHistory,
     /// Send the agent's per-line scroll key, or its page key if `fast`.
     Scroll { fast: bool },
+    /// Send the dedicated close key: already at the bottom, and still
+    /// scrolling down has nowhere left to go — get out rather than no-op.
+    Close,
 }
 
-/// Pure. `toggle_pending` is `pane_toggle_sent_at`'s guard already resolved to a
-/// bool (elapsed vs. [`TOGGLE_SETTLE`]) — kept out of this function so it stays
-/// clock-free and trivially testable.
-const fn decide_agent_view_action(
+/// Inputs to [`decide_agent_view_action`], bundled rather than four positional
+/// `bool`s — each has a distinct meaning, and four bare bools at a call site is
+/// exactly the shape that gets two of them silently transposed.
+#[derive(Debug, Clone, Copy)]
+struct AgentViewInputs {
     is_open: bool,
-    mode: crate::config::PaneScrollView,
+    /// `pane_toggle_sent_at`'s guard already resolved to a bool (elapsed vs.
+    /// [`TOGGLE_SETTLE`]) — kept out of this function so it stays clock-free
+    /// and trivially testable. Reused for BOTH directions of the open/close
+    /// transition (see `send_agent_view_scroll_keys`'s doc): the same debounce
+    /// that stops a fast-flick reopen also stops a re-close mid-settle.
     toggle_pending: bool,
     escalate: bool,
+    at_bottom: bool,
+}
+
+/// Pure.
+///
+/// `dir`: -1 up, +1 down. Only consulted once already open, to decide whether
+/// "at the bottom" should mean "close" rather than "scroll" — scrolling UP at
+/// the bottom is just normal scrolling.
+const fn decide_agent_view_action(
+    in_: AgentViewInputs,
+    mode: crate::config::PaneScrollView,
+    dir: i8,
 ) -> AgentViewAction {
     use crate::config::PaneScrollView as V;
-    if !is_open {
+    if !in_.is_open {
         return match mode {
             V::Off => AgentViewAction::Nothing,
             V::SpycHistory => AgentViewAction::UseSpycHistory,
-            V::Native if toggle_pending => AgentViewAction::Nothing,
+            V::Native if in_.toggle_pending => AgentViewAction::Nothing,
             V::Native => AgentViewAction::Toggle,
         };
     }
-    AgentViewAction::Scroll { fast: escalate }
+    // Mode-independent: once open — however it got that way — "at the bottom,
+    // still scrolling down" means the same thing regardless of how it opened.
+    if dir > 0 && in_.at_bottom && !in_.toggle_pending {
+        return AgentViewAction::Close;
+    }
+    AgentViewAction::Scroll { fast: in_.escalate }
 }
 
 /// Route one mouse event to a sink. Pure and total.
@@ -838,11 +863,13 @@ impl super::App {
             return Vec::new();
         };
         let tab_index = tabs.active_index();
-        let is_open = tabs
-            .active()
-            .visible_lines()
-            .iter()
-            .any(|l| l.contains(marker));
+        // One scrape, reused for both checks below — codex's own vt100
+        // scrollback is confirmed empty (#230), so this reads the viewport, not
+        // scrollback, and there is no cheaper way to ask "is X still true" than
+        // reading the same lines twice.
+        let visible = tabs.active().visible_lines();
+        let is_open = visible.iter().any(|l| l.contains(marker));
+        let at_bottom = is_open && profile.transcript_at_bottom(&visible);
         let toggle_pending = self
             .view
             .pane_toggle_sent_at
@@ -858,10 +885,14 @@ impl super::App {
         };
 
         let action = decide_agent_view_action(
-            is_open,
+            AgentViewInputs {
+                is_open,
+                toggle_pending,
+                escalate,
+                at_bottom,
+            },
             self.state.config.mouse.pane_scroll_view,
-            toggle_pending,
-            escalate,
+            dir,
         );
 
         // State mutation lives here, once, keyed to the decision — not scattered
@@ -879,6 +910,18 @@ impl super::App {
             }
             AgentViewAction::Toggle => {
                 let Some((code, mods)) = profile.transcript_toggle_key() else {
+                    return Vec::new();
+                };
+                self.view.pane_toggle_sent_at = Some(now);
+                Self::repeat_key_effect(code, mods, 1)
+            }
+            // Reuses the SAME debounce field `Toggle` sets: the next tick or two
+            // will still read `is_open == true` (codex hasn't redrawn the
+            // composer yet), and without this a fast flick continuing past the
+            // bottom would send `q` again into what may already be the
+            // composer's own text input.
+            AgentViewAction::Close => {
+                let Some((code, mods)) = profile.transcript_close_key() else {
                     return Vec::new();
                 };
                 self.view.pane_toggle_sent_at = Some(now);
@@ -2773,7 +2816,7 @@ mod tests {
 
     // ── decide_agent_view_action: the codex ^T auto-open + escalation policy ──
 
-    use super::AgentViewAction;
+    use super::{AgentViewAction, AgentViewInputs};
     use crate::config::PaneScrollView;
 
     /// The DEFAULT behaviour, and the owner's stated preference: closed +
@@ -2782,7 +2825,16 @@ mod tests {
     #[test]
     fn closed_and_native_opens_it() {
         assert_eq!(
-            decide_agent_view_action(false, PaneScrollView::Native, false, false),
+            decide_agent_view_action(
+                AgentViewInputs {
+                    is_open: false,
+                    toggle_pending: false,
+                    escalate: false,
+                    at_bottom: false
+                },
+                PaneScrollView::Native,
+                1,
+            ),
             AgentViewAction::Toggle
         );
     }
@@ -2793,7 +2845,16 @@ mod tests {
     #[test]
     fn closed_with_a_pending_toggle_does_nothing() {
         assert_eq!(
-            decide_agent_view_action(false, PaneScrollView::Native, true, false),
+            decide_agent_view_action(
+                AgentViewInputs {
+                    is_open: false,
+                    toggle_pending: true,
+                    escalate: false,
+                    at_bottom: false
+                },
+                PaneScrollView::Native,
+                1,
+            ),
             AgentViewAction::Nothing
         );
     }
@@ -2804,7 +2865,16 @@ mod tests {
     fn closed_and_off_does_nothing() {
         for pending in [false, true] {
             assert_eq!(
-                decide_agent_view_action(false, PaneScrollView::Off, pending, false),
+                decide_agent_view_action(
+                    AgentViewInputs {
+                        is_open: false,
+                        toggle_pending: pending,
+                        escalate: false,
+                        at_bottom: false
+                    },
+                    PaneScrollView::Off,
+                    1,
+                ),
                 AgentViewAction::Nothing,
                 "pending={pending}"
             );
@@ -2817,7 +2887,16 @@ mod tests {
     #[test]
     fn closed_and_spyc_history_uses_spycs_own_view() {
         assert_eq!(
-            decide_agent_view_action(false, PaneScrollView::SpycHistory, false, false),
+            decide_agent_view_action(
+                AgentViewInputs {
+                    is_open: false,
+                    toggle_pending: false,
+                    escalate: false,
+                    at_bottom: false
+                },
+                PaneScrollView::SpycHistory,
+                1,
+            ),
             AgentViewAction::UseSpycHistory
         );
     }
@@ -2833,7 +2912,16 @@ mod tests {
             PaneScrollView::SpycHistory,
         ] {
             assert_eq!(
-                decide_agent_view_action(true, mode, false, false),
+                decide_agent_view_action(
+                    AgentViewInputs {
+                        is_open: true,
+                        toggle_pending: false,
+                        escalate: false,
+                        at_bottom: false
+                    },
+                    mode,
+                    1,
+                ),
                 AgentViewAction::Scroll { fast: false },
                 "{mode:?}"
             );
@@ -2845,8 +2933,106 @@ mod tests {
     #[test]
     fn open_and_escalated_scrolls_fast() {
         assert_eq!(
-            decide_agent_view_action(true, PaneScrollView::Native, false, true),
+            decide_agent_view_action(
+                AgentViewInputs {
+                    is_open: true,
+                    toggle_pending: false,
+                    escalate: true,
+                    at_bottom: false
+                },
+                PaneScrollView::Native,
+                1,
+            ),
             AgentViewAction::Scroll { fast: true }
+        );
+    }
+    /// The headline: open, scrolling DOWN, already at the bottom -> close
+    /// rather than a no-op scroll. Mode-independent, matching how `Scroll`
+    /// already ignores mode once open.
+    #[test]
+    fn open_at_bottom_scrolling_down_closes() {
+        for mode in [
+            PaneScrollView::Native,
+            PaneScrollView::Off,
+            PaneScrollView::SpycHistory,
+        ] {
+            assert_eq!(
+                decide_agent_view_action(
+                    AgentViewInputs {
+                        is_open: true,
+                        toggle_pending: false,
+                        escalate: false,
+                        at_bottom: true
+                    },
+                    mode,
+                    1,
+                ),
+                AgentViewAction::Close,
+                "{mode:?}"
+            );
+        }
+    }
+
+    /// Scrolling UP while at the bottom is just... scrolling up. `at_bottom`
+    /// only means something for a DOWN gesture.
+    #[test]
+    fn at_bottom_scrolling_up_still_scrolls() {
+        assert_eq!(
+            decide_agent_view_action(
+                AgentViewInputs {
+                    is_open: true,
+                    toggle_pending: false,
+                    escalate: false,
+                    at_bottom: true
+                },
+                PaneScrollView::Native,
+                -1,
+            ),
+            AgentViewAction::Scroll { fast: false }
+        );
+    }
+
+    /// Not at the bottom: scrolling down is just... scrolling down, regardless
+    /// of escalation.
+    #[test]
+    fn not_at_bottom_scrolling_down_still_scrolls() {
+        for escalate in [false, true] {
+            assert_eq!(
+                decide_agent_view_action(
+                    AgentViewInputs {
+                        is_open: true,
+                        toggle_pending: false,
+                        escalate,
+                        at_bottom: false
+                    },
+                    PaneScrollView::Native,
+                    1,
+                ),
+                AgentViewAction::Scroll { fast: escalate },
+                "escalate={escalate}"
+            );
+        }
+    }
+
+    /// A close was just sent (still settling): a further down tick that still
+    /// reads "open, at bottom" must NOT re-send close — this is the guard
+    /// against sending `q` twice while codex's redraw is in flight, mirroring
+    /// the open-side toggle-storm guard.
+    #[test]
+    fn a_pending_settle_suppresses_a_second_close() {
+        assert_eq!(
+            decide_agent_view_action(
+                AgentViewInputs {
+                    is_open: true,
+                    toggle_pending: true,
+                    escalate: false,
+                    at_bottom: true
+                },
+                PaneScrollView::Native,
+                1,
+            ),
+            AgentViewAction::Scroll { fast: false },
+            "must fall through to a harmless scroll key, not re-close"
         );
     }
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -94,8 +94,13 @@ pub(super) enum MouseSink {
     /// Give the keyboard to a file-list column AND anchor a row selection there.
     /// Both halves in one variant, for the reason [`Self::FocusAndForward`] documents.
     FocusAndSelectRows(crate::app::state::Side),
-    /// Copy the status line's text.
-    CopyStatus,
+    /// Anchor a charwise selection on the single-line chrome surface under the
+    /// pointer (status bar, pane divider/tab line).
+    ///
+    /// Replaces an earlier click-copies-the-whole-line: a bare click that silently
+    /// took the entire line was surprising, and it couldn't copy just the one thing
+    /// you wanted out of it — a session id, a branch name.
+    SelectChrome,
     /// Give the keyboard to the pane AND anchor a spyc-side text selection over its
     /// visible grid — for a child that ignores mouse reports, so nothing else can
     /// do the selecting (codex's `^T` transcript, a plain shell).
@@ -295,10 +300,11 @@ pub(super) const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseS
             if matches!(region, Region::RightColumn) {
                 return MouseSink::FocusAndSelectRows(crate::app::state::Side::Right);
             }
-            // The status line is one line of text; a click copies all of it. It owns
-            // no keyboard focus, so there is nothing else a click there could mean.
-            if matches!(region, Region::Status) {
-                return MouseSink::CopyStatus;
+            // The single-line chrome surfaces hold text and no keyboard focus, so a
+            // press there can only mean "select this". The divider carries the tab
+            // bar, where a custom session name is the thing worth copying.
+            if matches!(region, Region::Status | Region::Divider) {
+                return MouseSink::SelectChrome;
             }
             return MouseSink::FocusRegion;
         }
@@ -442,6 +448,7 @@ impl super::App {
                         MouseDragTarget::Pager(_) => self.extend_pager_selection(ev),
                         MouseDragTarget::List(side) => self.extend_row_selection(ev, side),
                         MouseDragTarget::Pane => self.extend_pane_selection(ev),
+                        MouseDragTarget::Chrome => self.extend_chrome_selection(ev),
                     };
                 }
                 MouseEventKind::Up(MouseButton::Left) => {
@@ -449,6 +456,7 @@ impl super::App {
                         MouseDragTarget::Pager(_) => self.finish_pager_selection(ev),
                         MouseDragTarget::List(_) => self.finish_row_selection(ev),
                         MouseDragTarget::Pane => self.finish_pane_selection(ev),
+                        MouseDragTarget::Chrome => self.finish_chrome_selection(ev),
                     };
                 }
                 // Any other button mid-drag abandons the selection rather than
@@ -562,16 +570,7 @@ impl super::App {
                 self.focus_region(region);
                 self.begin_pane_selection(ev)
             }
-            MouseSink::CopyStatus => {
-                let text = self.status_bar_plain_text();
-                if text.is_empty() {
-                    return Vec::new();
-                }
-                vec![Effect::CopyToClipboard {
-                    text,
-                    ok: super::effect::ClipMsg::StatusLine,
-                }]
-            }
+            MouseSink::SelectChrome => self.begin_chrome_selection(ev),
             MouseSink::Paste => vec![Effect::PasteFromClipboard],
             MouseSink::LeaderMenu => {
                 self.state.resolver.enter_leader();
@@ -743,6 +742,89 @@ impl super::App {
         // full-frame mount.
         let ok_msg = format!("copied {lines} line{}", if lines == 1 { "" } else { "s" });
         vec![Effect::CopyToPagerClipboard { text, ok_msg }]
+    }
+
+    /// The chrome row under the pointer, and the pointer's column within it.
+    ///
+    /// Matched on the recorded row's `y`, which is its identity — each chrome
+    /// surface is exactly one screen row. Reads what the renderer actually drew, so
+    /// the column the user pressed maps to the character they saw.
+    fn chrome_col_at(&self, ev: MouseEvent) -> Option<(u16, u16)> {
+        let rows = self.view.chrome_rows.borrow();
+        let row = rows.iter().find(|r| r.y == ev.row && ev.column >= r.x)?;
+        Some((row.y, ev.column - row.x))
+    }
+
+    /// Anchor a chrome-line selection where the pointer pressed.
+    fn begin_chrome_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        let Some((y, col)) = self.chrome_col_at(ev) else {
+            return Vec::new();
+        };
+        self.view.chrome_selection = Some(super::ChromeSelection {
+            y,
+            anchor_col: col,
+            focus_col: col,
+        });
+        self.view.mouse_selection = Some(MouseDragTarget::Chrome);
+        Vec::new()
+    }
+
+    /// Extend it. The pointer is clamped to the row it started on: these surfaces
+    /// are one row each, so drifting vertically mid-drag should widen the selection
+    /// rather than abandon it.
+    fn extend_chrome_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        let Some(sel) = self.view.chrome_selection else {
+            return Vec::new();
+        };
+        let col = {
+            let rows = self.view.chrome_rows.borrow();
+            let Some(row) = rows.iter().find(|r| r.y == sel.y) else {
+                return Vec::new();
+            };
+            ev.column.saturating_sub(row.x)
+        };
+        if let Some(s) = self.view.chrome_selection.as_mut() {
+            s.focus_col = col;
+        }
+        Vec::new()
+    }
+
+    /// Copy the selected columns, keeping the highlight up.
+    ///
+    /// A press that never moved is a click, not a selection — the highlight is
+    /// dropped and the clipboard left alone, matching every other surface. That is
+    /// also why this replaced click-copies-everything: a click now does nothing
+    /// surprising.
+    fn finish_chrome_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        self.view.mouse_selection = None;
+        self.extend_chrome_selection(ev);
+        let Some(sel) = self.view.chrome_selection else {
+            return Vec::new();
+        };
+        if sel.anchor_col == sel.focus_col {
+            self.view.chrome_selection = None;
+            return Vec::new();
+        }
+        let (lo, hi) = sel.range();
+        let text = {
+            let rows = self.view.chrome_rows.borrow();
+            let Some(row) = rows.iter().find(|r| r.y == sel.y) else {
+                return Vec::new();
+            };
+            crate::ui::line_select::text_between_columns(
+                &row.line,
+                usize::from(lo),
+                usize::from(hi),
+            )
+        };
+        let text = text.trim().to_string();
+        if text.is_empty() {
+            return Vec::new();
+        }
+        vec![Effect::CopyToClipboard {
+            text,
+            ok: super::effect::ClipMsg::StatusLine,
+        }]
     }
 
     /// Translate the pointer into the pane's own grid coordinates, clamped into it.
@@ -1578,24 +1660,20 @@ mod tests {
     /// Clicking chrome or off-frame moves nothing — but middle/right still act,
     /// since they aren't about the region.
     ///
-    /// `Status` is excluded: it holds one line of text and no keyboard focus, so a
-    /// left click there copies it (`copying_the_status_line_needs_no_focus`).
+    /// `Status` and `Divider` are excluded: they hold text and no keyboard focus, so
+    /// a press there starts a selection — see
+    /// `chrome_lines_start_a_selection_rather_than_taking_focus`.
     #[test]
     fn chrome_focuses_nothing_but_still_pastes_and_opens_the_menu() {
-        for region in [Region::Divider, Region::Prompt] {
-            assert_eq!(
-                route_mouse(snap(Some(region)), Gesture::Left),
-                MouseSink::FocusRegion,
-                "{region:?}: routed, then `focus_region` no-ops on chrome"
-            );
-            assert_eq!(
-                route_mouse(snap(Some(region)), Gesture::Middle),
-                MouseSink::Paste
-            );
-        }
-        // Off-frame is the one case where even middle/right do nothing: there is
-        // no region, so the early return fires before the gesture match.
-        assert_eq!(route_mouse(snap(None), Gesture::Middle), MouseSink::Swallow);
+        // Only the prompt row is left: `Status` and `Divider` now start selections.
+        let prompt = snap(Some(Region::Prompt));
+        assert_eq!(
+            route_mouse(prompt, Gesture::Left),
+            MouseSink::FocusRegion,
+            "routed, then `focus_region` no-ops on chrome"
+        );
+        assert_eq!(route_mouse(prompt, Gesture::Middle), MouseSink::Paste);
+        assert_eq!(route_mouse(prompt, Gesture::Right), MouseSink::LeaderMenu);
     }
 
     /// Coordinate translation, for both `status_position` values — the trap
@@ -1997,14 +2075,18 @@ mod tests {
     }
     // ── file list + status bar selection ─────────────────────────────────
 
-    /// The status line owns no keyboard focus, so a left click there can only mean
-    /// "copy this". Kept out of the chrome test above for that reason.
+    /// The single-line chrome surfaces hold text and no keyboard focus, so a press
+    /// there can only mean "select this". Both of them: the divider carries the tab
+    /// bar, where a custom session name is the thing worth copying.
     #[test]
-    fn copying_the_status_line_needs_no_focus() {
-        assert_eq!(
-            route_mouse(snap(Some(Region::Status)), Gesture::Left),
-            MouseSink::CopyStatus
-        );
+    fn chrome_lines_start_a_selection_rather_than_taking_focus() {
+        for region in [Region::Status, Region::Divider] {
+            assert_eq!(
+                route_mouse(snap(Some(region)), Gesture::Left),
+                MouseSink::SelectChrome,
+                "{region:?}"
+            );
+        }
     }
 
     /// A pager over the list still wins: `covering_pager` is checked before the
@@ -2206,6 +2288,11 @@ mod tests {
                 full_path: false,
             });
             app.view.pane_selection = Some(((0, 0), (2, 4)));
+            app.view.chrome_selection = Some(crate::app::ChromeSelection {
+                y: 0,
+                anchor_col: 2,
+                focus_col: 8,
+            });
 
             let mut pager = PagerView::new_plain("p", vec!["a".into(), "b".into()]);
             pager.visual = Some(crate::ui::pager::VisualSelection {
@@ -2228,8 +2315,89 @@ mod tests {
                 "a keypress must retire the pane selection"
             );
             assert!(
+                app.view.chrome_selection.is_none(),
+                "a keypress must retire the chrome selection"
+            );
+            assert!(
                 app.view.pager.as_ref().and_then(|v| v.visual).is_some(),
                 "the pager's visual mode is modal and must survive"
+            );
+        });
+    }
+    /// End-to-end: a drag across part of a chrome line copies exactly those columns
+    /// — the point of the feature being substring selection rather than
+    /// copy-the-whole-line (so you can take just a session id or a branch name).
+    #[test]
+    fn a_chrome_drag_copies_only_the_dragged_columns() {
+        use crossterm::event::KeyModifiers;
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        crate::state::with_state_root(&tmp, || {
+            let mut app = App::test_app(tmp.clone());
+            // Stand in for what the renderer records: one chrome row at y=0, x=0.
+            app.view
+                .chrome_rows
+                .borrow_mut()
+                .push(crate::app::ChromeRow {
+                    y: 0,
+                    x: 0,
+                    line: ratatui::text::Line::from(vec![
+                        ratatui::text::Span::raw("spyc"),
+                        ratatui::text::Span::raw("|"),
+                        ratatui::text::Span::raw("main*"),
+                    ]),
+                });
+            let at = |kind, col| MouseEvent {
+                kind,
+                column: col,
+                row: 0,
+                modifiers: KeyModifiers::NONE,
+            };
+            // Drag columns 5..9 — "main*", crossing no segment seam of its own but
+            // starting past two.
+            app.begin_chrome_selection(at(MouseEventKind::Down(MouseButton::Left), 5));
+            app.extend_chrome_selection(at(MouseEventKind::Drag(MouseButton::Left), 9));
+            let effects = app.finish_chrome_selection(at(MouseEventKind::Up(MouseButton::Left), 9));
+
+            let [Effect::CopyToClipboard { text, .. }] = effects.as_slice() else {
+                panic!("expected one clipboard copy, got {effects:?}");
+            };
+            assert_eq!(text, "main*");
+            assert!(
+                app.view.chrome_selection.is_some(),
+                "the highlight stays up after the copy, like the other surfaces"
+            );
+        });
+    }
+
+    /// A click that never moved is a click: no copy, no lingering highlight. This is
+    /// what makes replacing click-copies-the-whole-line safe — a stray click on the
+    /// status bar no longer silently overwrites the clipboard.
+    #[test]
+    fn a_chrome_click_without_motion_copies_nothing() {
+        use crossterm::event::KeyModifiers;
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        crate::state::with_state_root(&tmp, || {
+            let mut app = App::test_app(tmp.clone());
+            app.view
+                .chrome_rows
+                .borrow_mut()
+                .push(crate::app::ChromeRow {
+                    y: 0,
+                    x: 0,
+                    line: ratatui::text::Line::from(vec![ratatui::text::Span::raw("spyc|main*")]),
+                });
+            let at = |kind| MouseEvent {
+                kind,
+                column: 3,
+                row: 0,
+                modifiers: KeyModifiers::NONE,
+            };
+            app.begin_chrome_selection(at(MouseEventKind::Down(MouseButton::Left)));
+            let effects = app.finish_chrome_selection(at(MouseEventKind::Up(MouseButton::Left)));
+            assert!(effects.is_empty(), "a click must not copy: {effects:?}");
+            assert!(
+                app.view.chrome_selection.is_none(),
+                "and leaves no highlight"
             );
         });
     }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -19,7 +19,7 @@ use ratatui::layout::Rect;
 
 use super::modal::{Modal, ModalSnapshot, active_modal};
 use super::pager_handler::PagerSlot;
-use super::{Effect, FrameLayout, MouseDragTarget};
+use super::{Effect, FrameLayout};
 use crate::ui::pager::Mount;
 
 /// Which frame region the pointer is over. Resolved from the pointer's
@@ -42,6 +42,87 @@ pub(super) enum Region {
     Status,
     /// The 1-column vertical separator between split columns.
     VDivider,
+}
+
+/// The surface an in-flight mouse drag belongs to. See
+/// [`super::ViewState::mouse_selection`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseDragTarget {
+    /// A pager's charwise text selection, in this slot.
+    Pager(crate::app::pager_handler::PagerSlot),
+    /// A file-list row selection, in this column.
+    List(super::state::Side),
+    /// A spyc-side text selection over the pty pane's visible grid.
+    Pane,
+    /// A charwise selection over a single-line chrome surface.
+    Chrome,
+}
+
+/// A file-list row selection.
+///
+/// `anchor`/`focus` rather than a sorted range so a backwards drag keeps its
+/// direction, and so extending never has to re-derive which end the user started
+/// from. Row *indices*, not paths: the copy resolves paths at release time from the
+/// live listing, so a selection can't outlive a refresh with stale paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ListSelection {
+    pub side: super::state::Side,
+    pub anchor: usize,
+    pub focus: usize,
+    /// Copy absolute paths instead of bare names — the modifier held at press.
+    pub full_path: bool,
+}
+
+impl ListSelection {
+    /// Inclusive `(low, high)` row indices.
+    pub const fn range(&self) -> (usize, usize) {
+        if self.anchor <= self.focus {
+            (self.anchor, self.focus)
+        } else {
+            (self.focus, self.anchor)
+        }
+    }
+}
+
+/// A charwise selection over a single-line chrome surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ChromeSelection {
+    /// Screen row of the chrome line — its identity, since each is one row.
+    pub y: u16,
+    pub anchor_col: u16,
+    pub focus_col: u16,
+}
+
+impl ChromeSelection {
+    /// Inclusive `(low, high)` columns, relative to the row's own left edge.
+    pub const fn range(self) -> (u16, u16) {
+        if self.anchor_col <= self.focus_col {
+            (self.anchor_col, self.focus_col)
+        } else {
+            (self.focus_col, self.anchor_col)
+        }
+    }
+}
+
+/// A sustained same-direction wheel-scroll gesture over an agent's own view. See
+/// [`super::ViewState::pane_scroll_streak`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneScrollStreak {
+    /// The tab this streak belongs to — switching tabs starts a fresh streak
+    /// rather than inheriting the old one's elapsed time.
+    pub tab_index: usize,
+    /// -1 up, +1 down.
+    pub dir: i8,
+    pub started_at: std::time::Instant,
+    pub last_at: std::time::Instant,
+}
+
+/// One chrome line as drawn, recorded by the renderer for a later mouse copy.
+#[derive(Debug, Clone)]
+pub struct ChromeRow {
+    pub y: u16,
+    pub x: u16,
+    pub line: ratatui::text::Line<'static>,
 }
 
 /// Where a mouse event is dispatched.
@@ -204,6 +285,102 @@ impl MouseSnapshot {
     const fn resolver_will_see_the_next_key(self) -> bool {
         !self.is_prompting && !matches!(self.pager_mount, Some(Mount::Overlay))
     }
+}
+
+/// How long spyc waits, after sending an agent's `transcript_toggle_key`, before
+/// it's willing to send it again — see [`ViewState::pane_toggle_sent_at`].
+/// Comfortably longer than one local pty round trip, short enough to recover
+/// quickly if the scrape genuinely never confirms.
+const TOGGLE_SETTLE: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// A gap between wheel ticks longer than this ends the current scroll streak — a
+/// paused-then-resumed scroll is a new gesture, not a continuation of the old
+/// speed. Comfortably longer than the inter-tick gap during a continuous flick.
+const STREAK_GAP: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// How long a same-direction streak must run before it escalates to a page-sized
+/// step. Owner-specified ("say past 1 second").
+const ESCALATE_AFTER: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Advance a wheel-scroll streak by one tick, and decide whether it has run long
+/// enough to escalate. Pure (the `route.rs`/`focus.rs` template): takes `now` as a
+/// parameter rather than reading the clock, so it's testable with synthetic
+/// `Instant`s built via `checked_add`/`checked_sub` off a real `Instant::now()`
+/// baseline (the same trick `codex_pin`'s tests use).
+///
+/// Restarts (rather than extending) the streak on a tab switch, a direction
+/// change, or a gap longer than [`STREAK_GAP`] — each of those means "a new
+/// gesture", not "the same one continuing", so none should inherit the old
+/// streak's elapsed time.
+fn scroll_streak_step(
+    prev: Option<PaneScrollStreak>,
+    tab_index: usize,
+    dir: i8,
+    now: std::time::Instant,
+) -> (PaneScrollStreak, bool) {
+    let restart = match prev {
+        Some(s) => {
+            s.tab_index != tab_index
+                || s.dir != dir
+                || now.duration_since(s.last_at).as_millis() > STREAK_GAP.as_millis()
+        }
+        None => true,
+    };
+    let started_at = if restart {
+        now
+    } else {
+        match prev {
+            Some(s) => s.started_at,
+            None => now, // unreachable: `prev.is_none()` implies `restart`
+        }
+    };
+    let streak = PaneScrollStreak {
+        tab_index,
+        dir,
+        started_at,
+        last_at: now,
+    };
+    let escalate = now.duration_since(started_at).as_millis() >= ESCALATE_AFTER.as_millis();
+    (streak, escalate)
+}
+
+/// What a wheel tick over an agent's own toggleable view should do — decided
+/// PURELY from whether the view is open, the configured mode, and whether this
+/// tick's streak has escalated. The impure half ([`App::send_agent_view_scroll_keys`])
+/// is a thin wrapper: scrape for `is_open`, call this, translate the answer into
+/// an effect + state mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AgentViewAction {
+    /// Send the toggle key once, and start the settle guard.
+    Toggle,
+    /// Nothing this tick — `Off` mode while closed, or a toggle already sent and
+    /// still settling.
+    Nothing,
+    /// Mount spyc's own `^a v` scrollback pager instead.
+    UseSpycHistory,
+    /// Send the agent's per-line scroll key, or its page key if `fast`.
+    Scroll { fast: bool },
+}
+
+/// Pure. `toggle_pending` is `pane_toggle_sent_at`'s guard already resolved to a
+/// bool (elapsed vs. [`TOGGLE_SETTLE`]) — kept out of this function so it stays
+/// clock-free and trivially testable.
+const fn decide_agent_view_action(
+    is_open: bool,
+    mode: crate::config::PaneScrollView,
+    toggle_pending: bool,
+    escalate: bool,
+) -> AgentViewAction {
+    use crate::config::PaneScrollView as V;
+    if !is_open {
+        return match mode {
+            V::Off => AgentViewAction::Nothing,
+            V::SpycHistory => AgentViewAction::UseSpycHistory,
+            V::Native if toggle_pending => AgentViewAction::Nothing,
+            V::Native => AgentViewAction::Toggle,
+        };
+    }
+    AgentViewAction::Scroll { fast: escalate }
 }
 
 /// Route one mouse event to a sink. Pure and total.
@@ -609,39 +786,144 @@ impl super::App {
         crate::agent::detect(&tabs.active_info().command).wheel_scroll()
     }
 
-    /// Translate a wheel tick into the child's own scroll keys, one press per
-    /// line, and send them as a single batch.
+    /// Translate a wheel tick into the child's own scroll keys.
     ///
-    /// One `SendToPane` rather than N: the executor writes to the pty once, so a
-    /// three-line tick can't interleave with the child's own output mid-burst.
-    fn send_scroll_keys(&self, delta: i32) -> Vec<Effect> {
-        let Some(scroll) = self.active_pane_wheel_scroll() else {
+    /// Agents with no dedicated, toggleable view (today: agy — its
+    /// `transcript_open_marker` is `None`) keep the exact behaviour verified
+    /// working: `wheel_scroll()`'s key, repeated `pane_scroll_lines` times, no
+    /// screen-scraping at all. An agent that opts into
+    /// `transcript_open_marker` (codex) gets the fuller machinery in
+    /// `send_agent_view_scroll_keys` — auto-open, and escalation to a page key
+    /// under a sustained gesture.
+    fn send_scroll_keys(&mut self, delta: i32) -> Vec<Effect> {
+        let Some(tabs) = self.runtime.pane_tabs.as_ref() else {
+            return Vec::new();
+        };
+        let profile = crate::agent::detect(&tabs.active_info().command);
+        if let Some(marker) = profile.transcript_open_marker() {
+            let dir: i8 = if delta < 0 { -1 } else { 1 };
+            return self.send_agent_view_scroll_keys(profile, marker, dir);
+        }
+        let Some(scroll) = profile.wheel_scroll() else {
             return Vec::new();
         };
         let (code, mods) = if delta < 0 { scroll.up } else { scroll.down };
-        let key = crossterm::event::KeyEvent::new(code, mods);
-        let per_press = crate::pane::input::encode_key(key);
-        if per_press.is_empty() {
-            return Vec::new();
-        }
         // The PANE's own step, not `scroll_lines`. Those are different jobs: the list
         // and pagers want 1 line per wheel event, because a trackpad already emits
         // one event per notional line (owner-confirmed: "the file list speed is
         // great"). But here spyc is driving somebody ELSE's pager by synthesizing
         // arrows, and that pager moves one line per key with no safe way to ask it
-        // for a page — so at 1 the wheel couldn't traverse a long `^T` history.
-        // Only `delta`'s SIGN is used here (resolved into `code` above).
-        let repeats = self.state.config.mouse.pane_scroll_lines.max(1);
-        let mut bytes = Vec::with_capacity(per_press.len() * repeats);
-        for _ in 0..repeats {
+        // for a page — so at 1 the wheel couldn't traverse a long history.
+        Self::repeat_key_effect(code, mods, self.state.config.mouse.pane_scroll_lines.max(1))
+    }
+
+    /// The fuller wheel-to-keys machinery for an agent with its OWN toggleable
+    /// scrollback view (today: codex's `^T`), gated on `marker` — see
+    /// `AgentProfile::transcript_open_marker`.
+    ///
+    /// First decides whether the view is open by scraping the pane's CURRENT
+    /// visible screen (`Pane::visible_lines` — the viewport, not scrollback:
+    /// codex's own vt100 scrollback is confirmed empty, per #230's
+    /// investigation, so scrollback has nothing to scrape). Cheap enough to run
+    /// every tick — a plain substring search over one screen's worth of text —
+    /// so no debounce is needed for the scrape itself; only the toggle-send
+    /// needs one (see `pane_toggle_sent_at`'s doc).
+    fn send_agent_view_scroll_keys(
+        &mut self,
+        profile: &'static dyn crate::agent::AgentProfile,
+        marker: &str,
+        dir: i8,
+    ) -> Vec<Effect> {
+        let Some(tabs) = self.runtime.pane_tabs.as_ref() else {
+            return Vec::new();
+        };
+        let tab_index = tabs.active_index();
+        let is_open = tabs
+            .active()
+            .visible_lines()
+            .iter()
+            .any(|l| l.contains(marker));
+        let toggle_pending = self
+            .view
+            .pane_toggle_sent_at
+            .is_some_and(|sent| sent.elapsed() < TOGGLE_SETTLE);
+
+        let now = std::time::Instant::now();
+        let (escalate, streak) = if is_open {
+            let (streak, escalate) =
+                scroll_streak_step(self.view.pane_scroll_streak, tab_index, dir, now);
+            (escalate, Some(streak))
+        } else {
+            (false, self.view.pane_scroll_streak) // no tick to record while closed
+        };
+
+        let action = decide_agent_view_action(
+            is_open,
+            self.state.config.mouse.pane_scroll_view,
+            toggle_pending,
+            escalate,
+        );
+
+        // State mutation lives here, once, keyed to the decision — not scattered
+        // across the branches that produce it.
+        self.view.pane_scroll_streak = streak;
+        if is_open {
+            self.view.pane_toggle_sent_at = None; // confirmed open; drop the guard
+        }
+
+        match action {
+            AgentViewAction::Nothing => Vec::new(),
+            AgentViewAction::UseSpycHistory => {
+                self.open_pane_scroll_pager();
+                Vec::new()
+            }
+            AgentViewAction::Toggle => {
+                let Some((code, mods)) = profile.transcript_toggle_key() else {
+                    return Vec::new();
+                };
+                self.view.pane_toggle_sent_at = Some(now);
+                Self::repeat_key_effect(code, mods, 1)
+            }
+            AgentViewAction::Scroll { fast } => {
+                if fast && let Some(f) = profile.fast_wheel_scroll() {
+                    let (code, mods) = if dir < 0 { f.up } else { f.down };
+                    return Self::repeat_key_effect(code, mods, 1);
+                }
+                let Some(scroll) = profile.wheel_scroll() else {
+                    return Vec::new();
+                };
+                let (code, mods) = if dir < 0 { scroll.up } else { scroll.down };
+                Self::repeat_key_effect(
+                    code,
+                    mods,
+                    self.state.config.mouse.pane_scroll_lines.max(1),
+                )
+            }
+        }
+    }
+
+    /// Encode `key` and repeat it `n` times as ONE `SendToPane` batch — the
+    /// executor writes to the pty once, so a multi-line tick can't interleave
+    /// with the child's own output mid-burst.
+    fn repeat_key_effect(
+        code: crossterm::event::KeyCode,
+        mods: crossterm::event::KeyModifiers,
+        n: usize,
+    ) -> Vec<Effect> {
+        let per_press = crate::pane::input::encode_key(crossterm::event::KeyEvent::new(code, mods));
+        if per_press.is_empty() {
+            return Vec::new();
+        }
+        let mut bytes = Vec::with_capacity(per_press.len() * n.max(1));
+        for _ in 0..n.max(1) {
             bytes.extend_from_slice(&per_press);
         }
         vec![Effect::SendToPane {
             target: super::effect::PaneTarget::Active,
             input: super::effect::PaneInput::Bytes(bytes),
             on_ok: None,
-            // Same reasoning as `forward_to_child`: no per-tick flash, or a dead
-            // pty buries its real exit message under one repeat per wheel line.
+            // No per-tick flash, and no early return on a dead pty: either would
+            // bury the real exit message under one repeat per wheel line.
             err_prefix: None,
         }]
     }
@@ -760,7 +1042,7 @@ impl super::App {
         let Some((y, col)) = self.chrome_col_at(ev) else {
             return Vec::new();
         };
-        self.view.chrome_selection = Some(super::ChromeSelection {
+        self.view.chrome_selection = Some(ChromeSelection {
             y,
             anchor_col: col,
             focus_col: col,
@@ -951,7 +1233,7 @@ impl super::App {
             .modifiers
             .contains(crossterm::event::KeyModifiers::CONTROL);
         self.state.col_mut(side).cursor.index = idx;
-        self.view.list_selection = Some(super::ListSelection {
+        self.view.list_selection = Some(ListSelection {
             side,
             anchor: idx,
             focus: idx,
@@ -1203,7 +1485,10 @@ fn mouse_report(
 
 #[cfg(test)]
 mod tests {
-    use super::{Gesture, MouseSink, MouseSnapshot, Region, region_at, route_mouse};
+    use super::{
+        Gesture, MouseSink, MouseSnapshot, Region, decide_agent_view_action, region_at,
+        route_mouse, scroll_streak_step,
+    };
     use crate::app::App;
     use crate::config::StatusPosition;
     use crate::ui::pager::Mount;
@@ -2281,14 +2566,14 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir").keep();
         crate::state::with_state_root(&tmp, || {
             let mut app = App::test_app(tmp.clone());
-            app.view.list_selection = Some(crate::app::ListSelection {
+            app.view.list_selection = Some(super::ListSelection {
                 side: Side::Left,
                 anchor: 1,
                 focus: 3,
                 full_path: false,
             });
             app.view.pane_selection = Some(((0, 0), (2, 4)));
-            app.view.chrome_selection = Some(crate::app::ChromeSelection {
+            app.view.chrome_selection = Some(super::ChromeSelection {
                 y: 0,
                 anchor_col: 2,
                 focus_col: 8,
@@ -2334,18 +2619,15 @@ mod tests {
         crate::state::with_state_root(&tmp, || {
             let mut app = App::test_app(tmp.clone());
             // Stand in for what the renderer records: one chrome row at y=0, x=0.
-            app.view
-                .chrome_rows
-                .borrow_mut()
-                .push(crate::app::ChromeRow {
-                    y: 0,
-                    x: 0,
-                    line: ratatui::text::Line::from(vec![
-                        ratatui::text::Span::raw("spyc"),
-                        ratatui::text::Span::raw("|"),
-                        ratatui::text::Span::raw("main*"),
-                    ]),
-                });
+            app.view.chrome_rows.borrow_mut().push(super::ChromeRow {
+                y: 0,
+                x: 0,
+                line: ratatui::text::Line::from(vec![
+                    ratatui::text::Span::raw("spyc"),
+                    ratatui::text::Span::raw("|"),
+                    ratatui::text::Span::raw("main*"),
+                ]),
+            });
             let at = |kind, col| MouseEvent {
                 kind,
                 column: col,
@@ -2378,14 +2660,11 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir").keep();
         crate::state::with_state_root(&tmp, || {
             let mut app = App::test_app(tmp.clone());
-            app.view
-                .chrome_rows
-                .borrow_mut()
-                .push(crate::app::ChromeRow {
-                    y: 0,
-                    x: 0,
-                    line: ratatui::text::Line::from(vec![ratatui::text::Span::raw("spyc|main*")]),
-                });
+            app.view.chrome_rows.borrow_mut().push(super::ChromeRow {
+                y: 0,
+                x: 0,
+                line: ratatui::text::Line::from(vec![ratatui::text::Span::raw("spyc|main*")]),
+            });
             let at = |kind| MouseEvent {
                 kind,
                 column: 3,
@@ -2400,5 +2679,174 @@ mod tests {
                 "and leaves no highlight"
             );
         });
+    }
+    // ── scroll_streak_step: the sustained-scroll escalation timer ──────────
+
+    fn later(base: std::time::Instant, ms: u64) -> std::time::Instant {
+        base.checked_add(std::time::Duration::from_millis(ms))
+            .expect("small offset from now")
+    }
+
+    /// The headline: a same-direction gesture escalates once it's run past
+    /// `ESCALATE_AFTER` — this is the fix for "scrolling is too slow in ^t mode".
+    #[test]
+    fn a_sustained_same_direction_streak_escalates_after_the_threshold() {
+        let t0 = std::time::Instant::now();
+        let (s1, esc1) = scroll_streak_step(None, 0, 1, t0);
+        assert!(!esc1, "the very first tick must not already be escalated");
+
+        // Each successive gap stays under STREAK_GAP (500ms) so this is one
+        // continuous streak, not a series of restarts.
+        let (s2, esc2) = scroll_streak_step(Some(s1), 0, 1, later(t0, 400));
+        assert!(!esc2, "under the threshold yet");
+
+        let (s3, esc3) = scroll_streak_step(Some(s2), 0, 1, later(t0, 800));
+        assert!(!esc3, "still under the threshold");
+
+        let (_, esc4) = scroll_streak_step(Some(s3), 0, 1, later(t0, 1_100));
+        assert!(esc4, "past ESCALATE_AFTER in the same direction");
+    }
+
+    /// A direction change is a new gesture — it must not inherit the old
+    /// streak's elapsed time and escalate immediately.
+    #[test]
+    fn a_direction_change_restarts_the_streak() {
+        let t0 = std::time::Instant::now();
+        let (s1, _) = scroll_streak_step(None, 0, 1, t0);
+        let (_, escalated_immediately) = scroll_streak_step(Some(s1), 0, -1, later(t0, 1_200));
+        assert!(
+            !escalated_immediately,
+            "reversing direction must restart at the slow speed"
+        );
+    }
+
+    /// A pause longer than STREAK_GAP is a new gesture too — resuming a scroll
+    /// after glancing away shouldn't inherit the old speed either.
+    #[test]
+    fn a_long_pause_restarts_the_streak() {
+        let t0 = std::time::Instant::now();
+        let (s1, _) = scroll_streak_step(None, 0, 1, t0);
+        // Long enough overall to be past ESCALATE_AFTER, but the GAP since the
+        // last tick is what should matter here.
+        let gap_tick_at = later(t0, 1_600);
+        let (_, escalated) = scroll_streak_step(Some(s1), 0, 1, gap_tick_at);
+        assert!(
+            !escalated,
+            "a stale streak with a big gap must restart, not escalate"
+        );
+    }
+
+    /// Switching tabs must not hand a fast-scrolled codex tab's escalation to a
+    /// DIFFERENT tab the user just switched to.
+    #[test]
+    fn switching_tabs_restarts_the_streak() {
+        let t0 = std::time::Instant::now();
+        let (s1, _) = scroll_streak_step(None, 0, 1, t0);
+        let (_, escalated) = scroll_streak_step(Some(s1), 1, 1, later(t0, 1_200));
+        assert!(
+            !escalated,
+            "a different tab index must not inherit the streak"
+        );
+    }
+
+    /// Consecutive fast ticks within the gap keep extending the SAME streak
+    /// (not restarting each time) — otherwise a real flick, whose ticks are only
+    /// tens of ms apart, would never accumulate enough elapsed time to escalate.
+    #[test]
+    fn consecutive_fast_ticks_accumulate_toward_escalation() {
+        let t0 = std::time::Instant::now();
+        let mut streak = None;
+        let mut escalated_at = None;
+        for i in 0..40 {
+            let t = later(t0, i * 30); // a tick every 30ms, like a real flick
+            let (s, esc) = scroll_streak_step(streak, 0, 1, t);
+            streak = Some(s);
+            if esc && escalated_at.is_none() {
+                escalated_at = Some(i);
+            }
+        }
+        assert!(
+            escalated_at.is_some(),
+            "40 ticks at 30ms (1.2s) must cross ESCALATE_AFTER"
+        );
+    }
+
+    // ── decide_agent_view_action: the codex ^T auto-open + escalation policy ──
+
+    use super::AgentViewAction;
+    use crate::config::PaneScrollView;
+
+    /// The DEFAULT behaviour, and the owner's stated preference: closed +
+    /// `Native` opens it. Exactly one toggle send, never also a scroll this tick
+    /// — see the doc on `send_agent_view_scroll_keys` for why not both.
+    #[test]
+    fn closed_and_native_opens_it() {
+        assert_eq!(
+            decide_agent_view_action(false, PaneScrollView::Native, false, false),
+            AgentViewAction::Toggle
+        );
+    }
+
+    /// A toggle already in flight (within TOGGLE_SETTLE) must NOT be re-sent —
+    /// this is the guard against the open/close flicker a fast multi-tick flick
+    /// would otherwise cause, since `^T` is a genuine toggle, not idempotent-open.
+    #[test]
+    fn closed_with_a_pending_toggle_does_nothing() {
+        assert_eq!(
+            decide_agent_view_action(false, PaneScrollView::Native, true, false),
+            AgentViewAction::Nothing
+        );
+    }
+
+    /// `Off` never opens anything, pending or not — the second of the owner's
+    /// three configurable choices ("have it do nothing").
+    #[test]
+    fn closed_and_off_does_nothing() {
+        for pending in [false, true] {
+            assert_eq!(
+                decide_agent_view_action(false, PaneScrollView::Off, pending, false),
+                AgentViewAction::Nothing,
+                "pending={pending}"
+            );
+        }
+    }
+
+    /// `SpycHistory` — the owner's stated personal preference — mounts spyc's OWN
+    /// view instead of touching the agent's, regardless of any pending toggle
+    /// (there is none to guard: this mode never sends one).
+    #[test]
+    fn closed_and_spyc_history_uses_spycs_own_view() {
+        assert_eq!(
+            decide_agent_view_action(false, PaneScrollView::SpycHistory, false, false),
+            AgentViewAction::UseSpycHistory
+        );
+    }
+
+    /// Once open, the MODE stops mattering — all three converge on scrolling.
+    /// Whatever opened it (auto or the user's own keyboard `^T`), the wheel must
+    /// scroll it.
+    #[test]
+    fn open_always_scrolls_regardless_of_mode() {
+        for mode in [
+            PaneScrollView::Native,
+            PaneScrollView::Off,
+            PaneScrollView::SpycHistory,
+        ] {
+            assert_eq!(
+                decide_agent_view_action(true, mode, false, false),
+                AgentViewAction::Scroll { fast: false },
+                "{mode:?}"
+            );
+        }
+    }
+
+    /// The other headline: open + escalated sends the FAST (page) key — this is
+    /// the fix for "scrolling is too slow in ^t mode".
+    #[test]
+    fn open_and_escalated_scrolls_fast() {
+        assert_eq!(
+            decide_agent_view_action(true, PaneScrollView::Native, false, true),
+            AgentViewAction::Scroll { fast: true }
+        );
     }
 }

--- a/src/app/mouse.rs
+++ b/src/app/mouse.rs
@@ -96,6 +96,10 @@ pub(super) enum MouseSink {
     FocusAndSelectRows(crate::app::state::Side),
     /// Copy the status line's text.
     CopyStatus,
+    /// Give the keyboard to the pane AND anchor a spyc-side text selection over its
+    /// visible grid — for a child that ignores mouse reports, so nothing else can
+    /// do the selecting (codex's `^T` transcript, a plain shell).
+    FocusAndSelectPane,
     /// Paste the system clipboard wherever a paste would land.
     Paste,
     /// Open the leader menu (right-click, from anywhere).
@@ -182,6 +186,16 @@ impl MouseSnapshot {
     /// A latch is not merely cosmetic: the popup stays on screen, and the first
     /// key that eventually reaches the resolver is consumed as a continuation —
     /// in the leader menu `p` is a chdir and `P` overwrites PROJECT_HOME.
+    /// Whether spyc should do the selecting over the pane itself.
+    ///
+    /// The complement of [`Self::can_forward_to_child`] on the mouse axis: a child
+    /// that speaks mouse draws its OWN selection (#224), and painting ours on top
+    /// would double it up. What's left — codex, a plain shell — has no other way to
+    /// be selected. Still requires a live, visible grid.
+    const fn pane_is_selectable(self) -> bool {
+        !self.pane_wants_mouse && !self.pane_closed && !self.has_scroll_pager
+    }
+
     const fn resolver_will_see_the_next_key(self) -> bool {
         !self.is_prompting && !matches!(self.pager_mount, Some(Mount::Overlay))
     }
@@ -265,6 +279,13 @@ pub(super) const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseS
             // swallowing the first click just to focus would read as broken.
             if matches!(region, Region::Pane) && snap.can_forward_to_child() {
                 return MouseSink::FocusAndForward;
+            }
+            // A live child that ignores mouse reports: nothing else can do the
+            // selecting, so spyc does it over the visible grid. Gated on the child
+            // being alive and not hidden behind a `^a v` pager, for the same reasons
+            // forwarding is — selecting text off a dead or invisible grid is noise.
+            if matches!(region, Region::Pane) && snap.pane_is_selectable() {
+                return MouseSink::FocusAndSelectPane;
             }
             // A bare list (no pager over it): focus the column and start a row
             // selection, so drag-to-copy-filenames works where the names are.
@@ -420,12 +441,14 @@ impl super::App {
                     return match target {
                         MouseDragTarget::Pager(_) => self.extend_pager_selection(ev),
                         MouseDragTarget::List(side) => self.extend_row_selection(ev, side),
+                        MouseDragTarget::Pane => self.extend_pane_selection(ev),
                     };
                 }
                 MouseEventKind::Up(MouseButton::Left) => {
                     return match target {
                         MouseDragTarget::Pager(_) => self.finish_pager_selection(ev),
                         MouseDragTarget::List(_) => self.finish_row_selection(ev),
+                        MouseDragTarget::Pane => self.finish_pane_selection(ev),
                     };
                 }
                 // Any other button mid-drag abandons the selection rather than
@@ -534,6 +557,10 @@ impl super::App {
             MouseSink::FocusAndSelectRows(side) => {
                 self.focus_region(region);
                 self.begin_row_selection(ev, side)
+            }
+            MouseSink::FocusAndSelectPane => {
+                self.focus_region(region);
+                self.begin_pane_selection(ev)
             }
             MouseSink::CopyStatus => {
                 let text = self.status_bar_plain_text();
@@ -709,6 +736,80 @@ impl super::App {
         // full-frame mount.
         let ok_msg = format!("copied {lines} line{}", if lines == 1 { "" } else { "s" });
         vec![Effect::CopyToPagerClipboard { text, ok_msg }]
+    }
+
+    /// Translate the pointer into the pane's own grid coordinates, clamped into it.
+    ///
+    /// Clamped rather than rejected outside the rect: dragging a little past the
+    /// pane's edge is normal, and it should extend to the edge cell instead of
+    /// stalling. `None` only when there is no pane rect at all.
+    fn pane_cell_at(&self, ev: MouseEvent) -> Option<(u16, u16)> {
+        let (cols, rows) = self.view.term_size;
+        let pane = self.frame_layout(Rect::new(0, 0, cols, rows)).pane?;
+        if pane.width == 0 || pane.height == 0 {
+            return None;
+        }
+        let col = ev.column.clamp(pane.x, pane.x + pane.width - 1) - pane.x;
+        let row = ev.row.clamp(pane.y, pane.y + pane.height - 1) - pane.y;
+        Some((row, col))
+    }
+
+    /// Anchor a pane text selection where the pointer pressed.
+    fn begin_pane_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        let Some(cell) = self.pane_cell_at(ev) else {
+            return Vec::new();
+        };
+        self.view.pane_selection = Some((cell, cell));
+        self.view.mouse_selection = Some(MouseDragTarget::Pane);
+        Vec::new()
+    }
+
+    /// Extend it to the pointer.
+    fn extend_pane_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        if let Some(cell) = self.pane_cell_at(ev)
+            && let Some((_, focus)) = self.view.pane_selection.as_mut()
+        {
+            *focus = cell;
+        }
+        Vec::new()
+    }
+
+    /// Copy the selected grid text, keeping the highlight up.
+    ///
+    /// A press that never moved is a click, not a selection: the highlight is
+    /// dropped and the clipboard left alone, matching the pager. Ordering happens
+    /// here (`(row, col)` pairs, not per-axis) so a backwards drag copies the same
+    /// text as the forward one.
+    fn finish_pane_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
+        self.view.mouse_selection = None;
+        if let Some(cell) = self.pane_cell_at(ev)
+            && let Some((_, focus)) = self.view.pane_selection.as_mut()
+        {
+            *focus = cell;
+        }
+        let Some((a, b)) = self.view.pane_selection else {
+            return Vec::new();
+        };
+        if a == b {
+            self.view.pane_selection = None;
+            return Vec::new();
+        }
+        let (start, end) = if a.0 < b.0 || (a.0 == b.0 && a.1 <= b.1) {
+            (a, b)
+        } else {
+            (b, a)
+        };
+        let Some(tabs) = self.runtime.pane_tabs.as_ref() else {
+            return Vec::new();
+        };
+        let text = tabs.active().selection_text(start, end);
+        if text.trim().is_empty() {
+            return Vec::new();
+        }
+        vec![Effect::CopyToClipboard {
+            text,
+            ok: super::effect::ClipMsg::PaneLines,
+        }]
     }
 
     /// The rect a column's list is drawn into, and a `ListView` over its cached
@@ -1320,10 +1421,15 @@ mod tests {
             "must do both, not just forward"
         );
 
-        // A child that never asked for mouse still gets focused, not forwarded —
-        // the #170 gate applies to buttons exactly as it does to the wheel.
+        // A child that never asked for mouse is never FORWARDED to — the #170 gate
+        // applies to buttons exactly as it does to the wheel. It now gets a
+        // spyc-side selection instead of a bare focus; see
+        // `a_non_mouse_pane_selects_instead_of_merely_focusing`.
         let unaware = snap(Some(Region::Pane));
-        assert_eq!(route_mouse(unaware, Gesture::Left), MouseSink::FocusRegion);
+        assert_eq!(
+            route_mouse(unaware, Gesture::Left),
+            MouseSink::FocusAndSelectPane
+        );
 
         // A list press focuses AND starts a row selection; see
         // `left_press_on_the_bare_list_selects_rows_in_that_column`.
@@ -2031,5 +2137,45 @@ mod tests {
                 "the drag itself must end, even though the selection stays"
             );
         });
+    }
+    // ── pane text selection (a child that ignores mouse) ──────────────────
+
+    /// The complement of forwarding: a child that ignores mouse reports gets a
+    /// spyc-side selection, because nothing else can select its text. This is what
+    /// makes copy work inside codex's `^T` transcript overlay.
+    #[test]
+    fn a_non_mouse_pane_selects_instead_of_merely_focusing() {
+        let s = snap(Some(Region::Pane));
+        assert!(!s.pane_wants_mouse);
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::FocusAndSelectPane);
+    }
+
+    /// A child that speaks mouse draws its OWN selection (#224); painting ours on
+    /// top would double it up, so forwarding still wins.
+    #[test]
+    fn a_mouse_aware_pane_still_forwards_rather_than_selecting() {
+        let s = MouseSnapshot {
+            pane_wants_mouse: true,
+            ..snap(Some(Region::Pane))
+        };
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::FocusAndForward);
+    }
+
+    /// No selecting text off a dead or hidden grid — the same two guards forwarding
+    /// uses, for the same reasons.
+    #[test]
+    fn a_dead_or_covered_pane_is_not_selectable() {
+        for (closed, covered) in [(true, false), (false, true)] {
+            let s = MouseSnapshot {
+                pane_closed: closed,
+                has_scroll_pager: covered,
+                ..snap(Some(Region::Pane))
+            };
+            assert_eq!(
+                route_mouse(s, Gesture::Left),
+                MouseSink::FocusRegion,
+                "closed={closed} covered={covered}"
+            );
+        }
     }
 }

--- a/src/app/mouse_mode.rs
+++ b/src/app/mouse_mode.rs
@@ -75,8 +75,10 @@ mod tests {
         let mut app = App::test_app(std::env::temp_dir());
         crate::set_mouse_capture_for_test(false);
 
-        // Agreement (both off, the default) → nothing.
-        assert!(!app.state.config.mouse.capture);
+        // Agreement (both off) → nothing. `capture` now defaults to true, so this
+        // starting condition is set explicitly rather than assumed from the struct
+        // default.
+        app.state.config.mouse.capture = false;
         assert!(app.settle_mouse_mode().is_empty(), "off/off must be silent");
 
         // User asks for capture → one enable.

--- a/src/app/render/chrome.rs
+++ b/src/app/render/chrome.rs
@@ -18,7 +18,6 @@ impl App {
         use ratatui::{
             style::{Modifier, Style},
             text::{Line, Span},
-            widgets::Paragraph,
         };
         let width = area.width as usize;
         // Tinting the rule + active tab in scroll mode is deliberate
@@ -291,7 +290,7 @@ impl App {
         // If anything's left (shouldn't be), pad.
         let _ = used;
 
-        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        self.draw_chrome_line(frame, area, Line::from(spans));
     }
 
     /// The per-tab agent-activity dot span: a spicy heat-pulse `●` while

--- a/src/app/render/inner.rs
+++ b/src/app/render/inner.rs
@@ -353,31 +353,6 @@ impl App {
     /// single top row, per `compute_layout`'s `pane_pct >= 100` branch). Called
     /// by the default draw and — when a vsplit keeps the status row free above a
     /// column-scoped overlay — by the overlay / TopPane-pager branches.
-    /// The status line as plain text — what a click on the status bar copies.
-    ///
-    /// Builds the same `StatusBar` the renderer does, from the same accessors, so
-    /// the copy can't drift from what's on screen.
-    pub(in crate::app) fn status_bar_plain_text(&self) -> String {
-        let (path, suffix) = self.header_parts();
-        let project_label = self
-            .state
-            .project_home
-            .as_deref()
-            .map(path_basename_display);
-        let agent_info = self.active_agent_status();
-        StatusBar {
-            project_home: project_label.as_deref(),
-            session_name: self.state.session_name.as_deref(),
-            path: &path,
-            suffix: &suffix,
-            git_info: self.state.cur().git.info.as_deref(),
-            agent_info: agent_info.as_deref(),
-            theme: &self.view.theme,
-            plain_logo: false,
-        }
-        .plain_text()
-    }
-
     fn render_status_bar(&self, frame: &mut Frame, rect: ratatui::layout::Rect) {
         let prompt_row_occupied = matches!(self.state.mode, Mode::Prompting(_))
             || self.state.flash.is_some()
@@ -392,7 +367,7 @@ impl App {
             .as_deref()
             .map(path_basename_display);
         let agent_info = self.active_agent_status();
-        StatusBar {
+        let line = StatusBar {
             project_home: project_label.as_deref(),
             session_name: self.state.session_name.as_deref(),
             path: &path,
@@ -403,7 +378,39 @@ impl App {
             // Non-truecolor terminals (GNU screen) mangle the 🌶️ glyph → red block.
             plain_logo: self.view.color_depth != crate::ui::color_depth::ColorDepth::TrueColor,
         }
-        .render(frame, rect);
+        .build_line(rect);
+        self.draw_chrome_line(frame, rect, line);
+    }
+
+    /// Draw a single-line chrome surface, recording what was drawn and painting any
+    /// mouse selection on it.
+    ///
+    /// The single funnel for the status bar and the divider, so "what got drawn" and
+    /// "what a selection copies" cannot diverge — the copy reads exactly the line
+    /// recorded here, including its width-driven truncation.
+    pub(in crate::app) fn draw_chrome_line(
+        &self,
+        frame: &mut Frame,
+        area: ratatui::layout::Rect,
+        line: ratatui::text::Line<'static>,
+    ) {
+        use ratatui::widgets::Paragraph;
+        self.view
+            .chrome_rows
+            .borrow_mut()
+            .push(crate::app::ChromeRow {
+                y: area.y,
+                x: area.x,
+                line: line.clone(),
+            });
+        let painted = match self.view.chrome_selection {
+            Some(sel) if sel.y == area.y => {
+                let (lo, hi) = sel.range();
+                crate::ui::line_select::highlight_columns(&line, usize::from(lo), usize::from(hi))
+            }
+            _ => line,
+        };
+        frame.render_widget(Paragraph::new(painted), area);
     }
 
     /// The pane selection as ordered screen coordinates, for the widget.

--- a/src/app/render/inner.rs
+++ b/src/app/render/inner.rs
@@ -49,6 +49,7 @@ impl App {
                     PaneWidget {
                         screen,
                         focused: overlay_focused,
+                        selection: self.pane_selection_screen_coords(),
                     },
                     overlay_area,
                 );
@@ -285,7 +286,14 @@ impl App {
         } else if let Some(tabs) = self.runtime.pane_tabs.as_ref() {
             let focused = self.state.pane_focused();
             tabs.active().with_screen(|screen| {
-                frame.render_widget(PaneWidget { screen, focused }, rect);
+                frame.render_widget(
+                    PaneWidget {
+                        screen,
+                        focused,
+                        selection: self.pane_selection_screen_coords(),
+                    },
+                    rect,
+                );
                 if focused && !suppress_cursor {
                     place_pty_cursor_from_screen(frame, screen, rect);
                 }
@@ -398,6 +406,22 @@ impl App {
         .render(frame, rect);
     }
 
+    /// The pane selection as ordered screen coordinates, for the widget.
+    ///
+    /// Ordered here rather than at drag time so the stored `(anchor, focus)` can
+    /// keep its direction — the renderer only ever wants start-before-end. Ordered
+    /// as `(row, col)` PAIRS, not per-axis: a backwards drag up-and-right must keep
+    /// each column attached to its own row, the same trap `char_endpoints` documents
+    /// for the pager.
+    fn pane_selection_screen_coords(&self) -> Option<((u16, u16), (u16, u16))> {
+        let (a, b) = self.view.pane_selection?;
+        Some(if a.0 < b.0 || (a.0 == b.0 && a.1 <= b.1) {
+            (a, b)
+        } else {
+            (b, a)
+        })
+    }
+
     /// The inclusive row range to highlight in `side`'s list, if a mouse row
     /// selection is active there. `None` for the other column, so a selection in `a`
     /// never paints in `b`.
@@ -473,6 +497,7 @@ impl App {
                         PaneWidget {
                             screen,
                             focused: right_focused,
+                            selection: self.pane_selection_screen_coords(),
                         },
                         rect,
                     );

--- a/src/app/render/inner.rs
+++ b/src/app/render/inner.rs
@@ -398,7 +398,7 @@ impl App {
         self.view
             .chrome_rows
             .borrow_mut()
-            .push(crate::app::ChromeRow {
+            .push(crate::app::mouse::ChromeRow {
                 y: area.y,
                 x: area.x,
                 line: line.clone(),

--- a/src/app/render/mod.rs
+++ b/src/app/render/mod.rs
@@ -416,6 +416,12 @@ impl App {
         // rows/grid) BEFORE drawing, so the draw path itself performs no
         // domain/view transitions.
         let layout = self.prepare_frame(frame.area());
+        // Chrome rows are re-recorded every frame by `draw_chrome_line`. Clearing
+        // here (not on read) means a row that stops being drawn — the status bar
+        // yields its row to the prompt when the pane is zoomed, the divider vanishes
+        // with the pane — leaves no stale rect behind for the mouse to hit-test
+        // against, which is the trap `pager_slot_at` documents for pager rects.
+        self.view.chrome_rows.borrow_mut().clear();
         // The two structural rules a centered popup border could land on (and so
         // visually merge with): the horizontal pane divider and the vertical
         // split separator. Captured before `layout` is consumed by render_inner.

--- a/src/app/streaming.rs
+++ b/src/app/streaming.rs
@@ -421,7 +421,7 @@ impl App {
             // unrelated repaint.
             if !matches!(
                 self.view.mouse_selection,
-                Some(super::MouseDragTarget::Pane)
+                Some(super::mouse::MouseDragTarget::Pane)
             ) {
                 self.view.pane_selection = None;
             }

--- a/src/app/streaming.rs
+++ b/src/app/streaming.rs
@@ -410,6 +410,21 @@ impl App {
         if pane_had_output {
             needs_draw = true;
             draw_reason = 1;
+            // A pane selection is anchored to SCREEN coordinates, so the moment the
+            // child paints, the grid scrolls out from under it and the highlight
+            // would name different text than the user picked. Dropping it is the
+            // simple half of the tradeoff in `docs/drafts/mouse_selection_plan.md`;
+            // it costs nothing for the case this serves (reading a static transcript
+            // overlay, where no output arrives) and avoids silently copying the
+            // wrong thing. Only while no drag is in flight: a drag over a chatty
+            // child should keep tracking the pointer rather than be cancelled by an
+            // unrelated repaint.
+            if !matches!(
+                self.view.mouse_selection,
+                Some(super::MouseDragTarget::Pane)
+            ) {
+                self.view.pane_selection = None;
+            }
             // Echo-latency probe (A-monitor only): this active-pane output is
             // the agent's echo of the last forwarded keystroke. Measure
             // forward→echo so we can see the pane round-trip vs render cost.

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -168,6 +168,67 @@ pub fn copy_image(png: &[u8]) -> Result<(), String> {
         .map_err(|e| format!("clipboard: {e}"))
 }
 
+/// The largest payload spyc will hand to OSC 52.
+///
+/// xterm's own limit is ~74 994 bytes of base64 and several terminals inherit it;
+/// tmux caps at 1 MB only with `set-clipboard on`. A payload over the limit is
+/// silently *truncated* by some terminals and dropped entirely by others, and a
+/// half-pasted selection is worse than a clear failure — so past this we fall back
+/// to the local helper rather than gamble.
+const OSC52_MAX_BASE64: usize = 74_994;
+
+/// Ask the TERMINAL to set the clipboard, via OSC 52.
+///
+/// This is the half that works over SSH: the escape travels back up the same
+/// connection the UI is drawn on, so the text lands on the clipboard of the machine
+/// the user is actually typing at. `pbcopy`/`xclip` set the clipboard of whatever
+/// host spyc runs on, which over SSH is the *server* — text the user can never
+/// paste.
+///
+/// `Err` when the payload is too large to send safely; the caller falls back.
+/// Success here means "the sequence was written", not "the terminal honored it":
+/// OSC 52 is write-only with no reply, and support varies (kitty/WezTerm/iTerm2/
+/// Ghostty/Alacritty yes; tmux needs `set -g set-clipboard on`; some terminals gate
+/// it deliberately, since a remote host writing your clipboard is a real risk).
+/// That unverifiability is exactly why `Auto` still prefers the local helper when
+/// there's no SSH session to justify the trade.
+pub fn copy_osc52(text: &str) -> Result<(), String> {
+    let seq = osc52_sequence(text, std::env::var_os("TMUX").is_some())?;
+    let mut out = io::stdout();
+    out.write_all(seq.as_bytes())
+        .and_then(|()| out.flush())
+        .map_err(|e| format!("osc52: {e}"))
+}
+
+/// Build the OSC 52 byte sequence for `text`. Pure — `in_tmux` is passed so tests
+/// exercise both modes without touching the process-global `TMUX`, the
+/// `term_title::wrap` / `notifications::osc9_sequence` template.
+///
+/// No sanitizing step is needed, unlike OSC 9's message: the payload is base64, so
+/// it cannot contain an `\x1b` or `\x07` to close the sequence early and inject
+/// escapes. Encoding *is* the escaping — which is why the raw text is never written
+/// through.
+fn osc52_sequence(text: &str, in_tmux: bool) -> Result<String, String> {
+    use base64::Engine as _;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    if encoded.len() > OSC52_MAX_BASE64 {
+        return Err(format!(
+            "selection too large for OSC 52 ({} bytes base64, limit {OSC52_MAX_BASE64})",
+            encoded.len()
+        ));
+    }
+    // `c` = the CLIPBOARD selection (not the X11 primary). BEL-terminated, which
+    // more terminals accept than ST.
+    let inner = format!("\x1b]52;c;{encoded}\x07");
+    Ok(if in_tmux {
+        // tmux eats escapes aimed at itself; DCS passthrough forwards them to the
+        // outer terminal, with inner ESCs doubled.
+        format!("\x1bPtmux;{}\x1b\\", inner.replace('\x1b', "\x1b\x1b"))
+    } else {
+        inner
+    })
+}
+
 /// Write `text` to the system clipboard.
 pub fn copy(text: &str) -> io::Result<()> {
     #[cfg(test)]
@@ -369,5 +430,88 @@ mod tests {
         let err = with_clipboard_override(&stub, || copy(&big))
             .expect_err("a helper that ignores a large stdin should surface a write error");
         assert_eq!(err.kind(), io::ErrorKind::BrokenPipe, "got {err:?}");
+    }
+}
+
+#[cfg(test)]
+mod osc52_tests {
+    use super::{OSC52_MAX_BASE64, osc52_sequence};
+
+    #[test]
+    fn plain_sequence_is_osc52_clipboard_base64_bel() {
+        let seq = osc52_sequence("hi", false).expect("small payload");
+        // "hi" -> aGk=
+        assert_eq!(seq, "\x1b]52;c;aGk=\x07");
+    }
+
+    /// Inside tmux the sequence must be DCS-wrapped with inner ESCs doubled, or tmux
+    /// consumes it instead of forwarding to the outer terminal.
+    #[test]
+    fn tmux_wraps_in_dcs_passthrough_with_doubled_escapes() {
+        let seq = osc52_sequence("hi", true).expect("small payload");
+        assert!(seq.starts_with("\x1bPtmux;"), "got {seq:?}");
+        assert!(seq.ends_with("\x1b\\"), "got {seq:?}");
+        assert!(
+            seq.contains("\x1b\x1b]52;c;aGk="),
+            "inner ESC must be doubled: {seq:?}"
+        );
+    }
+
+    /// **Encoding is the escaping.** Text containing the OSC terminators — the
+    /// injection vector that forces `notifications::osc9_sequence` to strip control
+    /// chars — cannot break out here, because everything between `52;c;` and the
+    /// terminator is base64 and its alphabet excludes ESC and BEL.
+    #[test]
+    fn control_chars_in_the_text_cannot_terminate_the_sequence() {
+        let hostile = "\x1b]52;c;evil\x07 and \x1b\\ more";
+        let seq = osc52_sequence(hostile, false).expect("small payload");
+        let body = seq
+            .strip_prefix("\x1b]52;c;")
+            .and_then(|r| r.strip_suffix('\x07'))
+            .expect("well-formed wrapper");
+        assert!(
+            body.chars()
+                .all(|c| c.is_ascii_alphanumeric() || "+/=".contains(c)),
+            "payload must be pure base64, got {body:?}"
+        );
+        // Exactly one terminator: the one we wrote.
+        assert_eq!(seq.matches('\x07').count(), 1);
+    }
+
+    /// Round-trips, so the terminal receives what the user selected.
+    #[test]
+    fn payload_decodes_back_to_the_original_text() {
+        use base64::Engine as _;
+        let text = "multi\nline\tselection — ünïcode 中";
+        let seq = osc52_sequence(text, false).expect("small payload");
+        let body = seq
+            .strip_prefix("\x1b]52;c;")
+            .and_then(|r| r.strip_suffix('\x07'))
+            .expect("well-formed");
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(body)
+            .expect("valid base64");
+        assert_eq!(String::from_utf8(decoded).expect("utf8"), text);
+    }
+
+    /// Over-limit payloads must ERROR rather than be sent: several terminals
+    /// silently truncate an oversized OSC 52, and half a selection on the clipboard
+    /// is worse than a reported failure (the caller falls back to the local helper).
+    #[test]
+    fn an_oversized_payload_is_refused_not_truncated() {
+        // 3 bytes -> 4 base64 chars, so this comfortably exceeds the cap.
+        let big = "x".repeat(OSC52_MAX_BASE64);
+        let err = osc52_sequence(&big, false).expect_err("must refuse");
+        assert!(err.contains("too large"), "got {err:?}");
+    }
+
+    /// And a payload just under the cap still goes out — the guard must not be so
+    /// conservative that ordinary selections start failing.
+    #[test]
+    fn a_payload_just_under_the_cap_is_sent() {
+        // 3 raw bytes encode to exactly 4 base64 chars, no padding growth.
+        let raw = (OSC52_MAX_BASE64 / 4) * 3;
+        let text = "y".repeat(raw);
+        assert!(osc52_sequence(&text, false).is_ok());
     }
 }

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -89,7 +89,7 @@
 # tab_width = 4
 
 # ── mouse ─────────────────────────────────────────────────────────────
-# `capture` (default false): ask the terminal for real mouse reporting
+# `capture` (default true): ask the terminal for real mouse reporting
 # (wheel + buttons) so spyc can scroll whatever is under the pointer.
 #
 # TRADE-OFF, read before enabling: any mouse capture takes native
@@ -107,7 +107,7 @@
 # forwarding to a mouse-aware child is unaffected — the child gets one event
 # per tick and picks its own step. Clamped to >= 1.
 [mouse]
-# capture = false
+# capture = true
 # scroll_lines = 1
 #
 # `pane_scroll_lines` (default 3): lines per wheel tick for an agent PANE whose

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -109,6 +109,14 @@
 [mouse]
 # capture = false
 # scroll_lines = 1
+#
+# `pane_scroll_lines` (default 3): lines per wheel tick for an agent PANE whose
+# child ignores mouse reports, where spyc synthesizes that agent's own scroll
+# keys (codex's `^T` transcript, agy inline). Separate from `scroll_lines`
+# because it's a different job: the list wants 1:1 with the trackpad, while
+# here spyc is driving somebody else's pager one keypress per line, with no
+# safe way to ask it for a page. Raise it to traverse long histories faster.
+# pane_scroll_lines = 3
 
 # ── markdown ──────────────────────────────────────────────────────────
 # Default view for `.md` / `.markdown` files in the pager.

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -116,7 +116,20 @@
 # because it's a different job: the list wants 1:1 with the trackpad, while
 # here spyc is driving somebody else's pager one keypress per line, with no
 # safe way to ask it for a page. Raise it to traverse long histories faster.
+# A sustained wheel gesture (default: past 1s) auto-escalates to a page-sized
+# step where an agent has one verified (codex's `^T`) — `pane_scroll_lines`
+# is the line-scroll floor under that.
 # pane_scroll_lines = 3
+#
+# `pane_scroll_view` (default native): what the wheel does the FIRST time it
+# hits an agent pane whose own scrollback view (today: codex's `^T`) isn't
+# open yet.
+#   native       open the agent's own view and scroll it.
+#   off          leave it closed — only scroll if it happens to already be open.
+#   spyc_history open spyc's OWN `^a v` scrollback pager instead.
+# Doesn't affect an already-open view (always scrolled) or an agent with no
+# such view (agy scrolls its live content directly, with nothing to open).
+# pane_scroll_view = "native"
 
 # ── markdown ──────────────────────────────────────────────────────────
 # Default view for `.md` / `.markdown` files in the pager.

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -165,6 +165,28 @@
 #                                you're usually in another app while it works.
 # The intrusive channels (bell + flash) fire on Blocked only by default; the
 # quiet desktop ping fires on Done too. Flip *_done to change that per channel.
+# ── [clipboard] ── where a yank actually lands ────────────────────────────
+#
+# `via` (default auto):
+#   auto    OSC-52 terminal escape when spyc is over SSH, the local helper
+#           otherwise. The distinction matters: `pbcopy` / `wl-copy` / `xclip`
+#           set the clipboard of the machine spyc RUNS on, so over SSH they
+#           succeed on the server and the text is somewhere you can never
+#           paste from. OSC 52 travels back up the connection to the terminal
+#           you're actually typing at.
+#   system  local helper only.
+#   osc52   terminal escape only.
+#   both    try both (useful if you paste on either end).
+#
+# Local stays helper-first on purpose: OSC 52 is write-only with no reply, so
+# spyc can't confirm the terminal honored it, and some terminals disable it
+# deliberately (a remote host writing your clipboard is a real risk). Inside
+# tmux it needs `set -g set-clipboard on`; spyc DCS-wraps the escape so tmux
+# forwards it. Oversized selections fall back rather than risk a terminal
+# silently truncating them.
+[clipboard]
+# via = "auto"
+
 [notify]
 # desktop = true
 # desktop_via = "auto"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -307,6 +307,7 @@ pub struct MouseConfig {
     /// forwarding to a mouse-aware child is unaffected: the child gets one event
     /// per tick and picks its own step. Clamped to at least 1 on load.
     pub scroll_lines: usize,
+    pub pane_scroll_lines: usize,
 }
 
 impl Default for MouseConfig {
@@ -314,6 +315,7 @@ impl Default for MouseConfig {
         Self {
             capture: false,
             scroll_lines: 1,
+            pane_scroll_lines: 3,
         }
     }
 }
@@ -336,6 +338,7 @@ struct FileMouse {
     capture: Option<bool>,
     #[serde(default)]
     scroll_lines: Option<usize>,
+    pane_scroll_lines: Option<usize>,
 }
 
 /// Markdown viewer knobs.
@@ -698,6 +701,9 @@ impl Config {
         // the wheel a no-op on spyc-owned surfaces.
         if let Some(b) = file.mouse.capture {
             self.mouse.capture = b;
+        }
+        if let Some(n) = file.mouse.pane_scroll_lines {
+            self.mouse.pane_scroll_lines = n.max(1);
         }
         if let Some(n) = file.mouse.scroll_lines {
             self.mouse.scroll_lines = n.max(1);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -297,6 +297,25 @@ impl Default for PagerConfig {
     }
 }
 
+/// `[mouse] pane_scroll_view` — what a wheel tick does the first time it hits an
+/// agent pane whose own scrollback view (today: codex's `^T`) isn't open yet.
+///
+/// Doesn't affect an already-open view (always scrolled) or an agent with no such
+/// view at all (agy scrolls its live content directly via `wheel_scroll`, with
+/// nothing to open).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PaneScrollView {
+    /// Open the agent's own view (its `transcript_toggle_key`) and scroll it.
+    #[default]
+    Native,
+    /// Leave it closed — only scroll if it happens to already be open.
+    Off,
+    /// Open spyc's OWN `^a v` scrollback pager instead of the agent's view.
+    #[serde(rename = "spyc_history")]
+    SpycHistory,
+}
+
 /// Mouse-reporting knobs (`[mouse]`).
 #[derive(Debug, Clone)]
 pub struct MouseConfig {
@@ -310,6 +329,9 @@ pub struct MouseConfig {
     /// per tick and picks its own step. Clamped to at least 1 on load.
     pub scroll_lines: usize,
     pub pane_scroll_lines: usize,
+    /// What a wheel tick over an agent pane whose OWN scrollback view spyc can
+    /// drive (today: codex's `^T`) does when that view isn't already open.
+    pub pane_scroll_view: PaneScrollView,
 }
 
 impl Default for MouseConfig {
@@ -318,6 +340,7 @@ impl Default for MouseConfig {
             capture: false,
             scroll_lines: 1,
             pane_scroll_lines: 3,
+            pane_scroll_view: PaneScrollView::default(),
         }
     }
 }
@@ -341,6 +364,8 @@ struct FileMouse {
     #[serde(default)]
     scroll_lines: Option<usize>,
     pane_scroll_lines: Option<usize>,
+    #[serde(default)]
+    pane_scroll_view: Option<PaneScrollView>,
 }
 
 /// Markdown viewer knobs.
@@ -747,6 +772,9 @@ impl Config {
         if let Some(n) = file.mouse.pane_scroll_lines {
             self.mouse.pane_scroll_lines = n.max(1);
         }
+        if let Some(v) = file.mouse.pane_scroll_view {
+            self.mouse.pane_scroll_view = v;
+        }
         if let Some(n) = file.mouse.scroll_lines {
             self.mouse.scroll_lines = n.max(1);
         }
@@ -856,6 +884,26 @@ mod tests {
     use super::*;
     use std::io::Write;
     use tempfile::tempdir;
+
+    /// The template documents `pane_scroll_view = "native" | "off" | "spyc_history"`
+    /// as the accepted strings. This is the test that would have caught it when
+    /// the doc initially said `spyc_history` while the enum's `rename_all =
+    /// "lowercase"` actually produced `spychistory` — `default_template_round_trips`
+    /// only parses the fully-commented template, so it never exercises a
+    /// documented VALUE string, only that the file parses at all.
+    #[test]
+    fn pane_scroll_view_accepts_every_string_the_template_documents() {
+        for (toml_value, want) in [
+            ("native", PaneScrollView::Native),
+            ("off", PaneScrollView::Off),
+            ("spyc_history", PaneScrollView::SpycHistory),
+        ] {
+            let doc = format!("[mouse]\npane_scroll_view = \"{toml_value}\"\n");
+            let file: FileConfig =
+                toml::from_str(&doc).unwrap_or_else(|e| panic!("{toml_value:?} must parse: {e}"));
+            assert_eq!(file.mouse.pane_scroll_view, Some(want), "{toml_value:?}");
+        }
+    }
 
     #[test]
     fn default_template_round_trips() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -320,9 +320,11 @@ pub enum PaneScrollView {
 #[derive(Debug, Clone)]
 pub struct MouseConfig {
     /// Ask the terminal for real mouse reporting (wheel + buttons) so spyc can
-    /// scroll whatever is under the pointer. Costs native click-drag selection
-    /// while on — the terminal's bypass modifier (Shift on most, Option/Fn on
-    /// iTerm2) or `:mouse off` reclaims it.
+    /// scroll whatever is under the pointer. Default ON as of the #226–#234
+    /// campaign (wheel routing, drag-select in the pager/list/chrome/pane,
+    /// per-agent scroll keys). Costs native click-drag selection while on —
+    /// the terminal's bypass modifier (Shift on most, Option/Fn on iTerm2) or
+    /// `:mouse off` reclaims it.
     pub capture: bool,
     /// Lines per wheel tick for the surfaces spyc scrolls itself. A pane
     /// forwarding to a mouse-aware child is unaffected: the child gets one event
@@ -337,7 +339,7 @@ pub struct MouseConfig {
 impl Default for MouseConfig {
     fn default() -> Self {
         Self {
-            capture: false,
+            capture: true,
             scroll_lines: 1,
             pane_scroll_lines: 3,
             pane_scroll_view: PaneScrollView::default(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -50,6 +50,8 @@ pub struct Config {
 
     /// Agent-status notification knobs (`[notify]`).
     pub notify: NotifyConfig,
+    /// `[clipboard]` — OSC 52 vs the local helper.
+    pub clipboard: ClipboardConfig,
 
     /// Mouse reporting knobs (`[mouse]`).
     pub mouse: MouseConfig,
@@ -385,6 +387,37 @@ struct FileDelete {
     confirm: Option<bool>,
 }
 
+/// How a clipboard copy is delivered (`[clipboard].via`).
+///
+/// `Auto` routes to an OSC-52 terminal escape over SSH — so a yank reaches the
+/// clipboard of the machine you're typing at rather than the remote box spyc runs on
+/// — and the local helper (`pbcopy`/`wl-copy`/`xclip`) otherwise. Same shape and
+/// same reasoning as [`DesktopVia`].
+///
+/// Local stays helper-first on purpose: OSC 52 is write-only with no reply, so spyc
+/// can never confirm the terminal honored it, and some terminals disable it
+/// deliberately (a remote host silently writing your clipboard is a real risk). With
+/// no SSH session there's nothing to trade that uncertainty for.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ClipboardVia {
+    #[default]
+    Auto,
+    /// Local helper only (`pbcopy` / `wl-copy` / `xclip` — the machine spyc runs on).
+    System,
+    /// OSC-52 terminal escape only (your client terminal).
+    Osc52,
+    /// Try OSC 52 and the local helper. Useful when you paste on both ends.
+    Both,
+}
+
+/// `[clipboard]` — where a yank actually lands.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct ClipboardConfig {
+    pub via: ClipboardVia,
+}
+
 /// How a desktop notification is delivered (`[notify].desktop_via`). `Auto`
 /// routes to an OSC-9 terminal escape over SSH (so the ping reaches your *client*
 /// terminal, not the remote box spyc runs on) and the OS notifier locally.
@@ -466,6 +499,13 @@ impl Default for NotifyConfig {
 /// On-disk shape of `[notify]`. `Option` per field for "didn't set" disambig,
 /// so a project file with a bare `[notify]` doesn't clobber user defaults.
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FileClipboard {
+    #[serde(default)]
+    via: Option<ClipboardVia>,
+}
+
+#[derive(Debug, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
 struct FileNotify {
     #[serde(default)]
@@ -563,6 +603,8 @@ struct FileConfig {
     delete: FileDelete,
     #[serde(default)]
     notify: FileNotify,
+    #[serde(default)]
+    clipboard: FileClipboard,
     #[serde(default)]
     ignore_masks: Vec<IgnoreMask>,
     #[serde(default)]
@@ -720,6 +762,9 @@ impl Config {
         }
 
         // Notify: per-field merge.
+        if let Some(v) = file.clipboard.via {
+            self.clipboard.via = v;
+        }
         if let Some(b) = file.notify.desktop {
             self.notify.desktop = b;
         }

--- a/src/pane/mod.rs
+++ b/src/pane/mod.rs
@@ -404,6 +404,29 @@ impl Pane {
     /// parser is mutex-protected (the worker thread owns the write
     /// path); this acquires the lock for the duration of `f`, so
     /// keep the closure body short. Returns whatever `f` returns.
+    /// The visible-grid text between two screen positions, for a clipboard copy.
+    ///
+    /// Delegates to `vt100::Screen::contents_between`, which is purpose-built for
+    /// this ("useful for things like determining the contents of a clipboard
+    /// selection"). Two properties make it the right primitive rather than merely a
+    /// convenient one, and are why this isn't a hand-rolled cell walk:
+    ///
+    /// - it reads `grid().visible_rows()`, so it follows the pane's CURRENT scroll
+    ///   position — the same rows the widget drew, with no coordinate translation;
+    /// - it honors `row.wrapped()`, emitting a newline only at a HARD line end. A
+    ///   cell walk inserts a spurious `\n` in the middle of every soft-wrapped
+    ///   line, which is the most irritating bug a terminal selection can have.
+    ///
+    /// Trailing whitespace is trimmed per line: the grid is space-padded to its full
+    /// width, so an untrimmed copy pastes a ragged block of spaces.
+    pub fn selection_text(&self, start: (u16, u16), end: (u16, u16)) -> String {
+        let raw = self.with_screen(|s| s.contents_between(start.0, start.1, end.0, end.1));
+        raw.lines()
+            .map(str::trim_end)
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
     pub fn with_screen<R, F: FnOnce(&vt100::Screen) -> R>(&self, f: F) -> R {
         let guard = self.lock_parser();
         f(guard.screen())

--- a/src/pane/widget.rs
+++ b/src/pane/widget.rs
@@ -14,6 +14,12 @@ use ratatui::{
 pub struct PaneWidget<'a> {
     pub screen: &'a vt100::Screen,
     pub focused: bool,
+    /// A spyc-side text selection over the visible grid, as ordered
+    /// `((start_row, start_col), (end_row, end_col))` in SCREEN coordinates.
+    ///
+    /// Only ever set for a child that ignores mouse reports — one that speaks mouse
+    /// draws its own selection, and painting ours on top would double it up.
+    pub selection: Option<((u16, u16), (u16, u16))>,
 }
 
 impl Widget for PaneWidget<'_> {
@@ -41,7 +47,14 @@ impl Widget for PaneWidget<'_> {
                 };
                 let contents = cell.contents();
                 let ch: &str = if contents.is_empty() { " " } else { contents };
-                let style = cell_style(cell).add_modifier(dim);
+                let mut style = cell_style(cell).add_modifier(dim);
+                if selected(self.selection, row, col) {
+                    // Reverse rather than a theme bg: the pane's cells carry the
+                    // CHILD's colors, which can be anything, so a fixed background
+                    // would vanish against a child that happens to use it. Reverse
+                    // is relative to whatever the cell already is.
+                    style = style.add_modifier(Modifier::REVERSED);
+                }
                 let x = area.x + col;
                 let y = area.y + row;
                 buf.set_string(x, y, ch, style);
@@ -105,5 +118,62 @@ pub const fn convert_color(c: vt100::Color) -> Color {
         vt100::Color::Default => Color::Reset,
         vt100::Color::Idx(i) => Color::Indexed(i),
         vt100::Color::Rgb(r, g, b) => Color::Rgb(r, g, b),
+    }
+}
+
+/// Whether `(row, col)` falls inside a charwise selection.
+///
+/// Charwise, not rectangular: the first row runs from its start column to the end
+/// of the line, interior rows are whole, and the last row stops at its end column.
+/// A rectangle would be wrong for prose — selecting three lines of a paragraph
+/// would clip them all to the same columns.
+const fn selected(sel: Option<((u16, u16), (u16, u16))>, row: u16, col: u16) -> bool {
+    let Some(((sr, sc), (er, ec))) = sel else {
+        return false;
+    };
+    if row < sr || row > er {
+        return false;
+    }
+    let after_start = row > sr || col >= sc;
+    let before_end = row < er || col <= ec;
+    after_start && before_end
+}
+
+#[cfg(test)]
+mod selection_tests {
+    use super::selected;
+
+    /// A multi-row selection takes the tail of the first row, all of the middle, and
+    /// the head of the last — not a rectangle.
+    #[test]
+    fn charwise_spans_rows_without_clipping_to_a_column_box() {
+        let sel = Some(((1, 5), (3, 2)));
+        assert!(
+            !selected(sel, 1, 4),
+            "before the start column on the first row"
+        );
+        assert!(selected(sel, 1, 5), "the start cell");
+        assert!(selected(sel, 1, 99), "to end of the first row");
+        assert!(selected(sel, 2, 0), "a whole interior row");
+        assert!(selected(sel, 2, 99), "…including its tail");
+        assert!(selected(sel, 3, 2), "up to the end column");
+        assert!(!selected(sel, 3, 3), "past the end column on the last row");
+        assert!(!selected(sel, 0, 5), "above the selection");
+        assert!(!selected(sel, 4, 0), "below the selection");
+    }
+
+    /// A single-row selection is bounded at BOTH ends.
+    #[test]
+    fn charwise_within_one_row_is_bounded_both_ends() {
+        let sel = Some(((2, 3), (2, 6)));
+        assert!(!selected(sel, 2, 2));
+        assert!(selected(sel, 2, 3));
+        assert!(selected(sel, 2, 6));
+        assert!(!selected(sel, 2, 7));
+    }
+
+    #[test]
+    fn no_selection_selects_nothing() {
+        assert!(!selected(None, 0, 0));
     }
 }

--- a/src/ui/line_select.rs
+++ b/src/ui/line_select.rs
@@ -1,0 +1,181 @@
+//! Column-range selection over a rendered [`Line`] — the primitive the
+//! single-line chrome surfaces (status bar, pane divider) use for drag-select.
+//!
+//! Both operations walk the line's spans accumulating **display width**, not byte
+//! or char counts, because a screen column is a width. The status bar opens with a
+//! 2-cell `🌶️` and can carry wide glyphs in a session name or a path, so a
+//! byte/char index would drift from the column the pointer was actually over — and
+//! the highlight and the copied text would then disagree about what was selected.
+//! One shared walk, so they cannot.
+
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+
+/// The text occupying columns `lo..=hi` of `line`.
+///
+/// A char straddling `lo` or `hi` (a wide glyph the range only half covers) is
+/// included: a partial cell is still a character the user pointed at, and
+/// returning half a glyph is not an option.
+pub fn text_between_columns(line: &Line<'_>, lo: usize, hi: usize) -> String {
+    let mut out = String::new();
+    let mut col = 0usize;
+    for span in &line.spans {
+        for ch in span.content.chars() {
+            let w = unicode_width::UnicodeWidthChar::width(ch)
+                .unwrap_or(0)
+                .max(1);
+            let end = col + w - 1; // last column this char occupies
+            if col <= hi && end >= lo {
+                out.push(ch);
+            }
+            col += w;
+            if col > hi {
+                return out;
+            }
+        }
+    }
+    out
+}
+
+/// `line` with columns `lo..=hi` reverse-video, for the selection highlight.
+///
+/// Reverse rather than a theme background: the chrome lines are powerline segments
+/// that already set their own per-segment backgrounds, so a fixed bg would be
+/// invisible against whichever segment happens to use it. Reverse is relative to
+/// whatever each cell already is.
+///
+/// Splits spans at the range boundaries, preserving each piece's original style —
+/// the same shape as the pager's `paint_block_selection`, generalized to any line.
+pub fn highlight_columns(line: &Line<'static>, lo: usize, hi: usize) -> Line<'static> {
+    let mut out: Vec<Span<'static>> = Vec::with_capacity(line.spans.len() + 2);
+    let mut col = 0usize;
+    for span in &line.spans {
+        // Accumulate runs of same-selectedness so the output isn't one span per
+        // character, which would bloat every frame's diff.
+        let mut run = String::new();
+        let mut run_selected: Option<bool> = None;
+        let flush = |out: &mut Vec<Span<'static>>, run: &mut String, sel: Option<bool>| {
+            if run.is_empty() {
+                return;
+            }
+            let style: Style = if sel == Some(true) {
+                span.style.add_modifier(Modifier::REVERSED)
+            } else {
+                span.style
+            };
+            out.push(Span::styled(std::mem::take(run), style));
+        };
+        for ch in span.content.chars() {
+            let w = unicode_width::UnicodeWidthChar::width(ch)
+                .unwrap_or(0)
+                .max(1);
+            let end = col + w - 1;
+            let selected = col <= hi && end >= lo;
+            if run_selected != Some(selected) {
+                flush(&mut out, &mut run, run_selected);
+                run_selected = Some(selected);
+            }
+            run.push(ch);
+            col += w;
+        }
+        flush(&mut out, &mut run, run_selected);
+    }
+    Line::from(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{highlight_columns, text_between_columns};
+    use ratatui::style::{Color, Modifier, Style};
+    use ratatui::text::{Line, Span};
+
+    fn seg_line() -> Line<'static> {
+        // Three styled segments, as the status bar builds them.
+        Line::from(vec![
+            Span::styled("spyc", Style::default().fg(Color::Red)),
+            Span::styled("|", Style::default().fg(Color::Blue)),
+            Span::styled("main*", Style::default().fg(Color::Green)),
+        ])
+    }
+
+    /// A range can start and end mid-span — that's the point of substring
+    /// selection: copy just the branch name, not the whole line.
+    #[test]
+    fn text_between_columns_crosses_span_boundaries() {
+        let l = seg_line();
+        assert_eq!(text_between_columns(&l, 0, 3), "spyc");
+        assert_eq!(text_between_columns(&l, 5, 9), "main*", "just the branch");
+        assert_eq!(text_between_columns(&l, 2, 6), "yc|ma", "across two seams");
+        assert_eq!(text_between_columns(&l, 0, 99), "spyc|main*", "clamped");
+    }
+
+    #[test]
+    fn text_between_columns_single_column() {
+        assert_eq!(text_between_columns(&seg_line(), 4, 4), "|");
+    }
+
+    /// Columns are display widths, not char indices. With a 2-cell leading glyph,
+    /// column 2 must be the character AFTER it — this is the drift that would make
+    /// the highlight and the copy disagree.
+    ///
+    /// Uses CJK, which is unambiguously width 2 in `unicode-width`. Emoji width is
+    /// table- and version-dependent (bare U+1F336 `🌶` measures 1, not 2), and
+    /// pinning that here would test the width crate rather than this walk.
+    #[test]
+    fn columns_are_display_widths_not_char_indices() {
+        let l = Line::from(vec![Span::raw("中ab")]);
+        assert_eq!(text_between_columns(&l, 0, 1), "中");
+        assert_eq!(text_between_columns(&l, 2, 2), "a");
+        assert_eq!(text_between_columns(&l, 3, 3), "b");
+    }
+
+    /// A wide glyph only half-covered by the range is still included — a partial
+    /// cell is a character the user pointed at, and half a glyph isn't a thing.
+    #[test]
+    fn a_straddled_wide_char_is_included() {
+        let l = Line::from(vec![Span::raw("a中b")]);
+        // `中` occupies columns 1-2; a range of just column 2 covers its right half.
+        assert_eq!(text_between_columns(&l, 2, 2), "中", "right half only");
+        assert_eq!(text_between_columns(&l, 1, 1), "中", "left half only");
+    }
+
+    /// The highlight reverses exactly the selected columns and preserves each
+    /// piece's original style, so a segment's own colors survive.
+    #[test]
+    fn highlight_reverses_only_the_selected_columns() {
+        let out = highlight_columns(&seg_line(), 5, 9);
+        // Reconstruct which columns came back REVERSED.
+        let mut reversed_cols = Vec::new();
+        let mut col = 0usize;
+        for s in &out.spans {
+            let rev = s.style.add_modifier.contains(Modifier::REVERSED);
+            for _ in s.content.chars() {
+                if rev {
+                    reversed_cols.push(col);
+                }
+                col += 1;
+            }
+        }
+        assert_eq!(reversed_cols, vec![5, 6, 7, 8, 9]);
+        // Text is unchanged.
+        let text: String = out.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "spyc|main*");
+        // The green of the branch segment survives under the reverse.
+        let branch = out
+            .spans
+            .iter()
+            .find(|s| s.content.contains("main"))
+            .expect("branch span");
+        assert_eq!(branch.style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn highlight_with_a_range_past_the_end_is_harmless() {
+        let out = highlight_columns(&seg_line(), 50, 60);
+        let any_rev = out
+            .spans
+            .iter()
+            .any(|s| s.style.add_modifier.contains(Modifier::REVERSED));
+        assert!(!any_rev, "nothing on the line is in range");
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,6 +13,7 @@ pub mod help;
 pub mod hex;
 pub mod json;
 pub mod line_edit;
+pub mod line_select;
 pub mod list_view;
 pub mod markdown;
 pub mod pager;

--- a/src/ui/status.rs
+++ b/src/ui/status.rs
@@ -1,9 +1,7 @@
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::Paragraph,
 };
 
 use crate::ui::theme::Theme;
@@ -45,39 +43,19 @@ fn push_segment(spans: &mut Vec<Span>, text: &str, fg: Color, bg: Color, next_bg
 }
 
 impl StatusBar<'_> {
-    /// The status line's **content** as plain text, for a mouse copy.
-    ///
-    /// Joins the semantic segments and deliberately omits the powerline separators
-    /// and the logo: those are chrome, and a copy that included them would paste
-    /// Nerd-Font glyphs into a bug report. Same rule the pager's selection follows —
-    /// copy what the line says, not what draws it.
-    ///
-    /// Not derived from the rendered spans, because those are truncated to the
-    /// terminal width; the copy should carry the full path even when the bar
-    /// elided it.
-    pub fn plain_text(&self) -> String {
-        [
-            self.project_home,
-            self.session_name,
-            Some(self.path),
-            self.git_info,
-            self.agent_info,
-            (!self.suffix.is_empty()).then_some(self.suffix),
-        ]
-        .into_iter()
-        .flatten()
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join(" | ")
+    /// The bar as a styled [`Line`], exactly as it will be drawn — including the
+    /// width-driven truncation. Split out so the app layer can record what was
+    /// actually rendered: a mouse selection maps screen COLUMNS back to characters,
+    /// which only works against the drawn line, not the semantic segments.
+    pub fn build_line(&self, area: Rect) -> Line<'static> {
+        if self.theme.mono {
+            return self.plain_line(area);
+        }
+        self.powerline(area)
     }
 
     #[allow(clippy::similar_names)]
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
-        if self.theme.mono {
-            self.render_plain(frame, area);
-            return;
-        }
-
+    fn powerline(&self, area: Rect) -> Line<'static> {
         let avail = area.width as usize;
 
         // Segment background/foreground colors.
@@ -168,7 +146,7 @@ impl StatusBar<'_> {
 
         // Path (always present).
         spans.push(Span::styled(
-            &path_text,
+            path_text.clone(),
             Style::default().fg(path_fg).bg(path_bg),
         ));
         spans.push(Span::styled(
@@ -204,11 +182,11 @@ impl StatusBar<'_> {
             ));
         }
 
-        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        Line::from(spans)
     }
 
     /// Fallback plain rendering for mono mode.
-    fn render_plain(&self, frame: &mut Frame, area: Rect) {
+    fn plain_line(&self, area: Rect) -> Line<'static> {
         let avail = area.width as usize;
 
         let parts: Vec<&str> = [self.project_home, self.session_name]
@@ -249,7 +227,7 @@ impl StatusBar<'_> {
                 Style::default().add_modifier(Modifier::DIM),
             ));
         }
-        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        Line::from(spans)
     }
 }
 
@@ -294,6 +272,7 @@ fn dw(s: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::widgets::Paragraph;
 
     #[test]
     fn short_path_unchanged() {
@@ -379,7 +358,7 @@ mod tests {
                     theme: &theme,
                     plain_logo,
                 };
-                bar.render(f, area);
+                f.render_widget(Paragraph::new(bar.build_line(area)), area);
             })
             .unwrap();
         let buf = terminal.backend().buffer().clone();


### PR DESCRIPTION
Closes the last selection gap — copy inside codex's `^T` transcript overlay, and in a plain shell pane. Owner-verified: *"it's workable now in codex and I can select / copy"*. Closes #231.

## The rule

The exact complement of #224's forwarding:

```rust
!pane_wants_mouse && !pane_closed && !has_scroll_pager
```

A child that speaks mouse (claude, vim) draws its **own** selection, so painting ours on top would double it up. What's left — codex, plain shells — has no other way to be selected. Still requires a live, visible grid.

## Extraction

`vt100::Screen::contents_between`, which is purpose-built for this ("useful for things like determining the contents of a clipboard selection"). Two properties earn it over a hand-rolled cell walk:

- it reads `grid().visible_rows()`, so it follows the pane's **current scroll position** with no coordinate translation;
- it honors `row.wrapped()`, emitting a newline only at a **hard** line end. A cell walk inserts a spurious `\n` into every soft-wrapped line — the most irritating bug a terminal selection can have.

Trailing whitespace is trimmed per line, since the grid is space-padded to full width.

Charwise, not rectangular: first row from its start column to end-of-line, interior rows whole, last row to its end column. A rectangle would clip every line of a selected paragraph to the same columns. Ordered as `(row, col)` **pairs**, not per-axis — the same trap `char_endpoints` documents for the pager.

The highlight is `REVERSED` rather than a theme background: the pane's cells carry the **child's** colors, which can be anything, so a fixed bg would vanish against a child that happens to use it.

## Selection stability — I did not do what #231 recommended

#231 recommended freeze-on-drag (tmux-style). I didn't, and the reason is measured: **codex has 0 rows of vt100 scrollback** (it confines its transcript to a DECSTBM scroll region), so scroll mode has nothing to freeze into — freezing is degenerate for the exact case this exists to serve.

Instead the selection is anchored to screen coordinates and dropped when the child paints (`drain_pane_output`). A static transcript overlay emits nothing while you read it, so that costs nothing there. The clear is **skipped while a drag is in flight**, so an unrelated repaint can't cancel a drag over a chatty child. On a live shell, output will clear a finished selection; absolute anchoring is the upgrade if that proves annoying.

## Verification

`make check` green (exit-code verified), 1744 tests pass.

New: unit tests for the charwise `selected()` predicate (multi-row spans without clipping to a column box, single-row bounded both ends); routing tests that a non-mouse pane selects, a mouse-aware pane still forwards, and a dead-or-covered pane is neither.

One existing test asserted a bare `FocusRegion` for a non-mouse pane press; updated to the new contract with the reason recorded, as with #229/#233.

## Follow-ups

- The wheel step for a pane is capped at `[mouse] scroll_lines` (now 1), which makes a long `^T` history slow to traverse — separate fix.
- Chrome-line (status / divider) drag-select still pending a design call.
