### PR TITLE
ci(deny): move the supply-chain gate off the commit path into audit.yml

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,8 +1,18 @@
-# Weekly dependency-drift + advisory report. Ported from the Bitbucket
+# Weekly dependency-drift + supply-chain report. Ported from the Bitbucket
 # `weekly-deps` custom pipeline (archived under docs/archive/).
 #
-# `cargo deny check advisories` re-fetches the RUSTSEC DB on every run, so it
-# surfaces new advisories against existing deps even on weeks with no commits.
+# **This workflow owns the supply-chain gate.** cargo-deny re-fetches the RUSTSEC
+# DB on every run — good here (it surfaces new advisories against unchanged deps
+# on weeks with no commits) and bad in the per-commit path, where it made the
+# pre-commit hook network-dependent and has segfaulted mid-run on the CI runner,
+# failing PRs that touched no dependencies. So `ci.yml` no longer runs it.
+#
+# The trade that buys: a PR introducing a banned / wrongly-licensed / duplicate
+# dependency is not caught at PR time — it surfaces on the next scheduled run, or
+# whenever someone runs `make deny` locally. Dispatch this workflow manually
+# (`workflow_dispatch`, or `gh workflow run audit.yml`) after merging anything
+# that moves `Cargo.toml` / `Cargo.lock`, and before cutting a release.
+#
 # `cargo outdated` / `cargo tree --duplicates` are soft signals (never fail).
 #
 # NOTE: the Bitbucket version lit up a Bitbucket→Slack integration on failure;
@@ -40,8 +50,14 @@ jobs:
             install -m 0755 "/tmp/${CARGO_DENY_DIR}/cargo-deny" "$HOME/.cargo/bin/cargo-deny"
           fi
       - run: cargo install cargo-outdated --locked
-      - name: Advisories (hard fail)
-        run: cargo deny check advisories
+      # `make deny` = `cargo deny --all-features check` — advisories, bans,
+      # licenses AND sources. Previously only `advisories` ran here and the other
+      # three rode on ci.yml; now that ci.yml doesn't run deny, this has to be the
+      # full check or bans/licenses/sources would go unchecked entirely. Via the
+      # Makefile target so there is one definition of what "the supply-chain
+      # gate" means.
+      - name: Supply chain — advisories, bans, licenses, sources (hard fail)
+        run: make deny
       - name: Outdated direct deps (soft)
         run: cargo outdated --root-deps-only || true
       - name: Duplicate deps (soft)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ permissions:
 
 jobs:
   lint:
+    # NOTE: this `name` is a REQUIRED STATUS CHECK in main's branch protection,
+    # so it is deliberately left saying "supply-chain / deny" even though deny
+    # moved to `audit.yml`. Renaming it needs the protection contexts updated in
+    # the same motion — a rename alone deadlocks every open PR, because the old
+    # required context would never report again. See the PR that moved deny.
     name: Lint + supply-chain (fmt, clippy, deny)
     runs-on: ubuntu-latest
     steps:
@@ -48,19 +53,11 @@ jobs:
       - name: Toolchain + C compiler (load-bearing for *-sys crates)
         run: rustc --version && cargo --version && cc --version
       - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-deny (pinned, sha256-verified)
-        run: |
-          CARGO_DENY_VERSION=0.19.4
-          CARGO_DENY_SHA256=3bd58b784e83715b86ddbc9deac591890372ec77fda5741bb0826970b958506f
-          CARGO_DENY_DIR=cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl
-          if ! cargo-deny --version 2>/dev/null | grep -q "${CARGO_DENY_VERSION}"; then
-            curl -sSLo /tmp/cargo-deny.tar.gz "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/${CARGO_DENY_DIR}.tar.gz"
-            echo "${CARGO_DENY_SHA256}  /tmp/cargo-deny.tar.gz" | sha256sum -c -
-            tar -xzf /tmp/cargo-deny.tar.gz -C /tmp
-            install -m 0755 "/tmp/${CARGO_DENY_DIR}/cargo-deny" "$HOME/.cargo/bin/cargo-deny"
-          fi
-      # fmt-check + clippy + deny. Tests run in the parallel `test` job.
-      - run: make fmt-check lint deny
+      # fmt-check + clippy. Tests run in the parallel `test` job; supply-chain
+      # (cargo-deny) runs in `audit.yml` — it re-fetches the RUSTSEC DB over the
+      # network on every invocation, which has segfaulted mid-run here and failed
+      # a PR that touched no dependencies.
+      - run: make fmt-check lint
 
   test:
     name: Tests (cargo test --all-targets)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,7 @@ spyc is Model-View-Update. Keep these — they're what make it reason-about-able
 ```sh
 cargo build / cargo build --release   # or: make release
 make install      # release build + copy to ~/.local/bin
-make check        # fmt + clippy + test + deny (CI gate)
+make check        # fmt + clippy + test (CI gate; supply-chain is audit.yml)
 make fuzz         # nightly + cargo-fuzz, on-demand (NOT in check)
 make changelog    # preview the pending CHANGELOG section
 make release-prep VERSION=x.y.z       # step 1, on a release branch: set version + changelog + commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,14 @@ We use GitHub pull requests. The target branch is `main`.
 
 3. **Run the quality gate** before pushing:
    ```sh
