### PR TITLE
fix(ci): build the fuzz targets for gnu, not musl (review F5 follow-up)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -71,6 +71,11 @@ jobs:
         with:
           workspaces: fuzz
 
+      # NOTE: this installs the *musl* build of cargo-fuzz, and cargo-fuzz
+      # defaults `--target` to its own compile-time host triple. Left alone it
+      # therefore builds for musl, where ASAN cannot work ("sanitizer is
+      # incompatible with statically linked libc"). Hence the explicit
+      # FUZZ_TRIPLE below — do not drop it.
       - uses: taiki-e/install-action@v2.85.5
         with:
           tool: cargo-fuzz
@@ -91,7 +96,8 @@ jobs:
           make fuzz \
             TARGET="${{ matrix.target }}" \
             FUZZ_SECS="${{ inputs.seconds || '300' }}" \
-            FUZZ_TOOLCHAIN="$NIGHTLY"
+            FUZZ_TOOLCHAIN="$NIGHTLY" \
+            FUZZ_TRIPLE=x86_64-unknown-linux-gnu
 
       # cargo-fuzz writes a reproducer into fuzz/artifacts/<target>/ on a
       # crash. `always()` so it uploads on the failing run — which is the only

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ deny: ## Supply-chain checks: advisories, licenses, sources, bans (cargo-deny)
 	cargo deny --all-features check
 
 .PHONY: fuzz
-fuzz: ## Coverage-guided fuzz (needs nightly + cargo-fuzz; on-demand, NOT in `check`). TARGET=dsl_parse|render_markdown|highlight|word_wrap|expand_path|expand_percent, FUZZ_SECS=N, FUZZ_TOOLCHAIN=nightly-YYYY-MM-DD.
+fuzz: ## Coverage-guided fuzz (needs nightly + cargo-fuzz; on-demand, NOT in `check`). TARGET=dsl_parse|render_markdown|highlight|word_wrap|expand_path|expand_percent, FUZZ_SECS=N, FUZZ_TOOLCHAIN=nightly-YYYY-MM-DD, FUZZ_TRIPLE=<host triple>.
 	@command -v cargo-fuzz >/dev/null 2>&1 || { \
 		echo "cargo-fuzz not found — install with: cargo install cargo-fuzz"; \
 		exit 1; \
@@ -93,7 +93,8 @@ fuzz: ## Coverage-guided fuzz (needs nightly + cargo-fuzz; on-demand, NOT in `ch
 		echo "nightly toolchain not found — install with: rustup toolchain install nightly"; \
 		exit 1; \
 	}
-	cargo +$(or $(FUZZ_TOOLCHAIN),nightly) fuzz run $(or $(TARGET),dsl_parse) \
+	cargo +$(or $(FUZZ_TOOLCHAIN),nightly) fuzz run \
+		$(if $(FUZZ_TRIPLE),--target $(FUZZ_TRIPLE),) $(or $(TARGET),dsl_parse) \
 		-- -max_total_time=$(or $(FUZZ_SECS),30)
 
 # Advisory AI-slop / code-quality scan. Deliberately NOT part of `check`: its


### PR DESCRIPTION
Follow-up to #240. The first dispatched run of the new fuzz workflow ([run 31142473716](https://github.com/Tripstack-Corp/spyc/actions/runs/31142473716)) failed on **all six targets**.

## What happened

```
error: sanitizer is incompatible with statically linked libc,
       disable it using `-C target-feature=-crt-static`
error[E0463]: can't find crate for `core`
  = note: the `x86_64-unknown-linux-musl` target may not be installed
```

`taiki-e/install-action` installs the static build — the log confirms `cargo-fuzz v0.13.2 (x86_64-unknown-linux-musl)` — and **cargo-fuzz defaults `--target` to its own compile-time host triple**. So it built for musl, where ASAN cannot work, and the pinned nightly's `--profile minimal` had no musl std either.

Six identical failures rather than one was the tell: a setup fault, not a crash the fuzzer found.

## Why local verification missed it

I did run the fuzz for real before shipping #240 — 69,948 executions, 87 corpus entries. But on macOS cargo-fuzz is a *darwin* binary, so its default target is correct there. The bug only exists where the installed cargo-fuzz is musl-built, which is exactly the CI runner. Running it locally was necessary and not sufficient; the dispatch was the test that mattered, and it could only run post-merge.

## Fix

The workflow passes `FUZZ_TRIPLE=x86_64-unknown-linux-gnu`. The Makefile emits `--target` only when the variable is set, so a local `make fuzz` keeps cargo-fuzz's own default:

```
WITH triple:  cargo +nightly fuzz run --target x86_64-unknown-linux-gnu highlight -- -max_total_time=30
WITHOUT:      cargo +nightly fuzz run highlight -- -max_total_time=30
```

The reason is recorded next to the install step — an explicit target looks redundant, and the next reader would otherwise delete it and reintroduce this.

## Verification

`make check` green (exit code checked with `set -o pipefail`), YAML parsed, both Makefile invocation paths dry-run confirmed. The real test is another `workflow_dispatch` once this merges — I'll run it and report rather than assuming.

Generated with [Claude Code](https://claude.com/claude-code)