### PR TITLE
fix(mcp): unify on one state-root resolver (review F6)

### DIFF
--- a/src/app/pane_tabs.rs
+++ b/src/app/pane_tabs.rs
@@ -118,15 +118,14 @@ impl App {
         // reach this spyc instance's socket and target THIS tab by id. Owned
         // locals so the `&str` env slice outlives the spawn call; `info` is then
         // free to move into the `TabEntry`.
-        let sock_str = crate::mcp::socket_path().to_string_lossy().into_owned();
+        // No state dir (neither XDG_STATE_HOME nor HOME) means no socket, so
+        // there is nothing to point the hook at — spawn without it.
+        let sock_str = crate::mcp::socket_path().map(|p| p.to_string_lossy().into_owned());
         let pane_id = info.id.clone();
-        let extra_env: Vec<(&str, &str)> = if is_agent {
-            vec![
-                ("SPYC_MCP_SOCK", sock_str.as_str()),
-                ("SPYC_PANE_ID", pane_id.as_str()),
-            ]
-        } else {
-            Vec::new()
+        let extra_env: Vec<(&str, &str)> = match (is_agent, sock_str.as_deref()) {
+            (true, Some(sock)) => vec![("SPYC_MCP_SOCK", sock), ("SPYC_PANE_ID", pane_id.as_str())],
+            (true, None) => vec![("SPYC_PANE_ID", pane_id.as_str())],
+            (false, _) => Vec::new(),
         };
         match Pane::spawn_with_env(
             cmd,
@@ -350,13 +349,14 @@ impl App {
                 after: std::time::Instant::now() + super::RESTORE_BANNER_SETTLE,
             });
         }
-        // Owned locals so the `&str` env slice outlives the spawn call.
-        let sock_str = crate::mcp::socket_path().to_string_lossy().into_owned();
+        // Owned locals so the `&str` env slice outlives the spawn call. No
+        // state dir means no socket to advertise (see the fresh-spawn path).
+        let sock_str = crate::mcp::socket_path().map(|p| p.to_string_lossy().into_owned());
         let pane_id = info.id.clone();
-        let extra_env = [
-            ("SPYC_MCP_SOCK", sock_str.as_str()),
-            ("SPYC_PANE_ID", pane_id.as_str()),
-        ];
+        let mut extra_env = vec![("SPYC_PANE_ID", pane_id.as_str())];
+        if let Some(sock) = sock_str.as_deref() {
+            extra_env.push(("SPYC_MCP_SOCK", sock));
+        }
         match Pane::spawn_with_env(
             cmd,
             rows,

--- a/src/mcp/config.rs
+++ b/src/mcp/config.rs
@@ -9,6 +9,11 @@ use serde_json::{Value, json};
 use super::server::{notify_disconnect, pid_from_sock_path};
 use super::{mcp_log, socket_path};
 
+/// Why an agent config wasn't written. With neither `$XDG_STATE_HOME` nor
+/// `$HOME` set there is no socket path, so registering one would point the
+/// agent at an address nothing listens on — worse than no registration.
+const NO_STATE_DIR: &str = "no state directory ($XDG_STATE_HOME / $HOME unset) — MCP disabled";
+
 /// Status of MCP configuration for this directory.
 #[derive(Debug)]
 pub enum McpConfigStatus {
@@ -107,7 +112,7 @@ fn decide_takeover(
 /// is reachable, else None. Used by the startup takeover prompt so we
 /// can ask the user before clobbering another instance's registration.
 pub fn detect_existing_spyc(dir: &Path) -> Option<u32> {
-    let our_sock = socket_path();
+    let our_sock = socket_path()?;
     let path = dir.join(".mcp.json");
     let text = std::fs::read_to_string(&path).ok()?;
     let parsed: Value = serde_json::from_str(&text).ok()?;
@@ -223,7 +228,9 @@ fn ensure_spyc_in_mcp_json(
     path: &Path,
     takeover_allowed: bool,
 ) -> Result<McpConfigStatus, io::Error> {
-    let our_sock = socket_path();
+    let Some(our_sock) = socket_path() else {
+        return Err(io::Error::other(NO_STATE_DIR));
+    };
     let our_pid = std::process::id();
     let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("spyc"));
 
@@ -349,7 +356,9 @@ pub fn ensure_codex_config_toml(
     dir: &Path,
     takeover_allowed: bool,
 ) -> Result<McpConfigStatus, io::Error> {
-    let our_sock = socket_path();
+    let Some(our_sock) = socket_path() else {
+        return Err(io::Error::other(NO_STATE_DIR));
+    };
     let our_pid = std::process::id();
     let path = dir.join(".codex").join("config.toml");
     let exe = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("spyc"));
@@ -486,7 +495,7 @@ pub fn ensure_codex_config_toml(
 /// `detect_existing_spyc` for the codex side; used by startup so a
 /// single takeover prompt covers both claude and codex.
 pub fn detect_existing_spyc_codex(dir: &Path) -> Option<u32> {
-    let our_sock = socket_path();
+    let our_sock = socket_path()?;
     let path = dir.join(".codex").join("config.toml");
     let text = std::fs::read_to_string(&path).ok()?;
     let parsed: toml::Value = toml::from_str(&text).ok()?;
@@ -521,7 +530,8 @@ pub enum ConfigCleanup {
 /// written by this running spyc, not a different (possibly successor) instance.
 /// Our socket path embeds our pid, so this is a sound "did we write it" proxy.
 fn sock_is_ours(sock_str: &str) -> bool {
-    socket_path().to_string_lossy() == sock_str
+    // No state dir → we never wrote a socket, so no entry can be ours.
+    socket_path().is_some_and(|p| p.to_string_lossy() == sock_str)
 }
 
 /// Shared core for `.mcp.json` spyc-entry removal. `should_remove` is given the
@@ -722,7 +732,7 @@ pub fn detect_existing_spyc_agy(dir: &Path) -> Option<u32> {
     let old_sock_str = parsed
         .pointer("/mcpServers/spyc/env/SPYC_MCP_SOCK")
         .and_then(|v| v.as_str())?;
-    live_owner_pid(old_sock_str, &socket_path())
+    live_owner_pid(old_sock_str, &socket_path()?)
 }
 
 /// Agy's counterpart to [`ensure_mcp_json`]. No enterprise-policy gate: that's a
@@ -793,7 +803,10 @@ mod tests {
     };
 
     fn our_sock() -> String {
-        crate::mcp::socket_path().to_string_lossy().into_owned()
+        crate::mcp::socket_path()
+            .expect("tests run with HOME set")
+            .to_string_lossy()
+            .into_owned()
     }
 
     /// A `.codex/config.toml` whose spyc entry points at `sock`, written into a

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -101,18 +101,38 @@ fn log_bodies() -> bool {
 
 // ── Shared JSON-RPC dispatch ────────────────────────────────────
 
-/// spyc's per-user state directory: `~/.local/state/spyc` (falling back
-/// to `/tmp` when `$HOME` is unset). Holds the MCP socket and the
-/// trusted-root sidecars — all owner-private; an attacker who can only
-/// plant files in a *cloned repo* cannot write here.
-pub fn state_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-    PathBuf::from(home).join(".local/state/spyc")
+/// spyc's per-user state directory, holding the MCP socket and the
+/// trusted-root sidecars — all owner-private; an attacker who can only plant
+/// files in a *cloned repo* cannot write here.
+///
+/// Delegates to [`crate::state::state_root`] so there is exactly ONE resolver.
+/// This used to read `$HOME` directly and ignore `$XDG_STATE_HOME`, which split
+/// state across two directories for anyone who sets it: the socket and sidecars
+/// landed in `~/.local/state/spyc` while marks, harpoon, and frecency went to
+/// `$XDG_STATE_HOME/spyc` — and the sidecar's "owner-private, attacker can't
+/// forge it" argument was being made about a path the rest of the program
+/// wasn't using.
+///
+/// `None` when neither `$XDG_STATE_HOME` nor `$HOME` is set. Callers **decline
+/// the feature** rather than inventing a fallback: the old code fell back to a
+/// world-readable bare `/tmp`, where predictable socket and sidecar names invite
+/// squatting. No MCP is a better failure than MCP on an untrustworthy path.
+pub fn state_dir() -> Option<PathBuf> {
+    crate::state::state_root()
 }
 
-/// Socket path for a given PID: `~/.local/state/spyc/mcp-<pid>.sock`.
-pub fn socket_path_for(pid: u32) -> PathBuf {
-    state_dir().join(format!("mcp-{pid}.sock"))
+/// Socket path for a given PID: `<state_dir>/mcp-<pid>.sock`.
+/// `None` when [`state_dir`] is — see there.
+pub fn socket_path_for(pid: u32) -> Option<PathBuf> {
+    socket_path_in(state_dir(), pid)
+}
+
+/// [`socket_path_for`] with the state dir injected, so the absent-state-dir
+/// branch is testable without mutating the environment (the same trick
+/// [`root_marker_path_in`] uses). `None` in, `None` out — the caller declines
+/// the feature rather than inventing a location.
+fn socket_path_in(state_dir: Option<PathBuf>, pid: u32) -> Option<PathBuf> {
+    Some(state_dir?.join(format!("mcp-{pid}.sock")))
 }
 
 /// Trusted-root sidecar path for a PID, in the given state dir:
@@ -126,8 +146,8 @@ pub fn root_marker_path_in(state_dir: &Path, pid: u32) -> PathBuf {
     state_dir.join(format!("mcp-{pid}.root"))
 }
 
-/// Socket path for the current process.
-pub fn socket_path() -> PathBuf {
+/// Socket path for the current process. `None` when [`state_dir`] is.
+pub fn socket_path() -> Option<PathBuf> {
     socket_path_for(std::process::id())
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -46,7 +46,9 @@ pub(super) fn discover_live_socket(caller_cwd: &Path) -> Option<UnixStream> {
         caller_cwd.display(),
     ));
     for pid in candidates {
-        let sock = socket_path_for(pid);
+        let Some(sock) = socket_path_for(pid) else {
+            continue;
+        };
         mcp_log(&format!("stdio: discover trying {}", sock.display()));
         match UnixStream::connect(&sock) {
             Ok(stream) => {
@@ -85,7 +87,12 @@ pub(super) fn discover_live_socket(caller_cwd: &Path) -> Option<UnixStream> {
 /// `.spyc-context-<pid>.json` markers. Returns the PIDs from the
 /// first ancestor that has any *trusted* matches; empty Vec otherwise.
 pub(super) fn collect_project_pids(start: &Path) -> Vec<u32> {
-    collect_project_pids_in(start, &state_dir())
+    // Without a state dir there are no trusted-root sidecars, and a marker
+    // with no sidecar is untrusted by definition — so nothing can match.
+    let Some(dir) = state_dir() else {
+        return Vec::new();
+    };
+    collect_project_pids_in(start, &dir)
 }
 
 /// As [`collect_project_pids`], but with the state dir injected so tests
@@ -371,7 +378,13 @@ pub fn start_socket_server(
     ctx_path: PathBuf,
     cmd_tx: std::sync::mpsc::Sender<McpRequest>,
 ) -> anyhow::Result<()> {
-    let sock = socket_path();
+    // Refuse rather than fall back: the pre-unification code bound into a
+    // world-readable bare `/tmp`, where a predictable socket name invites
+    // squatting. No MCP beats MCP on a path we don't trust.
+    let Some(sock) = socket_path() else {
+        mcp_log("socket: no state directory ($XDG_STATE_HOME / $HOME unset) — not serving");
+        anyhow::bail!("no state directory ($XDG_STATE_HOME / $HOME unset) — MCP server disabled");
+    };
 
     // Ensure the parent directory exists.
     if let Some(parent) = sock.parent() {
@@ -392,7 +405,9 @@ pub fn start_socket_server(
     // stdio discovery can verify a `.spyc-context-<pid>.json` marker
     // really belongs to a spyc rooted there — not a planted decoy. Done
     // before any connection is served.
-    write_root_marker(&state_dir(), &ctx_path);
+    if let Some(dir) = state_dir() {
+        write_root_marker(&dir, &ctx_path);
+    }
 
     let ctx_path = Arc::new(ctx_path);
     let cmd_tx = Arc::new(cmd_tx);
@@ -431,8 +446,12 @@ pub fn start_socket_server(
 
 /// Clean up the socket file and trusted-root sidecar on shutdown.
 pub fn cleanup_socket() {
-    let _ = std::fs::remove_file(socket_path());
-    let _ = std::fs::remove_file(root_marker_path_in(&state_dir(), std::process::id()));
+    if let Some(sock) = socket_path() {
+        let _ = std::fs::remove_file(sock);
+    }
+    if let Some(dir) = state_dir() {
+        let _ = std::fs::remove_file(root_marker_path_in(&dir, std::process::id()));
+    }
 }
 
 /// Extract the PID from a socket path like `mcp-12345.sock`.

--- a/src/mcp/tests/mod.rs
+++ b/src/mcp/tests/mod.rs
@@ -660,9 +660,49 @@ fn pid_from_sock_path_parses() {
 
 #[test]
 fn socket_path_contains_pid() {
-    let path = socket_path();
+    let path = socket_path().expect("tests run with HOME set");
     let pid = std::process::id();
     assert!(path.to_string_lossy().contains(&format!("mcp-{pid}.sock")));
+}
+
+#[test]
+fn mcp_state_dir_is_the_one_state_root() {
+    // The defect: `mcp::state_dir` read $HOME directly and ignored
+    // $XDG_STATE_HOME, so with XDG set the socket and trusted-root sidecar
+    // landed in ~/.local/state/spyc while marks/harpoon/frecency went to
+    // $XDG_STATE_HOME/spyc — state split across two directories, and the
+    // sidecar's trust argument made about a path nothing else used.
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let mcp_dir = crate::mcp::state_dir().expect("override is Some");
+        assert_eq!(mcp_dir, tmp.path());
+
+        // The socket and the sidecar follow it, so everything shares one root.
+        let sock = socket_path().expect("override is Some");
+        assert!(
+            sock.starts_with(tmp.path()),
+            "socket {sock:?} escaped the state root"
+        );
+        let marker = crate::mcp::root_marker_path_in(&mcp_dir, std::process::id());
+        assert!(marker.starts_with(tmp.path()));
+    });
+}
+
+#[test]
+fn no_state_dir_yields_no_socket_path() {
+    // With neither $XDG_STATE_HOME nor $HOME set there is nowhere trustworthy
+    // to put the socket. The pre-unification code fell back to a
+    // world-readable bare `/tmp`, where a predictable `mcp-<pid>.sock` name
+    // invites squatting; callers now decline the feature instead.
+    //
+    // Injected rather than env-mutated: `std::env::set_var` is unsafe in
+    // edition 2024, and the house rule is to avoid unsafe.
+    assert_eq!(super::socket_path_in(None, 1234), None);
+    let dir = std::path::PathBuf::from("/some/state/root");
+    assert_eq!(
+        super::socket_path_in(Some(dir.clone()), 1234),
+        Some(dir.join("mcp-1234.sock"))
+    );
 }
 
 // ── Project-scoped discovery ──────────────────────────────


### PR DESCRIPTION
Fifth change of the code-review remediation engagement.

## The finding, reframed

The original review reported "`state_dir()` falls back to bare `/tmp` when `$HOME` is unset" and asked for `/tmp`-squat hardening. The `/tmp` fallback is a **symptom**. The defect is that spyc had **two state-root resolvers that disagreed**:

| Resolver | `$XDG_STATE_HOME` | No HOME |
|---|---|---|
| `state::state_root()` | honoured | `None` — callers skip persistence safely |
| `mcp::state_dir()` | **ignored** | bare `/tmp` |

With `XDG_STATE_HOME` set — a common configuration, unlike an unset HOME — the MCP socket and trusted-root sidecar landed in `~/.local/state/spyc` while marks, harpoon, and frecency went to `$XDG_STATE_HOME/spyc`. State split across two directories, and the sidecar's "owner-private, attacker can't forge it" trust argument was being made about a path the rest of the program wasn't using.

So the likelier-to-bite bug wasn't the exotic no-HOME case at all.

## The fix

`mcp::state_dir()` now delegates to `state::state_root()`. Everything else already did — `health`, `frecency`, `harpoon`, and `marks` are all thin wrappers over it — so this was the **sole** divergence.

That makes it `Option`, which is the point rather than a side effect. With neither variable set there is nowhere trustworthy for a socket, and the old fallback put a predictable `mcp-<pid>.sock` in a world-readable `/tmp`. Callers now decline:

- the socket server **refuses to bind** and logs why
- config writers return an error instead of registering an address nothing will listen on
- discovery returns no pids (no state dir → no trusted sidecars → nothing can be trusted by definition)
- a pane spawns without `SPYC_MCP_SOCK`, keeping `SPYC_PANE_ID`

**No MCP is a better failure than MCP on a path we don't trust.** And the `/tmp`-squat hardening the original finding asked for is now unnecessary — the path it would defend no longer exists, exactly as the corrected brief predicted.

## Scope note

This rippled wider than the brief implied: `socket_path()` had 14 callers, all of which had to decide what "no state dir" means for them. That's the change being honest — each site now states its own answer rather than inheriting a silent `/tmp`.

## Test evidence

Two new tests, neither touching the environment (`std::env::set_var` is unsafe in edition 2024, and the house rule is to avoid unsafe):

- `mcp_state_dir_is_the_one_state_root` — uses the existing `with_state_root` override to prove the socket *and* the sidecar follow the same root that frecency/marks/harpoon use. This is the real defect.
- `no_state_dir_yields_no_socket_path` — `socket_path_in` now takes the state dir as an argument, mirroring `root_marker_path_in`'s existing inject-the-dir seam, so the absent-dir branch is asserted directly rather than left untested.

`make check` green, verified by exit code with `set -o pipefail` (a piped `make check | tail` reports *tail's* status — that produced a false green earlier in this engagement and is now in the brief's don't-do list).

Generated with [Claude Code](https://claude.com/claude-code)