### PR TITLE
debug(pane): record the child's cursor-key mode in the key trace (C1)

### DIFF
--- a/src/pane/mod.rs
+++ b/src/pane/mod.rs
@@ -316,8 +316,13 @@ impl Pane {
         let bytes = input::encode_key(key);
         if !bytes.is_empty() {
             if crate::key_trace::is_enabled() {
+                // `app_cursor` is the child's DECCKM state. spyc always encodes
+                // the CSI form, so a child in application-cursor mode is waiting
+                // for `ESC O A` and gets `ESC [ A` — logged here because it is
+                // invisible from the byte stream alone.
+                let app_cursor = self.lock_parser().screen().application_cursor();
                 crate::key_trace::log_tx(&format!(
-                    "send_key code={:?} mods={:?} bytes={}",
+                    "send_key code={:?} mods={:?} bytes={} app_cursor={app_cursor}",
                     key.code,
                     key.modifiers,
                     preview_bytes(&bytes),


### PR DESCRIPTION
C1 of the post-remediation cleanup engagement. **No fix — instrumentation only.**

## C1 did not reproduce

Deliberate attempt with an instrumented build: second spyc instance in `~/src/primes_research`, `SPYC_KEY_TRACE=1` armed and confirmed writing, Claude agent pane + plain shell pane, multi-question `AskUserQuestion` left unanswered, repeated pane switches. **Input stayed live.**

Per the brief, no speculative fix — that would convert an open question into false confidence. The reproduction matrix and the untried variations are recorded in `docs/drafts/mutli-question-bug-investigation.md`.

## What the investigation did establish

**Candidate A (latched `resolver_pending`) is ruled out.** A latch can swallow exactly one keystroke, never a sequence:
- every pending state resets on an unmatched continuation (`Leader` ends `_ => Ignored` then `self.reset()`; `reset()` appears 11× across the chord arms)
- with `pending` true and the pane focused, `route_input` falls through to `InputSink::Resolver`, so the key reaches `feed`, which resets
- the only pre-`feed` swallow, `is_post_chord_bounce`, is bounded to 60 ms, the same keycode, and explicitly requires `!resolver_pending`

The live trace confirmed it independently: `g` armed `pending=Some("g-")`, the next key resolved `Ignored` and cleared it.

**A new candidate C, confirmed to exist.** `vt100` tracks `application_cursor()` and spyc never reads it — `encode_key` emits the CSI form unconditionally. Throwaway probe:

```
PROBE application_cursor=true spyc_sends="\u{1b}[A"
```

After the child sends the DECCKM-set sequence it waits for `ESC O A` and gets `ESC [ A`. This is the first candidate that predicts the reported asymmetry — arrows are mode-dependent and die, `^c` is a bare `0x03` and survives. It also explains the intermittency: most parsers accept both forms, so the gap is normally benign.

## What this PR changes

One field on the trace's send line: `app_cursor=<bool>`. That's the variable separating "spyc sent the wrong bytes" from "spyc sent the right bytes and the child ignored them", and nothing else exposes it. The next occurrence now yields a decisive answer on first capture without rebuilding.

**The encoding gap itself is deliberately left unfixed** and is flagged as an unrequested finding.

## Test evidence

`make check` green, exit verified with `set -o pipefail`. Diagnostics-only; no behaviour change on any path that isn't already `key_trace::is_enabled()`.

Generated with [Claude Code](https://claude.com/claude-code)