### PR TITLE
docs(roadmap): the 800-LoC rule is a convention, not a finished foundation (review F4)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,12 +29,21 @@ integration is the defining work track, not the trailing milestone.
 
 The structural foundation has been **done** for a while: the full MVU/Elm
 migration (Model/Runtime/ViewState split, effects-as-data, single message
-channel, pure render), the `app/mod.rs` decomposition (12.4k → ~1k lines,
-ceiling-guard-enforced), the 800-LoC file rule, the complete git→gix migration
+channel, pure render), the `app/mod.rs` decomposition (12.4k → ~1.4k lines,
+ceiling-guard-enforced at 1,500), the complete git→gix migration
 (100% in-process, guard-enforced, with in-house side-by-side diff/show/blame
 views), off-thread PagerStream (grep / git-view / agent transcripts on one
 seam), and unified input routing (`route_input`/`InputSink`, `Focus` as the
 routing authority).
+
+The **800-LoC file rule is a convention, not a guard** — AGENTS.md states it
+with an explicit escape hatch ("without a solid reason"), and the only ceiling
+guard in the tree is `mod_rs_stays_decomposed`, which caps `src/app/mod.rs`
+alone. Listing it above as a finished foundation read as compliance; roughly a
+dozen and a half files exceed 800 *production* lines (counting lines outside
+`#[cfg(test)]` modules — a raw `wc -l` badly overstates it, since the house
+convention keeps tests in the same file). `src/app/mouse.rs` is the outlier
+worth acting on.
 
 Since then the **thesis work has largely shipped** — the differentiators the
 competitive review ([`docs/COMPETITIVE_REVIEW.md`](docs/COMPETITIVE_REVIEW.md))


### PR DESCRIPTION
Seventh change of the code-review remediation engagement. **Part A only** — the doc fix. The mouse.rs decomposition (Part B) is a proposal, deliberately not landed.

## The finding, corrected

The brief said ROADMAP.md:33 "jams `ceiling-guard-enforced` and `the 800-LoC file rule` into one clause." Reading it closely, `ceiling-guard-enforced` correctly describes the `app/mod.rs` decomposition — that *is* guarded.

The actually-wrong part is subtler: listing **"the 800-LoC file rule"** among structural foundations that are **done** reads as compliance. It isn't a finished state; AGENTS.md states it as a convention with an explicit escape hatch, and the only ceiling guard in the tree caps `src/app/mod.rs` alone at 1,500.

Also corrected: "~1k lines" for that decomposition, which is ~1.4k.

## Measuring instead of repeating

The review said "twenty-plus" files exceed 800. A raw `wc -l` says **35**. Both count inline test modules, and the house convention keeps tests at the bottom of the same file — so a 1,253-line file can hold 827 production lines and be perfectly well factored.

Counting only lines outside `#[cfg(test)]` modules: **16**.

Worth flagging how easy this is to get wrong. The obvious shortcut — split at the first `#[cfg(test)]` — is fooled by a *comment mentioning* the attribute, which reports `src/app/render/mod.rs` as **22** production lines when it has 827. I nearly published that number. These are brace-matched.

| File | production | total |
|---|---|---|
| `src/app/mouse.rs` | **1,529** | 3,038 |
| `src/app/mod.rs` | 1,438 | 1,443 |
| `src/mcp/protocol.rs` | 1,076 | 1,147 |
| `src/app/state/mod.rs` | 1,028 | 1,029 |

So the rule has genuinely drifted — sixteen files, not zero — but materially less than the raw count implies, and `app/mod.rs` is deliberately guarded and legitimately holds the module's type defs (AGENTS.md allows exactly that).

## Part B: proposed, not landed

`src/app/mouse.rs` is the outlier — largest, and ~450 production lines clear of the next non-guarded file. It grew ~1,000 lines in #233/#234, so the seams are recent and legible.

Full plan in `docs/drafts/mouse-rs-decomposition-proposal.md` (untracked draft, not in this PR). Summary: the file is a pure decision layer and an impure dispatch layer sharing a filename, with four near-identical `begin`/`extend`/`finish` selection triples in one contiguous block. Proposed `mouse/{mod,route,selection,scroll,forward}.rs`, each well under 800, `route.rs` first because it's pure and proves the seam before anything impure moves.

The proposal includes what would make it a **bad** idea — heavy shared private `App` state, and the existing `too_many_lines` dispatch-function rationale — so it can be rejected on evidence rather than vibes.

## Test evidence

`make check` green, exit code verified with `set -o pipefail`. Docs-only; no behaviour change.

Generated with [Claude Code](https://claude.com/claude-code)