### PR TITLE
docs(mcp): record the root-override scoping decision (review F1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -301,6 +301,27 @@ so we don't re-litigate them. Full history in CHANGELOG.md.
 - **No `unsafe` going forward** — DI / rustix / signal-hook over raw
   libc; unsafe is exceptional and isolated (a future crate split would
   give it a dedicated crate).
+- **The MCP `root` override is validated, not merely documented.**
+  `get_file_content`'s traversal check anchors on a caller-supplied
+  root, so `root: "/"` made it decorative. Enforcement beats a
+  SECURITY.md caveat because harnesses auto-approve MCP tool calls
+  while gating shell execution behind per-command prompts — there,
+  `search_content(root: "/")` bypasses a boundary the *user* believes
+  exists. ("The agent has Bash anyway" only holds where it does.)
+  Three constraints, in order of how easily they're lost:
+  1. The allowed set is **cursor-independent**. Anchoring on
+     `search_root`/`project_home` alone rejects the agent's own
+     worktree the moment the user browses elsewhere — and a rejected
+     call doesn't stop the agent, it sends it to unscoped `Bash rg`.
+     Over-tight scoping produces bypass, not safety.
+  2. It reuses the **trusted-root sidecar** (`write_root_marker`),
+     already spyc's boundary for marker discovery. One root concept,
+     not two — and `root_matches` already does the canonical compare
+     that keeps symlinked worktrees from false-rejecting.
+  3. Per-pane attribution — validating against the *calling* pane's
+     cwd — is the target design, blocked on transport: `SPYC_PANE_ID`
+     reaches the pane's env, but read-tool dispatch resolves through
+     the context file, which carries no pane identity.
 
 ## Doc map
 


### PR DESCRIPTION
First change of the code-review remediation engagement (`docs/drafts/spyc-review-remediation-prompt v4.md`). Docs only — no behavior change.

## What

Records the F1 decision in ROADMAP.md's decisions log, ahead of the implementation PR. The prompt sequences it this way so F2's SECURITY.md rewrite can fold in a decision that already exists on main.

## The finding

`src/mcp/readers.rs::effective_root` accepts any caller-supplied `root` passing `is_dir()`. `get_file_content` then canonicalizes and checks `starts_with(canonical_root)` (`src/mcp/protocol.rs:615`) — but the root it anchors on came from the caller, so `root: "/"` makes the guard decorative.

## Why enforce rather than document

Not because "the agent could read `~/.ssh`" — that argues the other way, since the connected agent usually has Bash and the socket is same-user 0600. The case that matters is the **harness permission asymmetry**: agent harnesses commonly auto-approve MCP tool calls while gating shell execution behind per-command permission prompts. In that configuration `search_content(root: "/", regex: "BEGIN OPENSSH PRIVATE KEY")` bypasses a boundary the *user* believes exists.

## What the entry pins down

1. **Cursor-independence** — anchoring the allowed set on `search_root`/`project_home` alone would reject the agent's own worktree the moment the user browses elsewhere. A rejected tool call doesn't stop an agent, it sends it to unscoped `Bash rg`, so over-tight scoping produces bypass rather than safety.
2. **Reuse of the trusted-root sidecar** (`write_root_marker`, `src/mcp/server.rs:146`) — already spyc's boundary for marker discovery, so this adds no second notion of "root". `root_matches` also already performs the canonical compare that keeps symlinked worktree paths from false-rejecting.
3. **Per-pane attribution as the target design**, with its blocker named: `SPYC_PANE_ID` reaches the pane's env, but read-tool dispatch resolves through the context file, which carries no pane identity.

Point 2 is a course correction — the brief assumed this would need a new session field. It doesn't; the anchor is already reachable from the `ctx_path` `effective_root` receives.

## Not in this PR

ROADMAP.md:33's misleading "ceiling-guard-enforced" phrasing is finding F4 and gets its own change.

## Test evidence

`make check` green (fmt, clippy, tests, cargo-deny). No behavior change to test.

Generated with [Claude Code](https://claude.com/claude-code)