### PR TITLE
fix(pane): confirm ^a R on a live child and restart in place (#151)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -409,8 +409,12 @@ Multiple tabs, each running an independent pty:
 - **^a n / ^a ]** next tab
 - **^a ^a** jump to the last-active tab (screen/tmux "last window")
 - **^a r** rename the active tab
-- **^a R** restart the active tab — closes it and respawns the same
-  command in the same working directory
+- **^a R** restart the active tab — respawns the same command in the same
+  working directory, **in place**, so the tab keeps its number (and its `^a r`
+  rename). Confirms first (`y`/`N`) when the child is still running, for the
+  same reason `^a x` does; an already-exited tab restarts silently. The new
+  child is a new process, so its `SPYC_PANE_ID`, agent conversation, and
+  scrollback all start fresh
 - Activity indicator (**+**) on background tabs that have new output
 - **Default command** for `^a c` resolves in this order:
   `$SPYC_PANE_CMD` env var → `[pane] default_command` in

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -90,8 +90,10 @@ works. Prefix is `^a` (screen-style); `^w` also works.
 | `^a c` | New tab |
 | `^a n` / `^a ]` | Next tab |
 | `^a p` / `^a [` | Prev tab |
-| `^a K` / `^a x` | Close tab |
+| `^a K` / `^a x` | Close tab (confirms first while its child is still running) |
 | `^a 1`..`9` | Switch to tab N |
+| `^a r` | Rename tab |
+| `^a R` | Restart tab in place, keeping its number (confirms first while its child is still running) |
 | `^a s` | Send selection paths to pane |
 | `^a P` | Pipe file contents to pane |
 | `^a z` | Zoom the active region — list or bottom pane (fullscreen toggle) |

--- a/src/app/harness_tests/pane.rs
+++ b/src/app/harness_tests/pane.rs
@@ -726,6 +726,112 @@ fn closing_a_running_tab_confirms_first() {
     });
 }
 
+/// `^a R` on a tab whose child is still running confirms before restarting —
+/// the restart kills the child, losing the session exactly as `^a x` would, and
+/// `R` is one shift away from `r` (rename). `n` keeps it, `y` restarts it.
+#[test]
+fn restarting_a_running_tab_confirms_first() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().join("work");
+        std::fs::create_dir(&dir).unwrap();
+        let mut app = App::test_app(dir);
+        app.open_pane_tab("cat"); // cat blocks on stdin → the tab stays live
+        let pane_id = |app: &App| {
+            app.runtime
+                .pane_tabs
+                .as_ref()
+                .expect("a tab exists")
+                .active_info()
+                .id
+                .clone()
+        };
+        let before = pane_id(&app);
+
+        // The running tab opens a confirm — nothing is respawned yet.
+        app.restart_active_tab();
+        assert!(
+            matches!(&app.state.mode, Mode::Prompting(p) if matches!(p.kind, PromptKind::RestartPane)),
+            "restarting a running tab opens the RestartPane confirm"
+        );
+        assert_eq!(pane_id(&app), before, "nothing restarts before confirming");
+
+        // `n` keeps the live child.
+        app.handle_key(key('n')).unwrap();
+        assert!(matches!(app.state.mode, Mode::Normal));
+        assert_eq!(pane_id(&app), before, "n cancels the restart");
+
+        // `y` goes through — a fresh child means a fresh pane id.
+        app.restart_active_tab();
+        app.handle_key(key('y')).unwrap();
+        assert!(matches!(app.state.mode, Mode::Normal));
+        assert_ne!(pane_id(&app), before, "y respawns the child");
+    });
+}
+
+/// Regression (#151): a restart respawns **into the same slot**, so tab numbers
+/// don't shift. The old close-then-append path removed the active tab (sliding
+/// every later tab's number down one) and pushed the replacement last.
+///
+/// Also pins what identity survives: command, cwd, and a `^a r` rename carry
+/// over; the `SPYC_PANE_ID` does not (it's a new process).
+#[test]
+fn restarting_a_tab_keeps_its_number() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().join("work");
+        std::fs::create_dir(&dir).unwrap();
+        let mut app = App::test_app(dir.clone());
+        for _ in 0..3 {
+            app.open_pane_tab("cat");
+        }
+        let ids = |app: &App| {
+            app.runtime
+                .pane_tabs
+                .as_ref()
+                .expect("tabs exist")
+                .tabs()
+                .iter()
+                .map(|t| t.info.id.clone())
+                .collect::<Vec<_>>()
+        };
+        let before = ids(&app);
+        assert_eq!(before.len(), 3);
+
+        // Restart the MIDDLE tab (number 2) after renaming it, so a shift left
+        // would be visible in both the order and the surviving label.
+        let tabs = app.runtime.pane_tabs.as_mut().expect("tabs exist");
+        tabs.switch_to(1);
+        tabs.tabs_mut()[1].info.label = "renamed".to_string();
+        app.restart_active_tab_now();
+
+        let after = ids(&app);
+        assert_eq!(after.len(), 3, "restart must not change the tab count");
+        assert_eq!(
+            app.runtime
+                .pane_tabs
+                .as_ref()
+                .expect("tabs exist")
+                .active_index(),
+            1,
+            "the restarted tab keeps its number"
+        );
+        assert_eq!(after[0], before[0], "tab 1 stays put");
+        assert_eq!(after[2], before[2], "tab 3 does NOT shift left");
+        assert_ne!(after[1], before[1], "the restarted tab is a new process");
+
+        let info = app
+            .runtime
+            .pane_tabs
+            .as_ref()
+            .expect("tabs exist")
+            .active_info();
+        assert_eq!(info.command, "cat", "command survives");
+        assert_eq!(info.cwd, dir, "cwd survives");
+        assert_eq!(info.label, "renamed", "a `^a r` rename survives");
+    });
+}
+
 /// Regression: `V`'s top-overlay editor pauses Pane-tier actions (new tab,
 /// rename, etc. would mutate the pane hidden behind the editor) — but the
 /// bottom pane STAYS VISIBLE while `V` is open (only the top file-list area is

