### PR TITLE
fix(agent): let `^c` clear a blocked dot too, alongside Enter and Esc

### DIFF
--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -46,10 +46,11 @@ three tiers; a higher tier always wins:
 | `💤` | `^z`-suspended |
 
 `blocked` is **latched**: it stays red until you settle the prompt in that pane —
-**Enter** to answer it, **Esc** to decline — or the agent files a newer report.
-No timer or stray output bounces it off. Esc counts because no hook reports a
-decline: Claude Code ends a declined turn as a user interrupt, and `Stop` doesn't
-fire on an interrupt, so the keystroke is the only signal spyc gets.
+**Enter** to answer it, **Esc** or **`^c`** to dismiss it — or the agent files a
+newer report. No timer or stray output bounces it off. The dismissal keys count
+because no hook reports one: Claude Code ends a declined turn as a user
+interrupt, and `Stop` doesn't fire on an interrupt, so the keystroke is the only
+signal spyc gets.
 
 **Auto-reporting.** So it works without the agent choosing to call the tool, spyc
 installs lifecycle hooks that run `spyc --report-status` (prompt-submit→working,

--- a/src/app/agent_status.rs
+++ b/src/app/agent_status.rs
@@ -66,8 +66,8 @@ const AGENT_ANIM_INTERVAL: Duration = Duration::from_millis(250);
 /// output-based supersede (even behind a grace window) eventually bounces the
 /// dot off red and back to the working pulse. Blocked is cleared only by its
 /// TTL, a newer report, or the user settling the prompt — answering it with
-/// Enter or declining it with Esc (the `SendToPane` handler in `run_effects`
-/// drops it on either keystroke).
+/// Enter or dismissing it with Esc / `^c` (the `SendToPane` handler in
+/// `run_effects` drops it on any of those keystrokes).
 /// Every other status is superseded by any output after it.
 fn report_superseded_by_output(r: ReportedStatus, last_output_at: Option<Instant>) -> bool {
     if r.status == AgentActivity::Blocked {
@@ -1051,7 +1051,7 @@ mod tests {
     // not the prompt's initial render, not the menu's later redraws while it
     // waits, and not the expiry clock (the bug where any of those bounced the
     // dot off red and back to the working pulse). It clears only via a newer
-    // report or the user settling the prompt — Enter or Esc, handled in
+    // report or the user settling the prompt — Enter, Esc or `^c`, handled in
     // `run_effects`. A non-blocked report still hands back to timing on output.
     #[test]
     fn blocked_report_is_latched_against_output() {

--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -307,24 +307,29 @@ impl PaneInput {
     }
 
     /// Whether this input settles a prompt the agent is blocked on — the signal
-    /// that clears a latched `Blocked` dot. Enter answers it; **Esc declines it**,
-    /// which ends the block just as decisively (the agent's question is gone
-    /// either way, and nothing needs the user any more).
+    /// that clears a latched `Blocked` dot. Enter answers it; **Esc and `^c`
+    /// dismiss it**, which ends the block just as decisively (the agent's
+    /// question is gone either way, and nothing needs the user any more).
     ///
-    /// Declining has to be handled here because no hook reports it: Claude Code
+    /// Dismissal has to be handled here because no hook reports it: Claude Code
     /// ends a declined turn as a user interrupt, and `Stop` — the event that
     /// would report `done` — does not fire on an interrupt. Left to the hooks
     /// alone the dot stays red until the next prompt or the idle-notification
     /// backstop, long after the question left the screen.
     ///
-    /// Exact matches only. A bare Esc byte is the key; `\x1b[A` and friends are
-    /// arrows, and typing, menu navigation, or a paste that merely *contains* a
-    /// newline still leaves the dot red until the user actually commits.
+    /// Exact matches only. A bare Esc / `\x03` byte is the key; `\x1b[A` and
+    /// friends are arrows, and typing, menu navigation, or a paste that merely
+    /// *contains* one of these leaves the dot red until the user commits.
     fn settles_prompt(&self) -> bool {
-        use crossterm::event::KeyCode;
+        use crossterm::event::{KeyCode, KeyModifiers};
         match self {
-            Self::Key(k) => matches!(k.code, KeyCode::Enter | KeyCode::Esc),
-            Self::Bytes(b) => matches!(b.as_slice(), b"\r" | b"\n" | b"\r\n" | b"\x1b"),
+            Self::Key(k) => match k.code {
+                KeyCode::Enter | KeyCode::Esc => true,
+                // `^c` arrives as the letter plus the modifier, either case.
+                KeyCode::Char('c' | 'C') => k.modifiers.contains(KeyModifiers::CONTROL),
+                _ => false,
+            },
+            Self::Bytes(b) => matches!(b.as_slice(), b"\r" | b"\n" | b"\r\n" | b"\x1b" | b"\x03"),
         }
     }
 }
@@ -596,7 +601,7 @@ impl App {
                         self.view.pane_send_at = Some(std::time::Instant::now());
                     }
                     // Only settling the prompt answers the pane — Enter to commit,
-                    // Esc to decline. A latched `blocked` dot stays red through
+                    // Esc / `^c` to dismiss. A latched `blocked` dot stays red through
                     // navigation / typing / pastes and clears only on one of those
                     // (or a newer report).
                     let clears_blocked = input.settles_prompt();
@@ -1075,17 +1080,31 @@ mod tests {
         assert!(PaneInput::Bytes(b"\r".to_vec()).settles_prompt());
         assert!(PaneInput::Bytes(b"\n".to_vec()).settles_prompt());
         assert!(PaneInput::Bytes(b"\r\n".to_vec()).settles_prompt());
-        // Declining settles it too — the question is off the screen either way,
-        // and no hook reports the decline (a declined turn ends as an interrupt,
+        // Dismissing settles it too — the question is off the screen either way,
+        // and no hook reports the dismissal (a declined turn ends as an interrupt,
         // which doesn't fire `Stop`), so this is the only signal spyc gets.
+        let ctrl = |c| PaneInput::Key(KeyEvent::new(c, KeyModifiers::CONTROL));
         assert!(key(KeyCode::Esc).settles_prompt());
         assert!(PaneInput::Bytes(b"\x1b".to_vec()).settles_prompt());
+        assert!(ctrl(KeyCode::Char('c')).settles_prompt());
+        assert!(ctrl(KeyCode::Char('C')).settles_prompt());
+        assert!(PaneInput::Bytes(b"\x03".to_vec()).settles_prompt());
         // Everything else leaves a latched blocked dot stuck: navigation, typing,
         // and pastes that merely *contain* a newline.
         assert!(!key(KeyCode::Char('y')).settles_prompt());
         assert!(!key(KeyCode::Down).settles_prompt());
         assert!(!PaneInput::Bytes(b"line1\nline2".to_vec()).settles_prompt());
         assert!(!PaneInput::Bytes(b"1".to_vec()).settles_prompt());
+        // A bare `c` is a letter, not an interrupt — only the modifier makes it one.
+        assert!(!key(KeyCode::Char('c')).settles_prompt());
+        assert!(!PaneInput::Bytes(b"c".to_vec()).settles_prompt());
+        // And other ctrl chords are ordinary keystrokes to the child.
+        for c in ['a', 'd', 'z', 'r'] {
+            assert!(
+                !ctrl(KeyCode::Char(c)).settles_prompt(),
+                "^{c} must not settle the prompt"
+            );
+        }
         // An escape *sequence* is a keypress, not a decline — the arrow keys the
         // user presses to move through the very question this would clear.
         for seq in [&b"\x1b[A"[..], b"\x1b[B", b"\x1b[C", b"\x1b[D", b"\x1bOA"] {


### PR DESCRIPTION
Follow-up to #257, which deliberately left `^c` out. Owner asked for it.

## Why it belongs

`^c` dismisses an agent's question exactly as Esc does, and it's the key actually
reached for in practice — it doubles as the interrupt. Leaving it out meant the
same stale hot-red dot #257 fixed, just via a different key: a "needs me" about a
question that is no longer on screen.

## Change

`PaneInput::settles_prompt` accepts `^c` in both forms the pane can deliver it:

- the keypress — `KeyCode::Char('c' | 'C')` carrying `CONTROL`
- the raw byte — an exact `\x03`

Exact byte match as before, so a paste that merely *contains* an ETX is still
just text. No other ctrl chord qualifies: `^a`, `^d`, `^z`, `^r` stay ordinary
keystrokes to the child, and a bare `c` is a letter.

## The trade-off, stated plainly

`^c` is overloaded in Claude Code — clear the input line, interrupt the turn,
exit on a double tap. So a `^c` that only clears a typed line while an agent is
genuinely blocked now clears the dot too. That's the cost of covering the
dismissal case, and it's the call made here knowingly.

## Tests

Extends the `settles_prompt` table: both `^c` key spellings and the `\x03` byte
settle; a bare `c`, a `c` byte, and `^a`/`^d`/`^z`/`^r` do not. The existing
arrow-sequence cases still pin that `\x1b[A` isn't a dismissal.

Docs: `AGENT_ORCHESTRATION.md` plus the three code comments that named only
Enter/Esc now name all three keys.

`make check` green: 1809 tests, clippy, fmt, cargo-deny.

Generated with [Claude Code](https://claude.com/claude-code)
