### PR TITLE
ci(lint): rename the lint job now that deny moved out of it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,12 @@ permissions:
 
 jobs:
   lint:
-    # NOTE: this `name` is a REQUIRED STATUS CHECK in main's branch protection,
-    # so it is deliberately left saying "supply-chain / deny" even though deny
-    # moved to `audit.yml`. Renaming it needs the protection contexts updated in
-    # the same motion — a rename alone deadlocks every open PR, because the old
-    # required context would never report again. See the PR that moved deny.
-    name: Lint + supply-chain (fmt, clippy, deny)
+    # This `name` is a REQUIRED STATUS CHECK context in main's branch protection.
+    # Changing it is a three-step operation, not an edit: drop the old context
+    # from protection, merge the rename, then add the new one. A rename on its own
+    # deadlocks every open PR — the old required context never reports again, so
+    # the merge button can never go green.
+    name: Lint (fmt, clippy)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -228,9 +228,11 @@ are the source of truth — Actions *call them* so local and CI never drift.
   (cargo-deny) moved to `audit.yml` — see §6. Toolchain cached via
   `Swatinem/rust-cache`; `cargo-llvm-cov` is the same sha-pinned prebuilt binary
   as before; `CARGO_INCREMENTAL=0` throughout. Make it a required status check in
-  branch protection — and note the `lint` job's **name is a required context**, so
-  renaming it needs the protection contexts changed in the same motion or every
-  open PR deadlocks on a context that never reports.
+  branch protection. The required contexts are exactly `Lint (fmt, clippy)` and
+  `Tests (cargo test --all-targets)` — a job's **`name` IS its context**, so
+  renaming either one is a three-step operation: drop the old context from
+  protection, merge the rename, add the new context. Renaming without that dance
+  deadlocks every open PR on a context that will never report again.
 - **Follow-ups:** (1) add a `macos-latest` matrix leg to catch OS-gated lints
   both ways (replaces needing `make lint-linux` + zig locally) — the initial
   port is Linux-only, matching the retired pipeline; (2) extend the trigger to


### PR DESCRIPTION
Follow-up to #273, which moved cargo-deny to `audit.yml` but left the job named
`Lint + supply-chain (fmt, clippy, deny)` — a name that no longer described what
it ran.

The reason it wasn't renamed there: **a job's `name` IS its status-check context**,
and that string is a required context in main's branch protection. Renaming inside
a PR deadlocks that PR, because the old required context never reports again and
the merge button can never go green.

## The three-step operation

This PR is step 2 of 3, and steps 1 and 3 are protection changes I'm making around
the merge:

1. Drop `Lint + supply-chain (fmt, clippy, deny)` from the required contexts.
2. **Merge this PR** (renames the job to `Lint (fmt, clippy)`).
3. Add `Lint (fmt, clippy)` to the required contexts.

Between 1 and 3 main briefly requires only `Tests (cargo test --all-targets)` plus
up-to-date. `enforce_admins` stays on, force-pushes and deletions stay blocked, and
linear history + conversation resolution are untouched — the only thing lifted is
the lint requirement, for about a minute. The full protection config is backed up
first so it can be restored verbatim if anything misbehaves.

## Also updated

- The `ci.yml` comment now records the three-step **procedure** instead of
  explaining why the name was stale.
- RELEASE_ENGINEERING §8 names both required contexts explicitly
  (`Lint (fmt, clippy)`, `Tests (cargo test --all-targets)`) and states that
  renaming a job is a protection operation, not a text edit — so the next person
  doesn't rediscover the deadlock.

`docs/archive/bitbucket-pipelines.yml` still contains the old string and is
deliberately untouched: it's a frozen record of the retired Bitbucket pipeline,
not live config.

`make check-ci` green.

Co-Authored-By: Claude <noreply@anthropic.com>