### PR TITLE
ci(fuzz): run the fuzz targets weekly instead of never (review F5)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,106 @@
+# Scheduled coverage-guided fuzzing. Background insurance, NOT a merge gate —
+# deliberately off the PR path (`make check` stays fast; `make fuzz` stays
+# on-demand locally).
+#
+# The targets cover spyc's untrusted-input surface, which is larger than it
+# looks: the pager renders arbitrary files, the pty pane parses ANSI from
+# arbitrary child processes, and markdown/highlighting run over both. See
+# SECURITY.md → threat model.
+#
+# Corpora persist between runs via the cache, so each week resumes from the
+# inputs previous weeks discovered rather than starting cold.
+#
+# The build calls `make fuzz` so local and CI can't drift (RELEASE_ENGINEERING
+# §8), passing FUZZ_TOOLCHAIN so the pin below applies without the Makefile
+# hardcoding a date for local users.
+name: Fuzz
+
+on:
+  schedule:
+    # Mondays 07:00 UTC — an hour after Audit, so a busy runner queue doesn't
+    # make the two contend. Scheduled runs use the default branch.
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      seconds:
+        description: "Seconds to fuzz each target"
+        required: false
+        default: "300"
+
+# Never cancel a run mid-fuzz: a cancelled run loses the corpus it just grew.
+concurrency:
+  group: fuzz
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  # Pinned, not floating. A moving nightly turns an unrelated compiler
+  # regression into a "fuzz failure" on a Monday morning, and the resulting
+  # noise is how scheduled jobs get muted. Bump deliberately.
+  NIGHTLY: nightly-2026-08-01
+
+jobs:
+  fuzz:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      # One crashing target must not cancel the others — a real crash is
+      # exactly when we want the remaining targets' results too.
+      fail-fast: false
+      matrix:
+        target:
+          - dsl_parse
+          - expand_path
+          - expand_percent
+          - highlight
+          - render_markdown
+          - word_wrap
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Pinned nightly toolchain
+        run: |
+          rustup toolchain install "$NIGHTLY" --profile minimal --no-self-update
+          rustup run "$NIGHTLY" rustc --version
+
+      # `fuzz/` is a standalone workspace (its own [workspace]), so point the
+      # cache at it rather than the parent crate.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+
+      - uses: taiki-e/install-action@v2.85.5
+        with:
+          tool: cargo-fuzz
+
+      # Accumulating cache: each run saves under a unique key and restores the
+      # newest matching prefix, so the corpus grows week over week instead of
+      # being rediscovered from scratch.
+      - name: Restore corpus
+        uses: actions/cache@v6
+        with:
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: |
+            fuzz-corpus-${{ matrix.target }}-
+
+      - name: Fuzz ${{ matrix.target }}
+        run: |
+          make fuzz \
+            TARGET="${{ matrix.target }}" \
+            FUZZ_SECS="${{ inputs.seconds || '300' }}" \
+            FUZZ_TOOLCHAIN="$NIGHTLY"
+
+      # cargo-fuzz writes a reproducer into fuzz/artifacts/<target>/ on a
+      # crash. `always()` so it uploads on the failing run — which is the only
+      # run where it matters.
+      - name: Upload crash reproducer
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-artifacts-${{ matrix.target }}
+          path: fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ deny: ## Supply-chain checks: advisories, licenses, sources, bans (cargo-deny)
 	cargo deny --all-features check
 
 .PHONY: fuzz
-fuzz: ## Coverage-guided fuzz (needs nightly + cargo-fuzz; on-demand, NOT in `check`). TARGET=dsl_parse|render_markdown|highlight|word_wrap, FUZZ_SECS=N.
+fuzz: ## Coverage-guided fuzz (needs nightly + cargo-fuzz; on-demand, NOT in `check`). TARGET=dsl_parse|render_markdown|highlight|word_wrap|expand_path|expand_percent, FUZZ_SECS=N, FUZZ_TOOLCHAIN=nightly-YYYY-MM-DD.
 	@command -v cargo-fuzz >/dev/null 2>&1 || { \
 		echo "cargo-fuzz not found — install with: cargo install cargo-fuzz"; \
 		exit 1; \
@@ -93,7 +93,8 @@ fuzz: ## Coverage-guided fuzz (needs nightly + cargo-fuzz; on-demand, NOT in `ch
 		echo "nightly toolchain not found — install with: rustup toolchain install nightly"; \
 		exit 1; \
 	}
