### PR TITLE
docs(security): describe the shipped distribution and signing chain (review F2)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,25 +9,54 @@ If you find something wrong, contact derek.marshall@tripstack.com.
 ## Threat model
 
 spyc is a single-binary terminal file manager. It runs locally as the
-invoking user, has no network code of its own, and is distributed as
-source from a public GitHub repo (engineers build it locally via
-`make install`). The realistic threats are:
+invoking user and has no network code of its own. It is distributed
+both as source and as **signed prebuilt binaries** (GitHub Releases,
+a Homebrew tap, a signed apt repo, and crates.io — see INSTALL.md).
+The realistic threats are:
 
 - **Supply-chain compromise of a Rust dependency** — a transitive
   crate is yanked + republished with malicious code, or an unmaintained
   dep develops a CVE.
+- **Release-pipeline compromise** — an attacker who can run code in a
+  release workflow, or who obtains the apt signing key, can publish a
+  malicious binary that installs as "spyc" on every consumer machine.
+  This is the highest-consequence threat and the reason for the
+  keyless-signing posture below.
 - **Tampered local build** — someone modifies the source on a shared
   clone before `make install` runs.
-- **MCP socket misuse** — the per-PID Unix socket exposes tool calls
-  (`navigate_to`, `pick_files`, `get_file_content`) to whatever process
-  reads `~/.local/state/spyc/mcp-<pid>.sock`. Filesystem permissions
-  gate this; an attacker who's already running as your user can talk
-  to any of your spyc instances.
+- **MCP socket misuse by another local process** — the per-PID Unix
+  socket exposes tool calls to whatever process can read
+  `~/.local/state/spyc/mcp-<pid>.sock`. Filesystem permissions gate
+  this; an attacker already running as your user can talk to any of
+  your spyc instances.
+- **MCP tool misuse by the connected agent** — distinct from the above
+  and worth stating plainly, because it is the case people assume is
+  covered. See "MCP is not a privilege boundary" below.
 
-We're not in scope for the kinds of threats that need professional
-hardening: there's no remote attack surface, no privilege boundary
-inside the binary, no secrets handling, and no untrusted-input parser
-beyond TOML config files we already control.
+spyc has no remote attack surface, no privilege boundary inside the
+binary, and handles no secrets of its own.
+
+It does, however, **parse a great deal of untrusted input**: any file
+you open in the pager, ANSI/escape output from arbitrary child
+processes in the pty pane (vt100), git objects (gix), and images /
+SVG / markdown / syntax-highlighting input. A malicious file or a
+hostile child process is a realistic way to reach a parser bug. This
+is what `fuzz/fuzz_targets/` exists for — see the fuzzing caveat.
+
+### MCP is not a privilege boundary against the connected agent
+
+The MCP read tools take an optional `root` argument to scope a query to
+a worktree. That argument is **validated against a set of roots spyc
+knows about**, so an agent cannot point a read tool at an arbitrary
+directory. The rationale is recorded in ROADMAP.md's decisions log:
+agent harnesses commonly auto-approve MCP tool calls while gating shell
+execution behind per-command permission prompts, so an unvalidated
+`root` would bypass a boundary the *user* believes exists.
+
+That validation is a guardrail, not a sandbox. An agent with shell
+access can read anything you can read, and spyc does not try to prevent
+it. Do not treat the MCP tool surface as a containment mechanism for an
+untrusted agent.
 
 ## Supply-chain controls (what we do)
 
@@ -38,13 +67,16 @@ beyond TOML config files we already control.
   fails loudly. The Makefile and the GitHub Actions CI
   (`.github/workflows/ci.yml`) both enforce this.
 - **`cargo deny check`** runs on every CI build (advisories,
-  licenses, sources, bans). Replaces the older `cargo audit` step.
-  Configuration is checked in at `deny.toml` with documented reasons
-  for every advisory ignore — none are silent.
+  licenses, sources, bans). Configuration is checked in at `deny.toml`
+  with documented reasons for every advisory ignore — none are silent.
 - **License allow-list.** Only the licenses present in our actual
-  dep graph as of v1.37.1 are allowed. Adding a dep with a license
+  dep graph are allowed; the list is reviewed against
+  `cargo deny list` when deps change. Adding a dep with a license
   outside that set fails CI; you read it, decide, and either add to
-  the allow-list (with a reason) or pick a different dep.
+  the allow-list (with a reason) or pick a different dep. Several deps
+  are multi-licensed and offer a copyleft option (`self_cell`,
+  `r-efi`, the `Unlicense OR MIT` BurntSushi crates); cargo-deny
+  selects an allowed alternative, so no copyleft obligation attaches.
 - **Source allow-list.** Only crates from
   `https://github.com/rust-lang/crates.io-index` are accepted.
   No `git = "..."` deps, no patched forks.
