### PR TITLE
fix(pager): flash pager-action messages in the pager, not the occluded status bar (#166)

### DIFF
--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -295,9 +295,11 @@ impl App {
                 if let Some(prev) = self.view.pager_history.pop_back() {
                     self.view.pager = Some(prev);
                     self.view.needs_full_repaint = true;
-                    self.state
-                        .flash_info(format!("buffer ←{}", self.view.pager_history.back_len()));
+                    let msg = format!("buffer ←{}", self.view.pager_history.back_len());
+                    // The reopened pager covers the status bar (#166).
+                    self.set_active_pager_flash(msg);
                 } else {
+                    // Nothing reopened — the user is still on the list.
                     self.state.flash_info("no buffers in history");
                 }
             }

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -863,51 +863,134 @@ pub(super) fn cmd_resume(app: &mut App, args: &str) -> Vec<Effect> {
 
 /// `:bprev` — step the pager buffer history backward (older).
 pub(super) fn cmd_bprev(app: &mut App, _args: &str) -> Vec<Effect> {
-    if let Some(current) = app.view.pager.take() {
-        match app.view.pager_history.go_back(current) {
+    if let Some(mut current) = app.view.pager.take() {
+        // A flash describes the keypress that set it, so it must not ride into
+        // history and resurface when this view is restored.
+        current.flash = None;
+        let msg = match app.view.pager_history.go_back(current) {
             Ok(prev) => {
                 app.view.pager = Some(prev);
                 app.view.needs_full_repaint = true;
                 let back = app.view.pager_history.back_len();
                 let fwd = app.view.pager_history.forward_len();
-                app.state.flash_info(format!("buffer ←{back} →{fwd}"));
+                format!("buffer ←{back} →{fwd}")
             }
             Err(current) => {
                 // At the start of history -- keep the current pager
                 // visible instead of closing it.
                 app.view.pager = Some(current);
-                app.state.flash_info("no older buffers");
+                "no older buffers".to_string()
             }
-        }
+        };
+        pager_flash(app, msg);
     } else if let Some(prev) = app.view.pager_history.pop_back() {
         app.view.pager = Some(prev);
         app.view.needs_full_repaint = true;
-        app.state
-            .flash_info(format!("buffer ←{}", app.view.pager_history.back_len()));
+        let msg = format!("buffer ←{}", app.view.pager_history.back_len());
+        pager_flash(app, msg);
     } else {
+        // No pager opened, so the user is looking at the list -- status bar.
         app.state.flash_info("no buffers in history");
     }
     Vec::new()
 }
 
+/// Land a buffer-history message on the pager the command just installed, not
+/// the file-list status bar it is drawn over (#166).
+fn pager_flash(app: &mut App, msg: String) {
+    if let Some(view) = app.view.pager.as_mut() {
+        view.flash = Some(msg);
+    }
+}
+
 /// `:bnext` — step the pager buffer history forward (newer).
 pub(super) fn cmd_bnext(app: &mut App, _args: &str) -> Vec<Effect> {
-    if let Some(current) = app.view.pager.take() {
-        match app.view.pager_history.go_forward(current) {
+    if let Some(mut current) = app.view.pager.take() {
+        current.flash = None;
+        let msg = match app.view.pager_history.go_forward(current) {
             Ok(next) => {
                 app.view.pager = Some(next);
                 app.view.needs_full_repaint = true;
                 let back = app.view.pager_history.back_len();
                 let fwd = app.view.pager_history.forward_len();
-                app.state.flash_info(format!("buffer ←{back} →{fwd}"));
+                format!("buffer ←{back} →{fwd}")
             }
             Err(current) => {
                 app.view.pager = Some(current);
-                app.state.flash_info("no newer buffers");
+                "no newer buffers".to_string()
             }
-        }
+        };
+        pager_flash(app, msg);
     } else {
+        // Nothing on screen to flash into -- status bar is the only surface.
         app.state.flash_info("no pager open");
     }
     Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::App;
+    use crate::ui::pager::PagerView;
+
+    fn app_with_pager() -> App {
+        let mut app = App::test_app(std::env::temp_dir());
+        app.view.pager = Some(PagerView::new_plain("t", vec!["line".to_string()]));
+        app
+    }
+
+    /// #166: with a pager on screen the status bar is occluded by it, so the
+    /// end-of-history report has to land in the pager.
+    #[test]
+    fn bprev_bnext_at_the_edges_flash_in_the_pager_not_the_status_bar() {
+        for (cmd, msg) in [("bprev", "no older buffers"), ("bnext", "no newer buffers")] {
+            let mut app = app_with_pager();
+            let fx = app.dispatch_command(cmd);
+            assert!(fx.is_empty(), ":{cmd} effects: {fx:?}");
+            assert_eq!(
+                app.view.pager.as_ref().and_then(|v| v.flash.as_deref()),
+                Some(msg),
+                ":{cmd}"
+            );
+            assert!(
+                app.state.flash.is_none(),
+                ":{cmd} must not flash the occluded status bar: {:?}",
+                app.state.flash
+            );
+        }
+    }
+
+    /// Reopening a buffer from the list reports into the pager it just opened.
+    #[test]
+    fn bprev_reopening_from_the_list_flashes_in_the_reopened_pager() {
+        let mut app = App::test_app(std::env::temp_dir());
+        app.view
+            .pager_history
+            .push(PagerView::new_plain("older", vec!["a".to_string()]));
+        app.dispatch_command("bprev");
+        assert_eq!(
+            app.view.pager.as_ref().and_then(|v| v.flash.as_deref()),
+            Some("buffer ←0")
+        );
+        assert!(app.state.flash.is_none(), "{:?}", app.state.flash);
+    }
+
+    /// The deliberate exception: no pager opens, so the user is looking at the
+    /// list and the status bar is the only surface that can carry the message.
+    #[test]
+    fn buffer_commands_with_no_pager_to_open_stay_on_the_status_bar() {
+        for (cmd, msg) in [
+            ("bprev", "no buffers in history"),
+            ("bnext", "no pager open"),
+        ] {
+            let mut app = App::test_app(std::env::temp_dir());
+            app.dispatch_command(cmd);
+            assert!(app.view.pager.is_none(), ":{cmd} opened nothing");
+            assert_eq!(
+                app.state.flash.as_ref().map(|f| f.text.as_str()),
+                Some(msg),
+                ":{cmd} belongs on the status bar"
+            );
+        }
+    }
 }

--- a/src/app/key_dispatch/mod.rs
+++ b/src/app/key_dispatch/mod.rs
@@ -172,6 +172,8 @@ impl App {
 
         // Any keypress clears a lingering flash message.
         self.state.flash = None;
+        // Per-turn; the pager sink re-arms it (#166 flash relocation).
+        self.view.input_went_to_pager = false;
 
         // ^C is intentionally a no-op at the spyc-normal level (we
         // don't quit on Ctrl+C, that footgun's too easy with one

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -713,6 +713,10 @@ pub struct ViewState {
     pub pager_history: PagerHistory,
     pub pager_pending_bracket: Option<char>,
     pub pager_was_open: bool,
+    /// This turn's input went to a pager, so a status-bar flash raised while
+    /// running its effects belongs in the pager instead (#166). Consumed at
+    /// loop bottom by `relocate_flash_into_pager`.
+    pub input_went_to_pager: bool,
     /// Stash for the pager that was active when `?` opened the
     /// pager-help overlay. Restored verbatim on Esc/q dismissal so
     /// the user lands back in the same view. Separate from
@@ -954,6 +958,7 @@ impl ViewState {
             pager_history: PagerHistory::new(),
             pager_pending_bracket: None,
             pager_was_open: false,
+            input_went_to_pager: false,
             pager_help_stash: None,
             scroll_pager_help_stash: None,
             pager_positions: crate::state::pager_positions::PagerPositions::load(),

--- a/src/app/pager_handler/mod.rs
+++ b/src/app/pager_handler/mod.rs
@@ -69,11 +69,32 @@ pub enum PagerSlot {
 }
 
 impl App {
-    /// Route a key to the pager overlay. Also uses vi-like motion so the
-    /// pager feels native to the rest of the UI. Delegates each input
-    /// context to a sub-handler (returning `Some` when it consumes the key,
-    /// `None` to fall through); the final motion handler always consumes.
+    /// Route a key to the pager overlay, then re-home any status-bar flash the
+    /// handler raised into the pager itself (#166 — see
+    /// [`Self::relocate_flash_into_pager`]). `view.input_went_to_pager` carries
+    /// the same relocation past `run_effects`, for a message an executor emits.
     pub fn handle_pager_key(&mut self, key: KeyEvent) -> Vec<Effect> {
+        self.view.input_went_to_pager = true;
+        let effects = self.dispatch_pager_key(key);
+        self.relocate_flash_into_pager();
+        effects
+    }
+
+    /// Move a status-bar flash raised by a pager keypress into the pager that
+    /// still owns the screen: the pager is drawn over the status bar, so the
+    /// message would render half-occluded. A handler whose result lands on the
+    /// file list closed its pager first, leaving nothing to relocate into — so
+    /// those messages stay on the status bar without needing a per-site opt-out.
+    pub(crate) fn relocate_flash_into_pager(&mut self) {
+        if self.active_pager_ref().is_none() {
+            return;
+        }
+        if let Some(msg) = self.state.flash.take() {
+            self.set_active_pager_flash(msg.text);
+        }
+    }
+
+    fn dispatch_pager_key(&mut self, key: KeyEvent) -> Vec<Effect> {
         // The full-screen image overlay sits on top of the pager and is modal:
         // intercept before any pager handler and route to its own verbs.
         if self.view.image_view.is_some() {

--- a/src/app/pager_handler/modes.rs
+++ b/src/app/pager_handler/modes.rs
@@ -200,27 +200,34 @@ impl App {
             current.streaming = false;
             current.stream_id = None;
         }
+        // A flash describes the keypress that set it, so it must not ride into
+        // history and resurface when this view is restored.
+        current.flash = None;
         let step = if forward {
             self.view.pager_history.go_forward(current)
         } else {
             self.view.pager_history.go_back(current)
         };
-        match step {
+        let msg = match step {
             Ok(next) => {
                 self.view.pager = Some(next);
                 self.view.needs_full_repaint = true;
                 let back = self.view.pager_history.back_len();
                 let fwd = self.view.pager_history.forward_len();
-                self.state.flash_info(format!("buffer ←{back} →{fwd}"));
+                format!("buffer ←{back} →{fwd}")
             }
             Err(current) => {
                 self.view.pager = Some(current);
-                self.state.flash_info(if forward {
-                    "no newer buffers"
+                if forward {
+                    "no newer buffers".to_string()
                 } else {
-                    "no older buffers"
-                });
+                    "no older buffers".to_string()
+                }
             }
+        };
+        // Flash in the pager, not the file-list status bar the pager covers.
+        if let Some(view) = self.view.pager.as_mut() {
+            view.flash = Some(msg);
         }
     }
 
@@ -652,6 +659,128 @@ mod tests {
         assert_eq!(
             pager(&app).flash.as_deref(),
             Some("paste ignored — press `/` to search")
+        );
+    }
+
+    /// #166: the pager is drawn over the file list, so a status-bar flash renders
+    /// half-occluded. Exhausting the buffer history must report in the pager.
+    #[test]
+    fn exhausted_buffer_history_flashes_in_the_pager_not_the_status_bar() {
+        for (bracket, msg) in [('[', "no older buffers"), (']', "no newer buffers")] {
+            let mut app = jump_pager_app();
+            app.handle_pager_key(ch(bracket));
+            app.handle_pager_key(ch('b'));
+            assert_eq!(pager(&app).flash.as_deref(), Some(msg), "{bracket}b");
+            assert!(
+                app.state.flash.is_none(),
+                "{bracket}b must not flash the occluded status bar: {:?}",
+                app.state.flash
+            );
+        }
+    }
+
+    /// The success half: stepping to a real buffer reports its depth in the
+    /// pager too, so the whole action speaks in one place.
+    #[test]
+    fn buffer_history_step_flashes_depth_in_the_pager() {
+        let mut app = jump_pager_app();
+        app.view
+            .pager_history
+            .push(PagerView::new_plain("older", vec!["a".to_string()]));
+        app.handle_pager_key(ch('['));
+        app.handle_pager_key(ch('b'));
+        assert_eq!(pager(&app).title, "older", "stepped back a buffer");
+        assert_eq!(pager(&app).flash.as_deref(), Some("buffer ←0 →1"));
+        assert!(
+            app.state.flash.is_none(),
+            "depth belongs in the pager: {:?}",
+            app.state.flash
+        );
+    }
+
+    /// A pager carrying a flash must not resurrect it when restored from
+    /// history — the message described a keypress that is long gone.
+    #[test]
+    fn buffer_history_does_not_resurrect_a_stale_flash() {
+        let mut app = jump_pager_app();
+        app.view
+            .pager_history
+            .push(PagerView::new_plain("older", vec!["a".to_string()]));
+        for k in [ch('['), ch('b'), ch(']'), ch('b')] {
+            app.handle_pager_key(k);
+        }
+        assert_eq!(pager(&app).title, "t", "back then forward returns us home");
+        assert_eq!(pager(&app).flash.as_deref(), Some("buffer ←1 →0"));
+    }
+
+    /// A scrollback pager sits in its own slot, so the relocation has to follow
+    /// `active_pager_slot()` — not `view.pager`, which is empty here.
+    #[test]
+    fn scrollback_key_message_lands_in_the_scrollback_not_the_status_bar() {
+        use crate::app::state::Focus;
+        use crate::ui::pager::Mount;
+
+        let mut app = App::test_app(std::env::temp_dir());
+        app.state.focus = Focus::Pane;
+        let mut sb = PagerView::new_plain("transcript", vec!["line".to_string()]);
+        sb.pane_scroll = true;
+        sb.mount = Mount::LowerPane;
+        app.view.scroll_pager = Some(sb);
+
+        app.handle_pager_key(ch('t'));
+        assert_eq!(
+            app.view
+                .scroll_pager
+                .as_ref()
+                .and_then(|v| v.flash.as_deref()),
+            Some("tool calls: only in an agent transcript view")
+        );
+        assert!(
+            app.state.flash.is_none(),
+            "status bar is behind the scrollback: {:?}",
+            app.state.flash
+        );
+    }
+
+    /// `S` in the task viewer reaches the shared `pause_task`, which flashes the
+    /// status bar for `:pause`. The pager keypress re-homes it without the shared
+    /// handler needing to know who called it.
+    #[test]
+    fn task_viewer_pause_message_lands_in_the_pager() {
+        let mut app = jump_pager_app();
+        if let Some(v) = app.view.pager.as_mut() {
+            v.task_id = Some(7);
+        }
+        app.handle_pager_key(ch('S'));
+        assert_eq!(pager(&app).flash.as_deref(), Some("no task with id 7"));
+        assert!(
+            app.state.flash.is_none(),
+            "occluded surface: {:?}",
+            app.state.flash
+        );
+    }
+
+    /// The deliberate exception, and why it needs no per-site opt-out: an action
+    /// whose result is on the file list has already closed its pager, so there is
+    /// nothing to relocate into and the message stays on the status bar.
+    #[test]
+    fn a_message_from_an_action_that_closes_the_pager_stays_on_the_status_bar() {
+        use crate::app::state::Focus;
+        use crate::ui::pager::Mount;
+
+        let mut app = App::test_app(std::env::temp_dir());
+        app.state.focus = Focus::Pane;
+        let mut sb = PagerView::new_plain("transcript", vec!["line".to_string()]);
+        sb.pane_scroll = true;
+        sb.mount = Mount::LowerPane;
+        app.view.scroll_pager = Some(sb);
+
+        app.handle_pager_key(ch('q'));
+        assert!(app.view.scroll_pager.is_none(), "q closed the scrollback");
+        assert_eq!(
+            app.state.flash.as_ref().map(|f| f.text.as_str()),
+            Some("scroll: off"),
+            "the pager is gone, so the list's status bar is the right surface"
         );
     }
 }

--- a/src/app/run.rs
+++ b/src/app/run.rs
@@ -202,6 +202,12 @@ impl App {
                         // inline spawn + its after-work).
                         let effects = self.handle_key(key)?;
                         self.run_effects(effects, terminal, foreground_exec);
+                        // An executor's flash (e.g. `SignalGroup`'s "task #N
+                        // paused") lands after the handler, so re-home it here
+                        // too — the pager still covers the status bar (#166).
+                        if std::mem::take(&mut self.view.input_went_to_pager) {
+                            self.relocate_flash_into_pager();
+                        }
                     }
                     Event::Paste(text) => {
                         let effects = self.handle_paste(text);


### PR DESCRIPTION
Issue #166. Reproduced on current `main` (9e9179d): with a pager open, `:bprev`
past the end of the buffer history put "no older buffers" on the file-list
status bar, which the pager is drawn over — so it rendered half-occluded.

The pager already owns a flash channel (`PagerView::flash`, rendered in its
title bar) and most pager handlers use it. `pager_handler/modes.rs` even states
the contract in-tree for the `/` search: *"Flash inside the pager itself, not the
file-list status bar — the user is looking at the pager, the message belongs
there."* This applies that consistently rather than patching the one reported
message.

### Moved into the pager

- **Buffer history** — both halves (the `buffer ←N →M` depth report and the
  end-of-history hint) for `:bprev`, `:bnext`, `[b`, `]b`, and `gp`
  (`ReopenLastBuffer`). An outgoing view's flash is now cleared before it enters
  history, so a restored buffer no longer resurfaces a message about a keypress
  that is long gone.
- **Task viewer** — `S` / `C` / `[t` / `]t` (`pause_task` / `resume_task` /
  `cycle_task_viewer`, ~12 messages) *plus* `Effect::SignalGroup`'s
  `task #N paused — :resume to continue` and its failure text.
- **Scrollback** — `r` / `t` in a `^a v` scrollback (`open_pane_scroll_pager`,
  `toggle_scrollback_tool_calls`, `install_lower_pane_scroll_view`, 5 messages).
- **`v` editor handoff** — the `write temp: {e:#}` error, where the pager
  demonstrably stays open.

Most of those live in handlers **shared with non-pager callers** — `pause_task`
is both the task viewer's `S` and `:pause`; `open_pane_scroll_pager` is both the
scrollback's `r` and `^a v` — so per-site routing would have required the shared
code to know its caller. Instead `handle_pager_key` re-homes any status-bar flash
its handler raised into the pager that still owns the screen, and
`view.input_went_to_pager` carries the same relocation past `run_effects` for a
message an executor emits. It reuses the existing `set_active_pager_flash`, so it
follows `active_pager_slot()` — a scrollback or right-column pager gets the
message rather than a hardcoded `view.pager`.

### Deliberately left on the status bar

- **Every message whose action closes its pager first** — the jump-history and
  worktree pickers, the history editor, session pick, `scroll: off`,
  `vsplit: off`. The result of these lands on the file list, which is what the
  user is looking at once the pager is gone. These need no per-site opt-out: the
  relocation finds no pager to land in and leaves them alone. That self-exclusion
  is asserted by a test.
- **`no buffers in history` / `no pager open`** — no pager opens, so there is no
  other surface.
- **Task-exit flashes** (`streaming.rs`) — tick-driven, not a pager action; they
  fire whenever a `!` task exits regardless of what is on screen, so the
  app-wide status bar is the right home.

### Not taken on

The issue's two speculative asks are left alone: the pager's flash already
renders in its title bar, so no reserved footer line was added, and the embedded
(`Mount::TopPane` / `LowerPane`) case needs no separate treatment because the
relocation resolves whichever slot owns input. I don't think a reserved line is
warranted — see the report.

### Tests

Fails-before / passes-after, driving real keys through `handle_pager_key` /
`dispatch_command` and asserting **both** halves (pager flash set *and*
`AppState::flash` untouched — either alone proves nothing):

- `exhausted_buffer_history_flashes_in_the_pager_not_the_status_bar`
- `buffer_history_step_flashes_depth_in_the_pager`
- `buffer_history_does_not_resurrect_a_stale_flash`
- `bprev_bnext_at_the_edges_flash_in_the_pager_not_the_status_bar`
- `bprev_reopening_from_the_list_flashes_in_the_reopened_pager`
- `buffer_commands_with_no_pager_to_open_stay_on_the_status_bar`
- `scrollback_key_message_lands_in_the_scrollback_not_the_status_bar`
- `task_viewer_pause_message_lands_in_the_pager`
- `a_message_from_an_action_that_closes_the_pager_stays_on_the_status_bar`

Red state before the fix, e.g.
`exhausted_buffer_history_flashes_in_the_pager_not_the_status_bar`:
`assertion left == right failed: [b  left: None  right: Some("no older buffers")`.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)