--- a/src/app/key_dispatch/confirms.rs
+++ b/src/app/key_dispatch/confirms.rs
@@ -142,6 +142,21 @@ impl App {
         Vec::new()
     }
 
+    /// Single-key confirmation for `^a R` on a tab whose child is still
+    /// running. `y`/`Y` restarts it; anything else leaves it alone. An exited
+    /// tab never opens this prompt — it restarts straight from
+    /// `restart_active_tab`.
+    pub(super) fn handle_restart_pane_confirm_key(&mut self, key: KeyEvent) -> Vec<Effect> {
+        let confirmed = matches!(key.code, KeyCode::Char('y' | 'Y'));
+        self.state.mode = Mode::Normal;
+        if confirmed {
+            self.restart_active_tab_now();
+        } else {
+            self.view.needs_full_repaint = true;
+        }
+        Vec::new()
+    }
+
     /// Single-key confirmation for the auto-fired claude crash recovery
     /// prompt. `y` / `Y` / Enter kills the broken tab and replaces it with
     /// a fresh `claude` (the user can then `/resume` manually); anything

--- a/src/app/key_dispatch/prompts.rs
+++ b/src/app/key_dispatch/prompts.rs
@@ -51,6 +51,12 @@ impl App {
         }
         if matches!(
             &self.state.mode,
+            Mode::Prompting(p) if matches!(p.kind, PromptKind::RestartPane)
+        ) {
+            return self.handle_restart_pane_confirm_key(key);
+        }
+        if matches!(
+            &self.state.mode,
             Mode::Prompting(p) if matches!(p.kind, PromptKind::LuaRunaway)
         ) {
             return self.handle_lua_runaway_confirm_key(key);

--- a/src/app/pane_tabs.rs
+++ b/src/app/pane_tabs.rs
@@ -14,7 +14,55 @@ use super::{
     StatusPosition, TabEntry, TabInfo, state,
 };
 
+/// Where a freshly-spawned tab lands. `Replace` keeps the restarted tab's
+/// number: appending after a close is what shifted every later tab left (#151).
+#[derive(Clone, Copy)]
+pub(super) enum TabSlot {
+    Append,
+    Replace(usize),
+}
+
+/// The bits `needs_live_child_confirm` decides on, snapshotted off the tab.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct TabConfirmSnapshot {
+    /// The pty reader saw EOF — the tab shows `[exited N]`.
+    pub pane_closed: bool,
+    /// An exit status was reaped, so the child is gone even if EOF was missed.
+    pub exit_reaped: bool,
+    /// `Mode::Normal`. A confirm can only be raised from the base mode; any
+    /// other mode already owns the keyboard, so asking there would strand it.
+    pub mode_normal: bool,
+}
+
+/// Whether a destructive tab-lifecycle action (`^a x` close, `^a R` restart)
+/// must confirm first: only when a live child stands to be lost. An exited tab
+/// prompting is pure friction.
+pub(super) const fn needs_live_child_confirm(s: TabConfirmSnapshot) -> bool {
+    !s.pane_closed && !s.exit_reaped && s.mode_normal
+}
+
 impl App {
+    /// [`needs_live_child_confirm`] over a snapshot of the active tab. False
+    /// when there is no pane at all.
+    fn needs_active_tab_confirm(&self) -> bool {
+        self.runtime.pane_tabs.as_ref().is_some_and(|tabs| {
+            let p = tabs.active();
+            needs_live_child_confirm(TabConfirmSnapshot {
+                pane_closed: p.is_closed(),
+                exit_reaped: p.exit_status().is_some(),
+                mode_normal: matches!(self.state.mode, Mode::Normal),
+            })
+        })
+    }
+
+    /// The active tab's label, so a confirm can name what it is about to kill.
+    fn active_tab_label(&self) -> String {
+        self.runtime
+            .pane_tabs
+            .as_ref()
+            .map_or_else(String::new, |t| t.active_info().label.clone())
+    }
+
     /// `^a-\` / F10 — toggle the bottom pane. Three states:
     ///   1. No tabs yet (`pane_tabs.is_none()`): spawn the default
     ///      command.
@@ -81,6 +129,17 @@ impl App {
     /// injection) MUST gate on this, or they act on the wrong tab when the
     /// spawn fails. On failure this flashes the error and returns `false`.
     pub fn open_pane_tab_in(&mut self, cmd: &str, cwd: &std::path::Path) -> bool {
+        self.open_pane_tab_into(cmd, cwd, TabSlot::Append)
+    }
+
+    /// [`Self::open_pane_tab_in`], with control over which slot the new tab
+    /// takes — `TabSlot::Replace` is the `^a R` restart-in-place path.
+    pub(super) fn open_pane_tab_into(
+        &mut self,
+        cmd: &str,
+        cwd: &std::path::Path,
+        slot: TabSlot,
+    ) -> bool {
         // A new pane is meant to be used — if the file list is zoomed (the
         // pane is collapsed to its tab bar), reveal the split so the pane
         // isn't created behind a fullscreen list and silently lost. The
@@ -141,10 +200,10 @@ impl App {
                 self.state
                     .flash_info(format!("pane: {cmd} (^W k for list)"));
                 let entry = TabEntry::new(p, info);
-                if let Some(tabs) = self.runtime.pane_tabs.as_mut() {
-                    tabs.push(entry);
-                } else {
-                    self.runtime.pane_tabs = Some(PaneTabs::new(entry));
+                match (self.runtime.pane_tabs.as_mut(), slot) {
+                    (Some(tabs), TabSlot::Replace(idx)) => tabs.replace_at(idx, entry),
+                    (Some(tabs), TabSlot::Append) => tabs.push(entry),
+                    (None, _) => self.runtime.pane_tabs = Some(PaneTabs::new(entry)),
                 }
                 // Claude status hooks: install (consented), skip (denied), or
                 // raise the first-launch per-project consent popup. After the
@@ -610,13 +669,8 @@ impl App {
     /// claude, a shell mid-task), confirm first — closing it loses that
     /// session. An already-exited tab closes silently.
     pub fn close_active_tab(&mut self) {
-        let running_label = self.runtime.pane_tabs.as_ref().and_then(|tabs| {
-            let p = tabs.active();
-            (!p.is_closed() && p.exit_status().is_none()).then(|| tabs.active_info().label.clone())
-        });
-        if let Some(label) = running_label
-            && matches!(self.state.mode, Mode::Normal)
-        {
+        if self.needs_active_tab_confirm() {
+            let label = self.active_tab_label();
             self.state.mode = Mode::Prompting(Prompt::simple(
                 PromptKind::ClosePane,
                 format!("close running tab '{label}'? [y/N] "),
@@ -655,31 +709,72 @@ impl App {
         self.prune_orphaned_pager_streams();
     }
 
-    /// ^a R — restart the active tab's command. Closes the tab and spawns
-    /// a fresh one with the same command and working directory.
+    /// ^a R — restart the active tab's command. Confirms first when its child is
+    /// still running: a restart kills that session exactly as `^a x` would, and
+    /// `R` sits one shift away from `r` (rename). An exited tab restarts silently.
     pub fn restart_active_tab(&mut self) {
+        if self.runtime.pane_tabs.is_none() {
+            return;
+        }
+        if self.needs_active_tab_confirm() {
+            let label = self.active_tab_label();
+            self.state.mode = Mode::Prompting(Prompt::simple(
+                PromptKind::RestartPane,
+                format!("restart running tab '{label}'? [y/N] "),
+            ));
+            return;
+        }
+        self.restart_active_tab_now();
+    }
+
+    /// Restart the active tab unconditionally — the shared body reached directly
+    /// for an exited tab, or after the running-tab confirm.
+    ///
+    /// Respawns **into the tab's own slot** rather than closing and appending:
+    /// a close shifts every later tab's number down one and lands the
+    /// replacement last, which is the numbering drift users see (#151).
+    pub(crate) fn restart_active_tab_now(&mut self) {
         let Some(tabs) = self.runtime.pane_tabs.as_ref() else {
             return;
         };
-        let cmd = tabs.active_info().command.clone();
-        let cwd = tabs.active_info().cwd.clone();
-        // Close the old tab first.
-        if let Some(tabs) = self.runtime.pane_tabs.as_mut()
-            && !tabs.close_active()
+        let idx = tabs.active_index();
+        let info = tabs.active_info();
+        let cmd = info.command.clone();
+        let cwd = info.cwd.clone();
+        let label = info.label.clone();
+        let owner = info.claim_owner.clone();
+        // Kill the outgoing child before its replacement spawns, so two agents
+        // never briefly share the cwd; `replace_at` reaps the rest of the tree.
+        if let Some(entry) = self
+            .runtime
+            .pane_tabs
+            .as_mut()
+            .and_then(|tabs| tabs.tabs_mut().get_mut(idx))
         {
-            self.runtime.pane_tabs = None;
-            self.state.focus = state::Focus::FileList;
+            entry.pane.try_kill();
         }
-        // The old tab is gone; reclaim its parked scrollback stream (if any)
-        // before spawning the replacement (which starts with no stash).
+        // A failed spawn leaves the existing tab in place — keep
+        // `open_pane_tab_into`'s error flash rather than claiming success.
+        if !self.open_pane_tab_into(&cmd, &cwd, TabSlot::Replace(idx)) {
+            return;
+        }
+        if let Some(entry) = self
+            .runtime
+            .pane_tabs
+            .as_mut()
+            .and_then(|tabs| tabs.tabs_mut().get_mut(idx))
+        {
+            // The fresh `TabInfo` re-derives the label from the command; restore
+            // a `^a r` rename so a restart doesn't silently undo it.
+            entry.info.label = label;
+        }
+        // The replacement carries a fresh `claim_owner`, so the old child's P2
+        // scope claims can never be released by it — drop them now (mirrors
+        // `close_active_tab_now`) instead of orphaning them in the registry.
+        self.state.scope_registry.retain(|c| c.owner != owner);
+        // Reclaim the replaced tab's parked scrollback stream, if it had one.
         self.prune_orphaned_pager_streams();
-        // Spawn a replacement with the same command and cwd. Only claim
-        // "restarted" if it actually spawned — otherwise leave
-        // open_pane_tab_in's "pane spawn failed" flash in place rather than
-        // clobbering it with a false success (the old tab is already gone).
-        if self.open_pane_tab_in(&cmd, &cwd) {
-            self.state.flash_info(format!("pane: restarted {cmd}"));
-        }
+        self.state.flash_info(format!("pane: restarted {cmd}"));
     }
 
     /// ^W j / ^W k — set keyboard focus directionally (no wrap).
@@ -1001,4 +1096,56 @@ fn pane_has_crash_marker(lines: &[String]) -> bool {
     lines
         .iter()
         .any(|line| MARKERS.iter().any(|m| line.contains(m)))
+}
+
+#[cfg(test)]
+mod confirm_tests {
+    use super::{TabConfirmSnapshot, needs_live_child_confirm};
+
+    const LIVE: TabConfirmSnapshot = TabConfirmSnapshot {
+        pane_closed: false,
+        exit_reaped: false,
+        mode_normal: true,
+    };
+
+    /// The live child is the whole reason the confirm exists — `^a x` / `^a R`
+    /// on it destroys a session.
+    #[test]
+    fn a_live_child_needs_confirming() {
+        assert!(needs_live_child_confirm(LIVE));
+    }
+
+    /// An `[exited N]` tab has nothing left to lose, so it must NOT prompt.
+    /// Either liveness signal alone settles it: pty EOF, or a reaped exit
+    /// status when EOF was missed.
+    #[test]
+    fn an_exited_child_skips_the_confirm() {
+        for s in [
+            TabConfirmSnapshot {
+                pane_closed: true,
+                ..LIVE
+            },
+            TabConfirmSnapshot {
+                exit_reaped: true,
+                ..LIVE
+            },
+            TabConfirmSnapshot {
+                pane_closed: true,
+                exit_reaped: true,
+                ..LIVE
+            },
+        ] {
+            assert!(!needs_live_child_confirm(s), "{s:?} must restart silently");
+        }
+    }
+
+    /// Outside `Mode::Normal` another modal owns the keyboard, so the action
+    /// proceeds rather than stranding a prompt nothing can route a key to.
+    #[test]
+    fn a_non_normal_mode_skips_the_confirm() {
+        assert!(!needs_live_child_confirm(TabConfirmSnapshot {
+            mode_normal: false,
+            ..LIVE
+        }));
+    }
 }

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -121,6 +121,11 @@ pub enum PromptKind {
     /// anything else keeps it. Always targets the active tab (the modal prompt
     /// blocks tab switching), so it needs no index. An exited tab skips this.
     ClosePane,
+    /// `^a R` on a tab whose child is still running — a restart kills it, so it
+    /// loses the session exactly as `^a x` does. Same single-key shape as
+    /// [`Self::ClosePane`]: `y`/`Y` restarts, anything else keeps the tab. An
+    /// exited tab has nothing to lose and restarts without asking.
+    RestartPane,
     /// A Lua script has run past the soft threshold — "keep waiting? [y/N]".
     /// `y`/`Y` re-arms the watchdog and keeps waiting; `n`/`N`/Esc (or any
     /// other key) requests the abort. Raised from the runaway watchdog
@@ -819,6 +824,7 @@ mod tests {
                 },
             ),
             ("ClosePane", K::ClosePane),
+            ("RestartPane", K::RestartPane),
             ("LuaRunaway", K::LuaRunaway),
             (
                 "SkillUpdate",

--- a/src/app/state/dispatch.rs
+++ b/src/app/state/dispatch.rs
@@ -385,6 +385,7 @@ impl AppState {
             | PromptKind::HookConsent { .. }
             | PromptKind::SkillUpdate { .. }
             | PromptKind::ClosePane
+            | PromptKind::RestartPane
             | PromptKind::LuaRunaway
             | PromptKind::GraveyardPurgeAllConfirm => PromptResult::Handled,
             // These need terminal/overlay/pager — caller handles them.

--- a/src/pane/tabs.rs
+++ b/src/pane/tabs.rs
@@ -570,9 +570,14 @@ impl PaneTabs {
 
     /// Replace the tab at `idx` in place. Active index and the order of
     /// remaining tabs are preserved. No-op if `idx` is out of range.
+    ///
+    /// Tears down the replaced tab's child tree the same way [`Self::remove_at`]
+    /// does — dropping the `TabEntry` alone would orphan its grandchildren.
     pub fn replace_at(&mut self, idx: usize, entry: TabEntry) {
         if idx < self.tabs.len() {
-            self.tabs[idx] = entry;
+            let old = std::mem::replace(&mut self.tabs[idx], entry);
+            old.pane
+                .shutdown_detached(std::time::Duration::from_millis(250));
         }
     }
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -257,7 +257,10 @@ const SECTIONS: &[Section] = &[
             ("^a 1..9", "switch to tab N"),
             ("^a ^a", "jump to last-active tab"),
             ("^a r", "rename active tab"),
-            ("^a R", "restart active tab command"),
+            (
+                "^a R",
+                "restart active tab command in place (confirms if its child is still running)",
+            ),
             (
                 "●  ■  ·",
                 "agent tab dot: pulse ● working, red square ■ blocked, teal square ■ done, dim · idle (:why-status)",


### PR DESCRIPTION
Both halves of #151 were real. Reported: "`^a-R` should ask for confirmation before restarting a running process ... also, a restarted pane should retain its numbering - right now the number of panes shifts left".

## 1. Confirm before restarting a live child

`^a R` killed the tab's child immediately, destroying a live agent conversation with no way back — the same class of loss `F10` / `^a-\` was fixed for (it hides now instead of killing) and the same loss `^a x` already confirms. `R` also sits one shift away from `r` (rename).

`^a R` now raises the same single-key confirm shape as `^a x` (`restart running tab 'claude'? [y/N]`, new `PromptKind::RestartPane` → `handle_restart_pane_confirm_key`) when the child is running, and restarts **silently** on an already-exited (`[exited N]`) tab, where prompting is pure friction.

The "is there something to lose" decision is extracted as the pure `needs_live_child_confirm` over a `Copy` `TabConfirmSnapshot` (pty EOF / reaped exit status / `Mode::Normal`), now **shared with `^a x`** rather than duplicated inline as it was.

## 2. Why the numbering shifted

Restart was literally close-then-spawn: `close_active` removed the tab — `remove_at` slides every later tab's number down one — and `open_pane_tab_in` pushed the replacement onto the **end**. So restarting tab 2 of 3 renumbered tab 3 to 2 and reopened the restarted tab as 3. Exactly what was reported.

It now respawns into the tab's own slot via a `TabSlot` parameter on the single spawn path. Keeping `open_pane_tab_in` as that path — rather than reusing the agent-only `spawn_agent_into_tab` — preserves the MCP-config write, startup-hook preinstall, codex resume-uuid pin and agent-gated env injection that only it performs.

## What identity survives a restart

**Survives:** the tab's number/position, the active-tab index, its command, its cwd, and a `^a r` rename (a fresh `TabInfo` re-derives the label from the command, so it is put back explicitly).

**Does not survive** — all because the child is genuinely a new process: `SPYC_PANE_ID` (`TabInfo::id`), the agent conversation, the scrollback, and the pinned `codex_session_id` / `live_session_id`. Churning `SPYC_PANE_ID` is correct here: the status hooks of the *new* child are handed the new id at spawn, and the dead child's hooks must not be able to drive this tab's activity dot. The old child's P2 scope claims are **released** rather than orphaned, mirroring `close_active_tab_now` — the replacement carries a fresh `claim_owner`, so it could never have released them itself.

## Two side fixes the in-place path required

- **`PaneTabs::replace_at` orphaned process trees.** It did a bare `self.tabs[idx] = entry`; dropping a `TabEntry` does not tear the child's tree down (that is why `remove_at` calls `shutdown_detached` — the `npm run dev` → node → esbuild case). It now does the same teardown. This also silently affected the two pre-existing callers, claude crash-recover and `:hooks on!`.
- **A failed respawn no longer loses the tab.** The old order closed the tab *before* attempting the spawn, so a spawn failure left you with nothing (the old code even acknowledged this: "the old tab is already gone"). The tab now survives a failed restart with the spawn error flashed.

## Tests

- `restarting_a_running_tab_confirms_first` — pane harness, real `cat` pty; `^a R` opens the confirm and respawns nothing, `n` cancels, `y` respawns (fresh pane id).
- `restarting_a_tab_keeps_its_number` — the #151 regression: 3 live tabs, restart the middle one, assert the count holds, `active_index` stays 1, tab 1 stays put, **tab 3 does not shift left**, and command/cwd/rename survive while the pane id does not. Fails on an append-based restart, passes in place.
- `a_live_child_needs_confirming`, `an_exited_child_skips_the_confirm` (both liveness signals, independently), `a_non_normal_mode_skips_the_confirm` — the pure decision.

Docs in the same commit: `FEATURES.md` (rewrote the `^a R` bullet, which said "closes it and respawns"), `docs/KEYBINDINGS.md` (had **no** `^a R` or `^a r` row at all, and no confirm note on `^a x` — added), `src/ui/help.rs`.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)