@@ -55,60 +87,111 @@ beyond TOML config files we already control.
   runs the same gate as CI before each commit so drift surfaces in
   seconds locally instead of ~10 min later in pipelines.
 
-## Build and install
+## Release pipeline, signing, and what you can verify
 
-There is no prebuilt binary distribution. Engineers install spyc by
-cloning the repo and running `make install` (default prefix
-`~/.local/bin`). The chain of trust is: SSH-authenticated `git clone`
-from GitHub → local Rust toolchain → local install.
+Pushing a `v*` tag runs `.github/workflows/release.yml`. Operator
+mechanics live in `docs/RELEASE_ENGINEERING.md` §8–9; this section
+covers only the security-relevant chain.
 
-This means:
+**Build.** macOS universal (`arm64` + `x86_64` lipo) on
+`macos-latest`; static musl `x86_64` and `aarch64` on `ubuntu-latest`
+via `cargo-zigbuild` with a pinned Zig. The workflows call the same
+`make` targets used locally, so CI and local builds don't drift.
+`SHA256SUMS` is generated over all three tarballs.
 
-- The integrity of an installation depends on the integrity of the
-  local clone. If you clone from a corp-managed machine over an
-  authenticated channel, the source is trusted.
-- We don't sign release artifacts (no GPG, no Apple Developer ID
-  cert) because there are no release artifacts to sign — nobody
-  downloads a prebuilt `spyc` binary today. Adding signatures would
-  be theater.
-- `make install` invokes `codesign -s -` on macOS. This is **ad-hoc
-  signing**, not Developer ID signing. It's enough for the binary
-  to keep entitlements across rebuilds (and to silence some
-  Gatekeeper-on-translocation noise), but it does **not** prove
-  the binary came from a specific person and would not survive
-  notarization. A real Developer ID requires Apple Developer
-  enrollment and is out of scope.
+**Signing is keyless — no stored secret is involved.**
 
-If/when we start publishing prebuilt binaries (a release page, S3,
-Homebrew tap, etc.), `Makefile` already has scaffolding for the
-right thing: `make dist-checksums` writes SHA-256s, and
-`make dist-sign` will produce a detached GPG signature on the
-checksums file. The signing key fingerprint will be published here
-when that happens.
+- **Build provenance** — `actions/attest-build-provenance` produces a
+  SLSA attestation binding each tarball to the workflow, repo, and
+  commit that produced it, via GitHub's OIDC identity.
+- **cosign-signed checksums** — `cosign sign-blob` signs `SHA256SUMS`
+  with an ephemeral OIDC-derived key, recorded in the Rekor
+  transparency log, published as `SHA256SUMS.cosign.bundle`.
+- **crates.io Trusted Publishing** — the publish job exchanges a
+  GitHub OIDC token for a crates.io token scoped to this repo and
+  workflow file, valid only for that step and auto-revoked afterwards.
+  No registry token is stored.
+
+**What a consumer can verify** (commands in INSTALL.md):
+
+```sh
+sha256sum -c SHA256SUMS --ignore-missing
+gh attestation verify spyc-<tag>-<platform>.tar.gz --repo Tripstack-Corp/spyc
+cosign verify-blob SHA256SUMS --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '...' --certificate-oidc-issuer '...'
+```
+
+Attestation verification is the strong check: it proves the artifact
+was built by this repo's release workflow, not merely that a hash
+matches a file someone published alongside it.
+
+**Actions permissions.** Every workflow defaults to
+`contents: read`. Only the release publish job widens it —
+`contents: write` (create the release), `id-token: write` (OIDC for
+attestation and cosign), `attestations: write`, and `actions: write`
+(to dispatch the homebrew and apt workflows, because a release created
+by `GITHUB_TOKEN` does not fire `on: release`). The crates.io job holds
+`id-token: write` and nothing else. `apt.yml` holds `contents: write`
+solely to push the index to `gh-pages`.
+
+**The apt signing key is the one real stored secret.** A dedicated
+RSA-4096 key signs the apt `Release` file; its public half is published
+as `KEY.gpg` and pinned by clients via `signed-by`. The private key and
+passphrase live in the `apt-publish` **protected Environment**
+(`APT_GPG_PRIVATE_KEY`, `APT_GPG_PASSPHRASE`), scoped by deployment
+policy so only that job, on a `v*` tag or `main`, can read them. The
+key is backed up off-repo in the owner's password manager together with
+a revocation certificate. The apt push itself uses the built-in
+org-owned `GITHUB_TOKEN`, not a personal or cross-repo token. The
+Homebrew tap bump uses an org GitHub App credential in the separate
+`homebrew-tap` Environment.
+
+**On key compromise.** The keyless channels need no rotation — there is
+no long-lived key to steal, and a malicious artifact would carry an
+attestation naming the workflow that actually built it. For apt:
+revoke using the stored revocation certificate, generate a new
+RSA-4096 key, replace both `apt-publish` secrets, and republish
+`KEY.gpg`. Every existing apt client must then re-import the new key,
+because `signed-by` pins the old one — an unavoidable break, and the
+reason the apt key is the most valuable secret in the project. This
+procedure is stated here but has never been rehearsed.
 
 ## Known caveats (what we don't do)
 
 - **No reproducible builds.** Two builds of the same source on two
   machines may differ in timestamps, paths, and rustc-version
   fingerprints. Bit-for-bit reproducibility is non-trivial for Rust