-   make check    # fmt-check + lint + test + deny
+   make check    # fmt-check + lint + test
    ```
-   All four must pass. Clippy runs with `pedantic` and `nursery`
-   lints — warnings are errors in CI. `deny` is cargo-deny
-   (advisories, licenses, sources, bans). If you touched
+   All three must pass. Clippy runs with `pedantic` and `nursery`
+   lints — warnings are errors in CI. Supply-chain checks
+   (`make deny` — cargo-deny advisories/licenses/sources/bans) are
+   **not** in `check`: they re-fetch the RUSTSEC DB over the network,
+   which is the wrong thing to do on every commit. `audit.yml` owns
+   them; run `make deny` by hand if you changed a dependency. If you touched
    `cfg(target_os = "linux")` code, also run `make lint-linux` —
    host clippy compiles that code out. `make aislop` is an advisory
    AI-slop scan (net-new findings vs the baseline).
@@ -219,11 +222,18 @@ happened and wants a human.
 ## CI
 
 GitHub Actions (`.github/workflows/ci.yml`) runs the quality gate on every PR
-(fmt + clippy + deny as one job, tests in parallel) and adds a coverage gate on
-merges to `main`. All jobs must pass before merge. A weekly
-`.github/workflows/audit.yml` re-runs `cargo deny check advisories` against a
-fresh RUSTSEC DB. CI pins the toolchain via `rust-toolchain.toml`, so it matches
-your local `make check`.
+(fmt + clippy as one job, tests in parallel) and adds a coverage gate on
+merges to `main`. All jobs must pass before merge. CI pins the toolchain via
+`rust-toolchain.toml`, so it matches your local `make check`.
+
+**Supply chain lives in `.github/workflows/audit.yml`**, not the PR gate: weekly
+plus `workflow_dispatch`, running the full `make deny` (advisories, bans,
+licenses, sources) against a freshly fetched RUSTSEC DB. It was taken off the PR
+path because cargo-deny's network fetch made every commit online-dependent and
+has segfaulted mid-run on the runner, failing PRs that touched no dependencies.
+The cost of that: a PR adding a banned or wrongly-licensed dependency isn't
+caught until the next scheduled run — so **dispatch `audit.yml` after merging a
+dependency change**, and before cutting a release.
 
 ## Cross-compilation
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,17 @@ run: ## Debug run
 # ---------- Quality gate -----------------------------------------------------
 
 .PHONY: check
-check: fmt-check lint test deny ## Full quality gate (CI)
+check: fmt-check lint test ## Full quality gate (CI)
+
+# `deny` is deliberately NOT in `check`. `check` is what the pre-commit hook
+# runs, and cargo-deny re-fetches the RUSTSEC advisory DB over the network on
+# every invocation — slow on every commit, offline-hostile, and the source of two
+# concrete incidents: the advisory-DB update inherits the hook's `GIT_DIR` and
+# hard-reset the developer's own checked-out branch (see the pre-commit hook and
+# AGENTS.md), and it has segfaulted mid-run on CI's Linux runner, failing a PR
+# that had nothing to do with dependencies. Supply chain is owned by
+# `audit.yml` (weekly + `workflow_dispatch`), which runs this same target.
+# Run it by hand any time with `make deny`.
 
 # A pipeline's exit status is its LAST command's, so `make check | tail` reports
 # the pager's success and a failed gate reads as green. No target can fix that —

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -182,9 +182,13 @@ and **Security Advisories**. spyc's equivalents:
   path, announced in the release notes under a dedicated "Errata" heading.
 - **Signing:** release notes + `SHA256SUMS` are signed (§9) so an advisory's
   artifacts are verifiable.
-- **Supply chain:** `audit.yml` runs `cargo deny check advisories` weekly (ported
-  from the retired Bitbucket `weekly-deps` pipeline) so RUSTSEC advisories surface
-  between releases; optionally Dependabot for the Actions themselves.
+- **Supply chain:** `audit.yml` owns it — the full `make deny` (advisories, bans,
+  licenses, sources) weekly *and* on `workflow_dispatch`, against a freshly
+  fetched RUSTSEC DB, so advisories surface between releases even with no commits.
+  Deliberately **not** in `ci.yml`'s PR gate (the fetch made commits
+  network-dependent and segfaulted a runner mid-check). **Dispatch it before
+  cutting a release**, and after merging anything that moves `Cargo.lock`;
+  optionally Dependabot for the Actions themselves.
 
 ## 7. Support & EOL policy
 
@@ -218,12 +222,15 @@ are the source of truth — Actions *call them* so local and CI never drift.
 > `snapshot.yml` (nightly cadence) remains to build.
 
 ### `ci.yml` — quality gate (PR + push to `main`) — **IMPLEMENTED**
-- Direct port of the retired `bitbucket-pipelines.yml`: `lint` (fmt + clippy +
-  deny) ∥ `test` on PRs, plus a `coverage` job (`cargo llvm-cov --locked
-  --all-targets --fail-under-lines 35`) on pushes to `main`. Toolchain cached via
-  `Swatinem/rust-cache`; `cargo-deny` + `cargo-llvm-cov` are the same sha-pinned
-  prebuilt binaries as before; `CARGO_INCREMENTAL=0` throughout. Make it a
-  required status check in branch protection.
+- Direct port of the retired `bitbucket-pipelines.yml`: `lint` (fmt + clippy) ∥
+  `test` on PRs, plus a `coverage` job (`cargo llvm-cov --locked
+  --all-targets --fail-under-lines 35`) on pushes to `main`. Supply-chain
+  (cargo-deny) moved to `audit.yml` — see §6. Toolchain cached via
+  `Swatinem/rust-cache`; `cargo-llvm-cov` is the same sha-pinned prebuilt binary
+  as before; `CARGO_INCREMENTAL=0` throughout. Make it a required status check in
+  branch protection — and note the `lint` job's **name is a required context**, so
+  renaming it needs the protection contexts changed in the same motion or every
+  open PR deadlocks on a context that never reports.
 - **Follow-ups:** (1) add a `macos-latest` matrix leg to catch OS-gated lints
   both ways (replaces needing `make lint-linux` + zig locally) — the initial
   port is Linux-only, matching the retired pipeline; (2) extend the trigger to


### PR DESCRIPTION
## Why

cargo-deny re-fetches the RUSTSEC advisory DB on **every** invocation. That's
correct for a scheduled audit and wrong for a per-commit gate, and it cost two
concrete incidents in opposite directions:

- **From the pre-commit hook** — the advisory-DB update
  (`git -C ~/.cargo/advisory-dbs/<hash> fetch && git reset --hard FETCH_HEAD`)
  inherited the hook's `GIT_DIR` and hard-reset the developer's own checked-out
  branch. #262 fixed that at the hook boundary, but the network fetch is what
  put a `git reset` in the commit path at all.
- **On CI** — `cargo deny check` **segfaulted** mid-run
  (`make: *** [Makefile:95: deny] Segmentation fault (core dumped)`) and failed a
  PR that touched no dependencies, then passed on re-run. That's the
  supply-chain gate blocking merges for reasons unrelated to the change.

## What moved

| | before | after |
|---|---|---|
| `make check` (hook + `check-ci`) | fmt-check + lint + test + **deny** | fmt-check + lint + test |
| `ci.yml` lint job | `make fmt-check lint deny` | `make fmt-check lint` |
| `audit.yml` | `cargo deny check advisories` | **`make deny`** — advisories, bans, licenses, sources |

`make deny` itself is unchanged and still available on demand.

**Broadening audit.yml was required, not incidental.** It only ran `advisories`;
bans/licenses/sources rode on ci.yml. Removing deny from ci.yml without
broadening audit.yml would have left three of the four checks running *nowhere*.
Both callers now go through the Makefile target, so there's one definition of
what "the supply-chain gate" means.

## The trade, stated plainly

A PR that introduces a **banned, wrongly-licensed, or duplicated dependency is no
longer caught at PR time.** It surfaces on the next weekly run, on a manual
`workflow_dispatch`, or from a local `make deny`. The docs now say to dispatch
`audit.yml` after merging a dependency change and before cutting a release.

If you'd rather not accept that gap, the middle option is a path-filtered deny job
that runs only when `Cargo.toml` / `Cargo.lock` / `deny.toml` change — I didn't
build it because a path-filtered job must **not** be a required check (a required
context that doesn't run blocks the merge), so it'd be advisory-only and the
segfault could still redden a dependency PR. Happy to add it if you want the
coverage back.

## One thing deliberately left inconsistent

The lint job's `name` still reads **"Lint + supply-chain (fmt, clippy, deny)"**
even though it no longer runs deny. That name is a **required status check** in
main's branch protection (confirmed via the protection API), so renaming it inside
a PR deadlocks that PR — the old required context would never report again.
Renaming safely needs the protection contexts updated in the same motion, which is
a repo-settings change I'm not making unasked. A comment in `ci.yml` and a note in
RELEASE_ENGINEERING §8 record why the name lies and what a rename requires.

Say the word and I'll do the rename properly: drop the old context from
protection, merge the rename, add the new context.

## Verified

- `make deny` standalone → `advisories ok, bans ok, licenses ok, sources ok`
- `make check-ci` → `=== GATE: PASS ===`, and grepping its output for deny's
  summary line returns **0** matches, so it genuinely stopped running it
- Job name byte-identical to the required context

Docs updated in the same commit: CONTRIBUTING (gate is three things now, plus
where supply chain went and the dispatch advice), RELEASE_ENGINEERING §6 and §8,
AGENTS' build block.

Co-Authored-By: Claude <noreply@anthropic.com>