### PR TITLE
fix(pager): paint the full row for a blank line in visual-line mode (#120)

### DIFF
--- a/src/ui/pager/layout.rs
+++ b/src/ui/pager/layout.rs
@@ -14,6 +14,17 @@ pub(super) fn line_plain_text(line: &Line) -> String {
     line.spans.iter().map(|s| s.content.as_ref()).collect()
 }
 
+/// Terminal columns a rendered row occupies. Per-char `unicode_width` summed
+/// the same way `wrap_line_capped` budgets, so padding and wrap agree on where
+/// a row ends.
+pub(super) fn line_display_width(line: &Line) -> usize {
+    line.spans
+        .iter()
+        .flat_map(|s| s.content.chars())
+        .map(|ch| unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0))
+        .sum()
+}
+
 /// Centered pager occupies this percent of the terminal width.
 /// Exposed so callers (help content generation) can compute the same
 /// column width the pager will actually render at.

--- a/src/ui/pager/render.rs
+++ b/src/ui/pager/render.rs
@@ -4,7 +4,7 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
 };
@@ -14,7 +14,8 @@ use crate::ui::theme::Theme;
 use super::{Mount, PagerView, VisualKind};
 
 use super::layout::{
-    COL_GAP, line_plain_text, pager_inner_area, partition_lines_static, wrap_line_capped,
+    COL_GAP, line_display_width, line_plain_text, pager_inner_area, partition_lines_static,
+    wrap_line_capped,
 };
 
 pub fn render(frame: &mut Frame, area: Rect, view: &PagerView, theme: &Theme) {
@@ -207,10 +208,18 @@ fn render_single_column(frame: &mut Frame, content_area: Rect, view: &PagerView,
         } else {
             vec![styled]
         };
+        // Padded per piece (after tab expansion and wrap) so the pad width is
+        // measured against what actually reaches the screen; the gutter is
+        // prepended below and stays outside the highlight, as vim's is.
+        let fill = line_fill_bg(view, abs_idx, theme);
         for (piece_idx, piece) in pieces.into_iter().enumerate() {
             if display_lines.len() >= viewport_h {
                 break;
             }
+            let piece = match fill {
+                Some(bg) => pad_row_to_width(piece, body_w, bg),
+                None => piece,
+            };
             if gutter_w > 0 {
                 let gutter_text = if piece_idx == 0 {
                     format!("{:>width$} ", abs_idx + 1, width = gutter_w - 1)
@@ -330,6 +339,51 @@ fn render_multi_column(
     }
 }
 
+/// A line selection's two tones: brighter on the cursor row, dim on the rest.
+const fn line_sel_bg(cursor: usize, abs_idx: usize, theme: &Theme) -> Color {
+    if abs_idx == cursor {
+        theme.cursor_bg
+    } else {
+        theme.cursor_bg_dim
+    }
+}
+
+/// Background a *whole-line* selection paints across `abs_idx`, or `None` when
+/// the row isn't line-selected. Line visual (`V`) and line placement take whole
+/// rows, so the bg has to reach the full width — charwise and block are
+/// column-bounded and never fill. Placement is painted after visual, so it wins
+/// where both could name the row.
+fn line_fill_bg(view: &PagerView, abs_idx: usize, theme: &Theme) -> Option<Color> {
+    if let Some(p) = view.placement
+        && p.row == abs_idx
+        && p.kind == VisualKind::Line
+    {
+        return Some(theme.cursor_bg);
+    }
+    let sel = view.visual?;
+    if sel.kind != VisualKind::Line {
+        return None;
+    }
+    let (lo, hi) = sel.range();
+    (lo..=hi)
+        .contains(&abs_idx)
+        .then(|| line_sel_bg(sel.cursor, abs_idx, theme))
+}
+
+/// Extend a row with blank cells so a whole-line selection's background spans
+/// the content width. Painting only the existing spans left a blank line with
+/// no highlight at all and a short line highlighted just to its last glyph, so
+/// a `V` range read as a ragged column instead of a block (#120).
+fn pad_row_to_width(line: Line<'static>, width: usize, bg: Color) -> Line<'static> {
+    let pad = width.saturating_sub(line_display_width(&line));
+    if pad == 0 {
+        return line;
+    }
+    let mut spans = line.spans;
+    spans.push(Span::styled(" ".repeat(pad), Style::default().bg(bg)));
+    Line::from(spans)
+}
+
 /// Apply match-highlight + picker-cursor styling to a source line.
 /// Extracted from `render_single_column` so wrap can re-use it
 /// (styling decisions happen before the visual split).
@@ -355,11 +409,9 @@ fn apply_row_styling(
         if (lo..=hi).contains(&abs_idx) {
             match sel.kind {
                 VisualKind::Line => {
-                    let bg = if abs_idx == sel.cursor {
-                        theme.cursor_bg
-                    } else {
-                        theme.cursor_bg_dim
-                    };
+                    // Only the glyphs the row actually has; `render_single_column`
+                    // pads the rest of the width to the same bg.
+                    let bg = line_sel_bg(sel.cursor, abs_idx, theme);
                     styled = Line::from(
                         styled
                             .spans

--- a/src/ui/pager/tests/mod.rs
+++ b/src/ui/pager/tests/mod.rs
@@ -10,6 +10,7 @@ use ratatui::style::Style;
 use ratatui::text::Span;
 
 mod selection;
+mod selection_render;
 
 fn plain_text(line: &Line<'_>) -> String {
     line.spans.iter().map(|s| s.content.as_ref()).collect()

--- a/src/ui/pager/tests/selection_render.rs
+++ b/src/ui/pager/tests/selection_render.rs
@@ -1,0 +1,174 @@
+//! Selection *painting* tests: which cells carry the selection background.
+//!
+//! These assert on resolved cell backgrounds, not glyphs. A glyph-level
+//! snapshot is blind to exactly the bug this cluster covers (#120) — the
+//! characters are identical whether or not the highlight reaches the end of
+//! the row — so the whole cluster reads `Cell::bg`.
+
+use super::*;
+use ratatui::style::Color;
+use ratatui::{Terminal, backend::TestBackend};
+
+/// Per-row cell backgrounds of a rendered pager, `[row][col]`.
+fn render_row_bgs(view: &PagerView, w: u16, h: u16) -> Vec<Vec<Color>> {
+    let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+    let theme = Theme::default();
+    terminal
+        .draw(|f| super::super::render(f, Rect::new(0, 0, w, h), view, &theme))
+        .unwrap();
+    let buf = terminal.backend().buffer().clone();
+    (0..h)
+        .map(|y| (0..w).map(|x| buf.cell((x, y)).unwrap().bg).collect())
+        .collect()
+}
+
+/// Borderless, gutterless view so row/col indices map straight onto the
+/// content area — the highlight geometry is what's under test, not the chrome.
+fn bare_view(lines: &[&str]) -> PagerView {
+    let mut view = PagerView::new_plain(
+        "sel.txt",
+        lines.iter().map(|s| (*s).to_string()).collect::<Vec<_>>(),
+    );
+    view.full_width = true;
+    view.show_line_numbers = false;
+    view
+}
+
+const W: u16 = 10;
+
+#[test]
+fn visual_line_paints_a_blank_row_across_the_full_width() {
+    // The reported symptom: a blank line inside a `V` range showed no
+    // highlight at all, so the selection read as a column with holes in it.
+    let mut view = bare_view(&["aaaa", "", "bbbb"]);
+    view.enter_visual();
+    view.visual_move(2, 8);
+    let bgs = render_row_bgs(&view, W, 4);
+    let theme = Theme::default();
+
+    assert!(
+        bgs[1].iter().all(|c| *c == theme.cursor_bg_dim),
+        "blank row inside the selection should carry the selection bg across \
+         the full width, got {:?}",
+        bgs[1]
+    );
+    // The cursor row is the brighter bg, also full width.
+    assert!(
+        bgs[2].iter().all(|c| *c == theme.cursor_bg),
+        "cursor row should be fully painted, got {:?}",
+        bgs[2]
+    );
+}
+
+#[test]
+fn visual_line_paints_a_short_rows_tail() {
+    // Same defect, less obvious instance: a line shorter than the viewport
+    // was highlighted only as far as its text.
+    let mut view = bare_view(&["ab", "cd"]);
+    view.enter_visual();
+    view.visual_move(1, 8);
+    let bgs = render_row_bgs(&view, W, 3);
+    let theme = Theme::default();
+
+    assert!(
+        bgs[0].iter().all(|c| *c == theme.cursor_bg_dim),
+        "short row's tail should carry the selection bg, got {:?}",
+        bgs[0]
+    );
+}
+
+#[test]
+fn visual_line_leaves_rows_outside_the_range_unpainted() {
+    let mut view = bare_view(&["aaaa", "", "bbbb"]);
+    view.enter_visual();
+    // Selection covers row 0 only; rows 1-2 stay clean.
+    let bgs = render_row_bgs(&view, W, 4);
+    let theme = Theme::default();
+
+    assert!(bgs[0].iter().all(|c| *c == theme.cursor_bg));
+    for (offset, row_bgs) in bgs[1..=2].iter().enumerate() {
+        assert!(
+            row_bgs.iter().all(|c| *c == Color::Reset),
+            "row {} is outside the selection and must not be painted, got {row_bgs:?}",
+            offset + 1
+        );
+    }
+}
+
+#[test]
+fn visual_line_row_that_already_fills_the_width_is_unchanged() {
+    // A fully-populated row needs no padding — every cell was already painted
+    // before the fix, and still is, with nothing spilling past the width.
+    let mut view = bare_view(&["0123456789", "0123456789"]);
+    view.enter_visual();
+    view.visual_move(1, 8);
+    let bgs = render_row_bgs(&view, W, 3);
+    let theme = Theme::default();
+
+    assert_eq!(bgs[0].len(), W as usize);
+    assert!(bgs[0].iter().all(|c| *c == theme.cursor_bg_dim));
+    assert!(bgs[1].iter().all(|c| *c == theme.cursor_bg));
+}
+
+#[test]
+fn visual_char_does_not_get_a_full_width_highlight() {
+    // Regression guard for the fix above: charwise selects a character range,
+    // so a partial row stays partial. Anchor mid-row on the last line of the
+    // selection => cells past `to` must stay unpainted.
+    let mut view = bare_view(&["aaaaaaaa", "bbbbbbbb"]);
+    view.begin_char_selection(0, 0);
+    view.extend_char_selection(1, 2);
+    let bgs = render_row_bgs(&view, W, 3);
+
+    // Row 1 is selected only through column 2.
+    assert!(
+        bgs[1][3..].iter().all(|c| *c == Color::Reset),
+        "charwise must not fill the row tail, got {:?}",
+        bgs[1]
+    );
+    assert!(
+        bgs[1][..=2].iter().all(|c| *c != Color::Reset),
+        "charwise selected cells should still be painted, got {:?}",
+        bgs[1]
+    );
+    // Even the interior/first row stops at end-of-text, not end-of-width.
+    assert!(
+        bgs[0][8..].iter().all(|c| *c == Color::Reset),
+        "charwise first row must stop at end-of-text, got {:?}",
+        bgs[0]
+    );
+}
+
+#[test]
+fn visual_block_row_is_not_widened_past_its_rectangle() {
+    // The other column-bounded kind: `^v` paints a rectangle, so the fill
+    // must not leak past `hi_col`.
+    let mut view = bare_view(&["aaaaaaaa", "bbbbbbbb"]);
+    view.enter_visual_block();
+    view.visual_move(1, 8);
+    view.visual_col_move(2);
+    let bgs = render_row_bgs(&view, W, 3);
+
+    assert!(
+        bgs[0][3..].iter().all(|c| *c == Color::Reset),
+        "block selection must stay a rectangle, got {:?}",
+        bgs[0]
+    );
+}
+
+#[test]
+fn line_placement_preview_fills_the_candidate_row() {
+    // The first `V` of the double-tap arm previews the whole candidate row;
+    // a blank candidate row should still be visible as the target.
+    let mut view = bare_view(&["aaaa", "", "bbbb"]);
+    view.enter_placement_line();
+    view.placement_move(1, 0, 8);
+    let bgs = render_row_bgs(&view, W, 4);
+    let theme = Theme::default();
+
+    assert!(
+        bgs[1].iter().all(|c| *c == theme.cursor_bg),
+        "blank placement row should preview across the full width, got {:?}",
+        bgs[1]
+    );
+}


### PR DESCRIPTION
`V` (visual-line) in the in-app pager highlighted a selected row only as far as
its text, because the selection background was applied to the row's existing
spans. A blank line has no spans to paint, so it showed no highlight at all;
issue #120 reports the resulting ragged column as "somewhat messy" when
scrolling a buffer.

It is not blank-lines-only — **any** line shorter than the viewport was clipped.
A probe of a 4-line buffer in an 8-column viewport, before the fix, painted the
background over 4 cells of `aaaa`, 0 of the blank line, and 2 of `bb`.

## Fix

`render_single_column` pads each row out to the content width with the selection
background. The pad happens per wrapped piece, *after* tab expansion and wrap, so
the width is measured against what actually reaches the screen and the pad can
never introduce an extra visual row. The line-number gutter is prepended
afterwards and so stays outside the highlight, matching vim.

`line_fill_bg` is the single place that decides whether a row fills:

- **visual-line (`V`)** and **line placement** (the first `V` of the double-tap
  arm) take whole rows → fill.
- **visual-char (`v`)** is a character range → does *not* fill; a partial row
  stays partial.
- **visual-block (`^v`)** is a rectangle → unchanged.

## Yank was already correct

Render-only. `visual_yank_text`'s Line arm maps `line_plain_text` over
`lines[lo..=hi]` and joins with `\n`, so a blank line already contributed its
empty string and its newline.

## Tests

New `src/ui/pager/tests/selection_render.rs` asserts on resolved `Cell::bg`, not
glyphs — the existing pager snapshots are glyph-only and pass identically either
side of this change, so they could not have caught it.

Reverting just the pad call turns the four line-mode tests red (the blank row
reports `[Reset × 10]`) while the charwise and block guards stay green in both
states, confirming they guard rather than merely follow the implementation.

`make check-ci` → `=== GATE: PASS ===`.
