### PR TITLE
fix(pager): put [EOF] on the last line of a markdown file, not the row below

### DIFF
--- a/src/ui/markdown/renderer.rs
+++ b/src/ui/markdown/renderer.rs
@@ -48,6 +48,25 @@ impl<'t> Renderer<'t> {
         if !self.current.is_empty() {
             self.flush_line();
         }
+        // Every block end emits its separator blank unconditionally (two for a
+        // blockquote), leaving trailing rows with nothing after them to separate.
+        // The pager reads `lines.len()` as the document length, so those rows
+        // inflated its `(N lines)` and put `[EOF]` below the last line of content.
+        // Safe to drop: code/table/mermaid blocks close on a fence row, so only a
+        // separator can be last.
+        while self
+            .lines
+            .last()
+            .is_some_and(|l| l.spans.iter().all(|s| s.content.is_empty()))
+        {
+            self.lines.pop();
+        }
+        // A mermaid block's range spans its placeholder *through* that separator,
+        // so a diagram ending the document is left pointing one row past the end.
+        let len = self.lines.len();
+        for block in &mut self.mermaid_blocks {
+            block.line_range.end = block.line_range.end.min(len);
+        }
         MarkdownDoc {
             lines: self.lines,
             mermaid_blocks: self.mermaid_blocks,

--- a/src/ui/markdown/tests.rs
+++ b/src/ui/markdown/tests.rs
@@ -334,3 +334,78 @@ fn no_code_block_records_nothing() {
     let d = doc("# just prose\n\nno diagrams here\n");
     assert!(d.mermaid_blocks.is_empty());
 }
+
+// --- the document ends on its last line of content ---
+
+/// The pager reads `lines.len()` as the document's length: it numbers rows from
+/// it, prints it as `(N lines)`, and puts `[EOF]` on the row after the last one.
+/// Every block end emitting its separator blank unconditionally left a trailing
+/// row with no content, so `[EOF]` sat a row below the text it was marking the
+/// end of. One case per block kind that can close on a blank — a blockquote
+/// closes on two (its inner paragraph, then the quote).
+#[test]
+fn rendered_doc_ends_on_content_not_a_separator_blank() {
+    for (kind, src) in [
+        ("paragraph", "hello\n"),
+        ("heading", "# Title\n"),
+        ("list", "- a\n- b\n"),
+        ("nested list", "- a\n  - b\n"),
+        ("code block", "```rust\nfn main() {}\n```\n"),
+        ("table", "|a|b|\n|-|-|\n|1|2|\n"),
+        ("blockquote", "> quoted\n"),
+        ("mermaid", "```mermaid\nflowchart LR\n  A-->B\n```\n"),
+        ("trailing blanks in source", "hello\n\n\n\n"),
+        (
+            "paragraph after block",
+            "```rust\nfn f() {}\n```\n\ntail text\n",
+        ),
+    ] {
+        let lines = render_plain(src);
+        assert!(
+            !lines.is_empty(),
+            "{kind}: rendered to nothing, expected content"
+        );
+        assert!(
+            !lines[lines.len() - 1].is_empty(),
+            "{kind}: last rendered line is blank — [EOF] would land past the \
+             content:\n{lines:#?}"
+        );
+    }
+}
+
+/// An empty (or blank-only) source has no content to end on, and must not
+/// underflow its way to a panic while the trailing blanks are trimmed.
+#[test]
+fn empty_source_renders_no_lines() {
+    for src in ["", "\n", "\n\n\n", "   \n"] {
+        let lines = render_plain(src);
+        assert!(
+            lines.iter().all(|l| l.trim().is_empty()),
+            "blank source rendered content: {lines:#?}"
+        );
+    }
+}
+
+/// A diagram's `line_range` runs from its header row *through* the separator
+/// blank that follows it, so trimming that blank off the end of the document
+/// leaves the range pointing one row past the end — the pager slices `lines`
+/// with it to find the source under the cursor.
+#[test]
+fn mermaid_range_stays_in_bounds_when_the_diagram_ends_the_doc() {
+    let d = doc("intro\n\n```mermaid\nflowchart LR\n  A-->B\n```\n");
+    assert_eq!(d.mermaid_blocks.len(), 1);
+    let b = &d.mermaid_blocks[0];
+    assert!(
+        b.line_range.end <= d.lines.len(),
+        "range {:?} escapes the {} rendered lines",
+        b.line_range,
+        d.lines.len()
+    );
+    // Still a usable slice: the header is its first row and the source is inside.
+    let block_text: String = d.lines[b.line_range.clone()]
+        .iter()
+        .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+        .collect();
+    assert!(block_text.contains("mermaid diagram"));
+    assert!(block_text.contains("flowchart LR"));
+}


### PR DESCRIPTION
## The bug

The pager's `[EOF]` marker sat one row below the last line of content on markdown
files, and the `(N lines)` header counted one line too many.

Reported against `BUILD.md`, with `cliff.toml` as the contrast that isolates it:
`cliff.toml` renders through the plain path and was correct, `BUILD.md` through
markdown and was not.

## Cause

Not the pager's EOF logic. Every block *end* in the markdown renderer pushes its
separator blank unconditionally — `TagEnd::Paragraph`, `Heading`, `BlockQuote`,
`List`, plus the code/table/mermaid emitters — so a rendered document always
finished on a blank row with nothing after it to separate. A blockquote ends on
two, its paragraph and quote ends both firing.

The pager reads `lines.len()` as the document's length, so that phantom row both
inflated the `(N lines)` header and pushed `[EOF]` past the text it marks the end
of. Plain files were unaffected: they split with `str::lines()`, which yields no
trailing element for a file ending in a newline.

Every markdown file was affected, measured before the fix:

```
BUILD.md:      118 rendered lines, 1 trailing blank
AGENTS.md:     548 rendered lines, 1 trailing blank
CHANGELOG.md: 4560 rendered lines, 1 trailing blank
"hello\n":       2 rendered lines, 1 trailing blank   ← a one-line document
"> quoted\n":    3 rendered lines, 2 trailing blanks
```

## Fix

Trim trailing empty rows in `finish_doc`. Nothing rendered can be lost: code,
table and mermaid blocks all close on a fence row, so only a separator can ever
be the last line.

One thing this would otherwise have broken silently — a mermaid block's
`line_range` runs from its header row *through* that separator, so a diagram
ending a document was left pointing one row past the end. The pager slices
`lines` with that range to find the diagram under the cursor, so the ranges are
now clamped.

## Tests

- `rendered_doc_ends_on_content_not_a_separator_blank` — table over every block
  kind that can close on a blank (paragraph, heading, list, nested list, code,
  table, blockquote, mermaid, trailing blanks in source, paragraph after block).
- `empty_source_renders_no_lines` — blank-only sources, so the trim loop can't
  underflow.
- `mermaid_range_stays_in_bounds_when_the_diagram_ends_the_doc` — the clamp, and
  that the range still slices to a usable block.

`make check` green: 1798 tests, clippy, fmt, cargo-deny.

Generated with [Claude Code](https://claude.com/claude-code)
