### PR TITLE
fix(test): stop the test suite writing to the real repo under a git hook (C9)

### DIFF
--- a/src/app/harness_tests/per_column.rs
+++ b/src/app/harness_tests/per_column.rs
@@ -214,6 +214,11 @@ fn dual_git_each_column_shows_its_own_repo() {
             .env("GIT_COMMITTER_EMAIL", "t@x")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+            // retarget this at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git")
             .success();
@@ -284,6 +289,11 @@ fn worktree_column_markers_clear_after_a_commit() {
             .env("GIT_COMMITTER_EMAIL", "t@x")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+            // retarget this at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git")
             .success();
@@ -370,6 +380,11 @@ fn why_git_dumps_per_column_refresh_state() {
             .env("GIT_COMMITTER_EMAIL", "t@x")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+            // retarget this at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
     };

--- a/src/app/state/tests/mod.rs
+++ b/src/app/state/tests/mod.rs
@@ -604,6 +604,11 @@ fn refresh_listing_picks_up_edit_and_clears_after_commit() {
             // hermetic on machines with unusual defaults.
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+            // retarget this at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");
@@ -672,6 +677,11 @@ fn throttled_worktree_edit_converges_on_next_poll() {
             .env("GIT_COMMITTER_EMAIL", "t@x")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+            // retarget this at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");
@@ -755,6 +765,11 @@ fn git_worker_available_enqueues_request_instead_of_spawning() {
             .env("GIT_COMMITTER_EMAIL", "t@x")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+            // retarget this at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");
@@ -829,6 +844,11 @@ fn forced_rewalk_keeps_stale_markers_and_star_instead_of_blanking() {
             .env("GIT_COMMITTER_EMAIL", "t@x")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+            // retarget this at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");
@@ -960,6 +980,11 @@ fn compute_git_info_fast_memoizes_branch_by_head_mtime() {
             .env("GIT_COMMITTER_EMAIL", "t@x")
             .env("GIT_CONFIG_GLOBAL", "/dev/null")
             .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+            // retarget this at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");

--- a/src/git/test_support.rs
+++ b/src/git/test_support.rs
@@ -21,6 +21,57 @@ use std::path::Path;
 /// logic bug — widen the budget rather than chase an unreproducible one-off.
 const RUN_GIT_MAX_ATTEMPTS: u32 = 6;
 
+/// Environment variables through which an ambient git process redirects a
+/// child at a different repository. **`GIT_DIR` overrides `-C`**, so a test
+/// that carefully passes `-C <tempdir>` still operates on whatever these name.
+///
+/// This is not theoretical. `git` exports `GIT_DIR` and `GIT_INDEX_FILE` into
+/// hook processes, so a `cargo test` launched from the pre-commit hook has
+/// every one of its scratch-repo commands silently retargeted at the real
+/// repository — writing its config, and staging into its index. Observed
+/// 2026-08-07: a full suite run under the hook wrote `core.bare = true` into
+/// the developer's checkout (breaking `git status` outright, which in turn
+/// blanked spyc's own git markers), corrupted the worktree index, and failed
+/// 99 tests. The 2026-07-02 `index.lock: Not a directory` failure recorded
+/// above was almost certainly the same leak, misread as contention and papered
+/// over by widening the retry budget.
+const GIT_REDIRECT_ENV: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_NAMESPACE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_PREFIX",
+    "GIT_CEILING_DIRECTORIES",
+];
+
+/// A `git` command targeting `dir`, with the ambient repo environment stripped
+/// and a hermetic config. Every test-side git spawn must go through this —
+/// `-C` alone is not enough (see [`GIT_REDIRECT_ENV`]).
+pub fn git_command(dir: &Path) -> std::process::Command {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("-C")
+        .arg(dir)
+        // Pin the process cwd to a stable, never-deleted dir: sibling tests
+        // `set_current_dir` and drop their tempdirs, which can transiently
+        // invalidate an inherited cwd mid-spawn.
+        .current_dir(std::env::temp_dir())
+        // Fixed author/committer so tests that assert on commit metadata
+        // (blame, diff-model `show`) get a stable name/email.
+        .env("GIT_AUTHOR_NAME", "Ada")
+        .env("GIT_AUTHOR_EMAIL", "ada@example.com")
+        .env("GIT_COMMITTER_NAME", "Ada")
+        .env("GIT_COMMITTER_EMAIL", "ada@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null");
+    for var in GIT_REDIRECT_ENV {
+        cmd.env_remove(var);
+    }
+    cmd
+}
+
 /// Run `git` against `dir` with a hermetic config (no user/system
 /// `.gitconfig`), returning stdout.
 ///
@@ -31,24 +82,9 @@ const RUN_GIT_MAX_ATTEMPTS: u32 = 6;
 /// heavy concurrent filesystem churn on the temp volume can transiently
 /// misreport on an unrelated path; retry with backoff to ride out either.
 pub fn run_git(dir: &Path, args: &[&str]) -> String {
-    let dir_str = dir.to_str().expect("utf8 dir");
     let mut last_err = String::new();
     for attempt in 0..RUN_GIT_MAX_ATTEMPTS {
-        let out = std::process::Command::new("git")
-            .arg("-C")
-            .arg(dir_str)
-            .args(args)
-            .current_dir(std::env::temp_dir())
-            // Fixed author/committer so tests that assert on commit metadata
-            // (blame, diff-model `show`) get a stable name/email.
-            .env("GIT_AUTHOR_NAME", "Ada")
-            .env("GIT_AUTHOR_EMAIL", "ada@example.com")
-            .env("GIT_COMMITTER_NAME", "Ada")
-            .env("GIT_COMMITTER_EMAIL", "ada@example.com")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            .output()
-            .expect("spawn git");
+        let out = git_command(dir).args(args).output().expect("spawn git");
         if out.status.success() {
             return String::from_utf8(out.stdout).expect("utf8 stdout");
         }
@@ -58,4 +94,69 @@ pub fn run_git(dir: &Path, args: &[&str]) -> String {
         ));
     }
     panic!("git {args:?} failed after {RUN_GIT_MAX_ATTEMPTS} attempts: {last_err}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{GIT_REDIRECT_ENV, git_command};
+
+    #[test]
+    fn git_command_strips_the_ambient_repo_redirect() {
+        // `GIT_DIR` overrides `-C`, so a hook-launched `cargo test` would
+        // retarget every scratch-repo command at the real repository. Asserted
+        // on the built command rather than by mutating the process
+        // environment: `std::env::set_var` is unsafe in edition 2024, and the
+        // parallel suite shares one environment anyway.
+        let cmd = git_command(std::path::Path::new("/tmp"));
+        let removed: Vec<&str> = cmd
+            .get_envs()
+            .filter(|(_, v)| v.is_none())
+            .filter_map(|(k, _)| k.to_str())
+            .collect();
+        for var in GIT_REDIRECT_ENV {
+            assert!(
+                removed.contains(var),
+                "{var} must be cleared — `-C` does not override it; got {removed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn git_dir_really_does_beat_dash_c() {
+        // Characterizes the hazard the removal above defends against, so the
+        // reason for it can't be lost. Two throwaway repos: `-C` names one,
+        // `GIT_DIR` names the other, and `GIT_DIR` wins.
+        let tmp = tempfile::tempdir().unwrap();
+        let decoy = tmp.path().join("decoy");
+        let target = tmp.path().join("target");
+        for p in [&decoy, &target] {
+            std::fs::create_dir(p).unwrap();
+            super::run_git(p, &["init", "-q", "--initial-branch=main"]);
+        }
+        // Deliberately NOT via `git_command` — this reproduces the ambient leak.
+        let ok = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&target)
+            .args(["config", "spyc.probe", "leaked"])
+            .env("GIT_DIR", decoy.join(".git"))
+            .status()
+            .expect("spawn git")
+            .success();
+        assert!(ok, "probe write must succeed");
+        assert_eq!(
+            super::run_git(&decoy, &["config", "--get", "spyc.probe"]).trim(),
+            "leaked",
+            "GIT_DIR should have captured the write"
+        );
+        let target_val = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&target)
+            .args(["config", "--get", "spyc.probe"])
+            .output()
+            .expect("spawn git");
+        assert!(
+            !target_val.status.success(),
+            "the -C target must NOT have been written — that is the whole hazard"
+        );
+    }
 }

--- a/src/mcp/config.rs
+++ b/src/mcp/config.rs
@@ -1089,6 +1089,11 @@ mod tests {
                 .env("GIT_COMMITTER_EMAIL", "t@x")
                 .env("GIT_CONFIG_GLOBAL", "/dev/null")
                 .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
+                // retarget this at the real repo — see git::test_support.
+                .env_remove("GIT_DIR")
+                .env_remove("GIT_WORK_TREE")
+                .env_remove("GIT_INDEX_FILE")
                 .status()
                 .expect("spawn git")
                 .success();

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -286,6 +286,11 @@ mod tests {
         let ok = std::process::Command::new("git")
             .args(["init", "-q"])
             .current_dir(tmp.path())
+            // `GIT_DIR` overrides the cwd, so a hook-launched test run would
+            // init/redirect at the real repo — see git::test_support.
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("git init")
             .success();


### PR DESCRIPTION
Added mid-engagement after the failure below happened live. **This is a repo-corrupting bug, not a flake.**

## What happens

**`GIT_DIR` overrides `-C`.** git exports `GIT_DIR` and `GIT_INDEX_FILE` into hook processes, so a `cargo test` launched from the pre-commit hook has every scratch-repo command in the suite silently retargeted at the developer's real repository — regardless of how carefully the call site passes `-C <tempdir>` and pins its cwd. Both defences are simply ignored.

Proven with a throwaway pair of repos:

```
git -C .../other config core.bare true     # with GIT_DIR=.../victim/.git
→ victim core.bare: true      ← the write landed here
→ other  core.bare: false     ← the -C target was untouched
```

## What it cost today

A full `make check` under the hook wrote `core.bare = true` into the real checkout. That makes `git status` fail outright (`fatal: this operation must be run in a work tree`), which:

- blanked spyc's own git markers in the running TUI
- corrupted the worktree index — every tracked file staged as deleted, a stray `f.txt`, a config file missing
- failed **99 tests**

Recovery was one command, but nothing pointed at the cause and the damage looked exactly like data loss. Worktrees share `.git/config`, so a commit in *any* worktree reaches the main checkout.

## It had happened before, and was misdiagnosed

`RUN_GIT_MAX_ATTEMPTS`' own comment records a 2026-07-02 failure under this same hook — `git add` hitting `index.lock: Not a directory` — attributed to "genuine transient contention" and papered over by widening the retry budget from 3 to 6. Same leak: the inherited `GIT_INDEX_FILE` pointed at the real index. The retry widening was treating a symptom.

## The fix

`git::test_support::git_command()` — one builder that strips the nine variables through which an ambient git redirects a child (`GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR`, `GIT_NAMESPACE`, `GIT_OBJECT_DIRECTORY`, `GIT_ALTERNATE_OBJECT_DIRECTORIES`, `GIT_PREFIX`, `GIT_CEILING_DIRECTORIES`). `run_git` routes through it.

The nine ad-hoc spawn sites that build their own command keep their existing shape — their author identities aren't asserted anywhere, but changing them was unnecessary churn — and drop the three variables that actually bite.

## Test evidence

- `git_command_strips_the_ambient_repo_redirect` — asserts every redirect variable is cleared, checked on the built `Command` rather than by mutating the process environment (`set_var` is unsafe in edition 2024, and the parallel suite shares one environment)
- `git_dir_really_does_beat_dash_c` — characterizes the hazard itself so the reason for the removals can't be lost to a future "why is this here?" cleanup

`make check` green, **1,790 tests**, exit verified with `set -o pipefail`. `core.bare` confirmed unchanged after the run.

## Consequence

`make install-hooks` becomes safe. The convention of gating explicitly then committing with `--no-verify` stays as the belt to this fix's braces.

Generated with [Claude Code](https://claude.com/claude-code)