-  binaries and we don't claim it.
+  binaries and we don't claim it. Build-provenance attestation is what
+  we offer instead: it proves *where* a binary came from rather than
+  letting you rebuild it yourself.
 - **No SBOM published.** `cargo deny check` and `Cargo.lock` together
   give us a full audit trail, but we don't emit a CycloneDX or SPDX
   SBOM artifact. If a consumer needs one, generating it from
   `Cargo.lock` is a one-shot script away.
 - **No commit signing requirement.** The repo does not require signed
-  commits (no GitHub branch-protection rule enforcing them). A compromised
-  dev account could push unsigned commits indistinguishable from real ones,
-  bounded by branch protection (PR-only merge into `main`, required
-  status checks, restricted write access).
+  commits. A compromised dev account could push unsigned commits
+  indistinguishable from real ones, bounded by branch protection
+  (PR-only merge into `main`, required status checks, restricted write
+  access). Note this is the weakest link in the release chain: signing
+  proves an artifact came from the workflow, not that the *source* the
+  workflow built was authored by who you think.
+- **Fuzz targets exist but do not run in CI.** `fuzz/fuzz_targets/`
+  covers the DSL parser, path/percent expansion, highlighting, markdown
+  rendering, and word wrap, run on demand via `make fuzz` (nightly,
+  deliberately out of `make check`). Nothing runs them on a schedule, so
+  in practice they only execute when someone remembers. Given the
+  untrusted-input surface noted in the threat model, that is a real gap
+  rather than a stylistic one.
+- **macOS binaries are ad-hoc signed only.** `make install` invokes
+  `codesign -s -`, which keeps entitlements stable across rebuilds and
+  silences some Gatekeeper-on-translocation noise. It does **not**
+  prove origin and would not survive notarization. A real Developer ID
+  requires Apple Developer enrollment and is out of scope; the
+  provenance attestation is the origin proof instead.
 - **MCP socket permissions are filesystem-default.** Anyone running
   as your user on the same machine can read the per-PID socket and
   exercise the MCP tool surface. We rely on user-process isolation,
   not stricter ACLs.
-- **No fuzzing.** The TOML and DSL parsers handle config we control;
-  there's no untrusted-input parsing path in production code worth
-  fuzzing today. If that changes (e.g., a remote-source feature),
-  it should be revisited.
 
 ## Reporting a vulnerability
 
@@ -129,8 +212,8 @@ Update this document when any of the following change:
   be expanded here under "known caveats" if it's load-bearing).
 - spyc gains a network attack surface (HTTP client, RPC server,
   remote config source).
-- spyc starts publishing prebuilt binaries (signing posture flips
-  from "theater-avoided" to "actually meaningful").
-- The MCP socket gains tools that mutate state outside spyc's own
-  process (today: spyc-internal navigation; future: anything that
-  writes outside `~/.local/state/spyc/`).
+- A distribution channel is added or removed, or the signing chain
+  changes (new key, a channel that stores a credential, a move away
+  from keyless).
+- The MCP tool surface gains a tool that writes outside spyc's own
+  process, or the `root` validation described above is relaxed.