-	cargo +nightly fuzz run $(or $(TARGET),dsl_parse) -- -max_total_time=$(or $(FUZZ_SECS),30)
+	cargo +$(or $(FUZZ_TOOLCHAIN),nightly) fuzz run $(or $(TARGET),dsl_parse) \
+		-- -max_total_time=$(or $(FUZZ_SECS),30)
 
 # Advisory AI-slop / code-quality scan. Deliberately NOT part of `check`: its
 # format/lint/security engines duplicate clippy+rustfmt (already in `check`),


### PR DESCRIPTION
Sixth change of the code-review remediation engagement.

## The finding

Six libFuzzer targets sit in `fuzz/fuzz_targets/` (`dsl_parse`, `expand_path`, `expand_percent`, `highlight`, `render_markdown`, `word_wrap`) with nothing running them on a schedule — so in practice they execute only when someone remembers `make fuzz`.

That matters more than tidiness. spyc's untrusted-input surface is large: the pager renders arbitrary files, the pty pane parses ANSI from arbitrary child processes (vt100), and markdown/highlighting run over both. SECURITY.md used to claim there was "no untrusted-input parsing path worth fuzzing" — corrected in #236, which is what turns this from a style gap into a real one.

## Shape

Weekly `schedule` **and** `workflow_dispatch`, deliberately off the PR path — background insurance, not a merge gate.

- **6-target matrix, `fail-fast: false`** — a crashing target must not cancel the others; that's exactly when the remaining results are wanted.
- **Accumulating corpus cache** — unique key per run with a prefix `restore-keys`, so each week resumes from inputs previous weeks discovered instead of starting cold.
- **Reproducers uploaded** under `if: always()` with `if-no-files-found: ignore`, 30-day retention.
- **`concurrency` never cancels mid-run** — a cancelled run loses the corpus it just grew.
- **Nightly pinned, not floating.** A moving nightly turns an unrelated compiler regression into a Monday-morning "fuzz failure", and that noise is how scheduled jobs get muted. I checked the pinned date actually resolves (`static.rust-lang.org` manifest returns 200) rather than guessing a date that would 404 on first run.

## The Makefile change, and why

The house rule is that Actions *call* the make targets so CI and local can't drift (RELEASE_ENGINEERING §8) — but `make fuzz` hardcoded floating `cargo +nightly`, which conflicts with pinning. Rather than duplicate the invocation in YAML (precisely the drift the rule prevents), the toolchain is now overridable:

```make
cargo +$(or $(FUZZ_TOOLCHAIN),nightly) fuzz run $(or $(TARGET),dsl_parse) \
	-- -max_total_time=$(or $(FUZZ_SECS),30)
```

Local users keep bare `nightly`; the workflow passes the pin. Also fixed the help text, which listed **four** of the six targets.

## Verification

Ran a real fuzz locally through the changed Makefile path:

```
#69948  DONE   cov: 99 ft: 264 corp: 87/1651b exec/s: 6358
Done 69948 runs in 11 second(s)
```

69,948 executions, 87 corpus entries written to `fuzz/corpus/dsl_parse/` — which confirms the cache `path` in the workflow matches where cargo-fuzz actually writes. Dry-run confirmed the pin plumbs through: `cargo +nightly-2026-08-01 fuzz run highlight`. Corpus is gitignored (`fuzz/.gitignore`), so nothing stray is committed. YAML parsed and asserted (6 targets, both triggers, `fail-fast: false`).

Also bumped `actions/cache` from the v4 I first wrote to **v6** — v4 is two majors stale, and this repo tracks current majors (`checkout@v7`, `upload-artifact@v7`).

## Acceptance caveat

The brief asks for a manual `workflow_dispatch` run as evidence. GitHub only exposes `workflow_dispatch` for workflows present on the **default branch**, so that cannot run until this merges. I'll dispatch it immediately after merge and report the result rather than claiming the criterion is met now.

Generated with [Claude Code](https://claude.com/claude-code)