--- a/deny.toml
+++ b/deny.toml
@@ -116,12 +116,14 @@ unmaintained = "workspace"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    # Permissive licenses present in our actual dep graph as of v1.37.1.
-    # Run `cargo deny check licenses` after adding deps to surface anything
-    # new — don't blanket-add categories, evaluate each.
+    # Permissive licenses present in our actual dep graph. Reconcile with
+    # `cargo deny list` when deps change — don't blanket-add categories,
+    # evaluate each. Some deps are multi-licensed and also offer a copyleft
+    # option (self_cell, r-efi, the Unlicense-OR-MIT BurntSushi crates);
+    # cargo-deny picks an allowed alternative, so none attaches an obligation.
     "0BSD",          # zero-clause BSD; effectively public domain
     "Apache-2.0",
-    "BSD-2-Clause",  # not currently in graph; future-proof for clap-style deps
+    "BSD-2-Clause",
     "BSD-3-Clause",  # spyc itself is BSD-3-Clause
     "BSL-1.0",       # Boost; permissive
     "CC0-1.0",       # public domain dedication (e.g. tiny-keccak)
@@ -129,7 +131,7 @@ allow = [
     "MIT",
     "MPL-2.0",       # weak copyleft (file-level); compliant since we don't modify dep sources
     "Unicode-3.0",   # newer unicode license used by unicode-* crates
-    "Unicode-DFS-2016",
+    "Unicode-DFS-2016", # no longer in the graph (unicode-ident moved to Unicode-3.0); retained
     "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.


### PR DESCRIPTION
Second change of the code-review remediation engagement (`docs/drafts/spyc-review-remediation-prompt v4.md`). Docs + one config comment block — no behavior change.

## The finding, and how it was worse than reported

SECURITY.md line 60 claimed **"There is no prebuilt binary distribution"** while the repo ships signed tarballs, a Homebrew tap, a signed apt repo, and crates.io. The license rationale was pinned to v1.37.1.

But the review undersold it. The doc also said:

> We don't sign release artifacts (no GPG, no Apple Developer ID cert) because there are no release artifacts to sign … Adding signatures would be theater.

`release.yml` has produced **SLSA build-provenance attestations** and **cosign-signed `SHA256SUMS`** (Rekor transparency log, keyless OIDC) since 2.0.0, and publishes to crates.io via **Trusted Publishing**. So the document didn't merely lag reality — it talked readers out of a verification path that already worked.

## What the rewrite covers

- **Threat model** reframed around release-pipeline compromise as the highest-consequence threat, which is what motivates the keyless posture
- **The keyless chain**: attestations, cosign/Rekor, crates.io Trusted Publishing — plus the verify commands, with a note that attestation is the strong check (it proves *origin*, not just that a hash matches a file published beside it)
- **Actions permissions**, job by job, including why the publish job needs `actions: write` (a `GITHUB_TOKEN` release doesn't fire `on: release`)
- **The apt GPG key** as the one real stored secret: RSA-4096, `apt-publish` protected Environment scoped to `v*`/`main`, off-repo backup with a revocation certificate
- **The F1 decision** folded into the threat model, with MCP stated as a guardrail and explicitly *not* a sandbox

## Three corrections the review didn't ask for

1. **The untrusted-input claim was false.** The old text said there was "no untrusted-input parser beyond TOML config files we already control." spyc parses arbitrary files in the pager, ANSI from arbitrary child processes (vt100), git objects (gix), and images/SVG/markdown/highlighting. The fuzz targets sitting next to that claim were evidence against it — and this gives F5 a real justification.
2. **No key-rotation procedure existed.** Now written down, including that every apt client must re-import because `signed-by` pins the old key, and stating plainly that it has never been rehearsed.
3. **Unsigned commits are the weakest link** in the release chain. Called out: signing proves an artifact came from the workflow, not that the source was authored by who you think.

## On the license allow-list

`cargo deny list` surfaces `GPL-2.0-only`, `LGPL-2.1-or-later`, `MIT-0`, and `Unlicense` in the graph — none allow-listed, yet CI passes. Traced rather than assumed: all four are multi-licensed crates (`self_cell`, `r-efi`, `dunce`, the BurntSushi set) offering an allowed alternative that cargo-deny selects. **No copyleft obligation attaches.** Documented so nobody re-runs that scare.

Two annotations were wrong and are fixed: `BSD-2-Clause` was marked "not currently in graph" and now is; `Unicode-DFS-2016` has dropped out.

**Deliberate restraint:** the absent entry is annotated, not removed. Removing an allow-list entry changes CI behavior, and this is a documentation-accuracy change — the brief's own one-finding rule says that belongs in its own PR.

## Test evidence

`make check` green (fmt, clippy, tests, cargo-deny). No behavior change. Cross-checked against README.md, INSTALL.md, and the workflow files for contradictions.

Generated with [Claude Code](https://claude.com/claude-code)