### PR TITLE
docs: fill in the missing keybindings + fix archive relative links

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -13,10 +13,14 @@ keys drive the file view (letters / `g` / `H` / `[`/`]`); **pane** keys use the
 | Key | Action |
 |-----|--------|
 | `h` `j` `k` `l` | Move (counts work: `5j`, `10k`) |
+| `0`-`9` `<motion>` | Count prefix (e.g. `5j`, `10k`, `5G`) |
 | `gg` / `G` | Top / bottom |
+| `^B` / `PageUp` | Previous page |
+| `^F` / `PageDown` | Next page |
 | `Enter` | Descend into dir or view file in pager |
 | `e` / `v` | Descend into dir or open file in `$EDITOR` |
 | `dd` / `Ndd` | Remove cursor entry (+ N-1 below) to the graveyard (confirm with `y`) |
+| `R` | Remove selection (picks, else cursor) to the graveyard |
 | `V` | Open `$EDITOR` in top pane (bottom pane stays visible) |
 | `D` | Open file in the in-app pager in top pane (bottom pane stays visible) |
 | `u` / `-` | Climb to parent |
@@ -25,6 +29,21 @@ keys drive the file view (letters / `g` / `H` / `[`/`]`); **pane** keys use the
 | `J` | Jump to any path |
 | `F` | Project-wide fuzzy filename finder (gitignore-aware) |
 | `:grep <pat>` | Project-wide content search (embedded ripgrep matcher) |
+
+## File operations
+
+`%` expands to the current selection in any prompt (e.g. `M` then `%.bak`).
+
+| Key | Action |
+|-----|--------|
+| `c` | Copy selection to a destination (prompt) |
+| `M` | Move / rename selection (prompt) |
+| `+` | Make a new directory (prompt) |
+| `O` | Create a new file in `$EDITOR` (prompt) |
+| `L` | Long listing — wide aligned table (inode, mode, octal, …) |
+| `S` | Cycle sort: name → size → mtime → ext |
+| `:chmod <mode>` | Change mode on the selection |
+| `:filetype` | Show the cursor file's detected type |
 
 ## Picks & inventory
 
@@ -35,12 +54,20 @@ file cache that survives across sessions.
 |-----|--------|
 | `t` | Toggle pick |
 | `T` | Pick by glob |
+| `^T` | Pick all / clear all |
 | `yy` | Yank to inventory (copies file to cache) |
+| `yf` | Yank cursor file's absolute path (or picks) to clipboard |
 | `yp` | Yank visible pane output to clipboard |
 | `yP` | Yank last typed prompt to clipboard |
+| `ya` | Yank full pane scrollback to clipboard |
 | `Y` | Remove cursor file from inventory |
 | `p` | Put inventory files into cwd |
 | `i` | Toggle inventory view |
+| `z` | Clear inventory (moves entries to the graveyard) |
+
+Inside the inventory view: `t` / `Space` tag-untag for a partial put,
+`p` puts tagged (or all) to cwd, `x` / `d` removes an item (to the
+graveyard), `Esc` / `i` returns to the directory view.
 
 > Yank-to-clipboard uses `pbcopy` on macOS and `wl-copy` / `xclip` /
 > `xsel` on Linux (auto-detected). Install one of those on Linux —
@@ -75,6 +102,8 @@ toggles), word-level intra-line change highlighting.
 | `gD` | Staged-only diff (`git diff --cached`) |
 | `gu` | Unstaged diff (`git diff`) — what changed since you staged |
 | `gb` | Blame the cursor file |
+| `gr` | Restore a deleted (struck-through) file from git |
+| `]g` / `[g` | Cursor to next / prev git-changed entry (wraps) |
 | `\|` (in view) | Toggle side-by-side ⇄ unified layout |
 
 ## Split pane
@@ -92,11 +121,15 @@ works. Prefix is `^a` (screen-style); `^w` also works.
 | `^a p` / `^a [` | Prev tab |
 | `^a K` / `^a x` | Close tab (confirms first while its child is still running) |
 | `^a 1`..`9` | Switch to tab N |
+| `^a ^a` | Jump to last-active tab |
 | `^a r` | Rename tab |
 | `^a R` | Restart tab in place, keeping its number (confirms first while its child is still running) |
+| `^z` | Suspend / resume the agent pane (💤); a shell tab's `^z` forwards as usual |
 | `^a s` | Send selection paths to pane |
 | `^a P` | Pipe file contents to pane |
+| `^a i` | Pipe inventory file contents to pane |
 | `^a z` | Zoom the active region — list or bottom pane (fullscreen toggle) |
+| `^a +` / `^a -` | Grow / shrink the focused split (pane height or vsplit width) |
 | `^a \|` | Vertical split — cycle off / top-only / full-height (live-reloading preview of the cursor file) |
 | `^a a` / `^a h` | Focus the left file pane (a) |
 | `^a b` / `^a l` | Focus the right file pane (b) |
@@ -106,6 +139,7 @@ works. Prefix is `^a` (screen-style); `^w` also works.
 | `^a u` | Quick Select — labeled picker for URL/path/SHA/IP |
 | `^a v` | Pane scrollback in the in-app pager (search, jump, visual yank) |
 | `Ctrl+J` | Newline in pane (multi-line input) |
+| `^a ↓` | Send a literal `^a` to the pane (e.g. so Claude receives it) |
 | `gf` | Jump to file path in pane output |
 | `gF` | Jump to file + open at referenced line |
 
@@ -144,6 +178,14 @@ rectangular selection.
 
 `%` in any command expands to the current selection.
 
+While a `!` capture is running in the pager:
+
+| Key | Action |
+|-----|--------|
+| `^C` | Interrupt the running capture (`SIGINT` to the child) |
+| `^\` | Hard-kill the running capture |
+| `^Z` | Send to background; resume later with `:fg` |
+
 ## Background tasks & buffer history
 
 Long captured commands shouldn't lock you out of spyc.
@@ -154,13 +196,15 @@ Long captured commands shouldn't lock you out of spyc.
 | `:fg` / `:fg N` | resume the most-recent (or specific) backgrounded task |
 | `gB` / `:task N` | open the *task viewer* -- a peek view without taking ownership |
 | `[t` / `]t` | (in pager, chord) cycle the task viewer prev/next by id |
+| `S` / `C` | (in task viewer) pause / continue the underlying task |
 | `gp` | reopen the most-recently-closed pager buffer |
 | `:bprev` / `:bnext` | walk pager buffer history back/forward |
 | `[b` / `]b` | (in pager, chord) walk buffer history back/forward |
 
 Backgrounded tasks render in the pane divider as `[N+]` (running, new
-output), `[N●]` (running, quiescent), `[N✓]` (exit 0), `[N✗]`
-(non-zero / killed / crashed), in a distinct color from pane tabs.
+output), `[N●]` (running, quiescent), `[N⏸]` (paused via `S`), `[N✓]`
+(exit 0), `[N✗]` (non-zero / killed / crashed), in a distinct color
+from pane tabs.
 When a viewed task exits, closing the task viewer pushes its
 final rendered view into the buffer-history stack so `[b` walks
 back to it later.
@@ -207,14 +251,33 @@ on the top bar and persist across `spyc -r`.
 | `:startdir [.\|<path>]` | Manage start dir |
 | `:name <NEW>` | Rename the active session |
 | `:whoami` | Show `user@host` in the status line |
+| `Space s` / `I` | Session info (pid, rss, counts) |
+| `Space ?` | This help overlay (same as `?`) |
+| `gV` / `:version` | Show the spyc version |
 
 The **leader** (`Space`, or `^a Space` from the agent pane) opens a
 global/workspace menu: `Space w l\|n\|d` (worktree list/new/delete),
 `Space p` (project home), `Space s` (session info), `Space ?` (help),
-`Space a` (about). Hold it to see the which-key popup.
+`Space a` (about). Hold it to see the which-key popup. `W l` / `W n` /
+`W d` is a list-focus alias for the same worktree list / new / delete.
 
 `PROJECT_HOME` is auto-set on startup if the launch directory contains
 `.git`. New pane tabs default their cwd to the focused column's
 worktree/repo root (`gw`'s target); set `[pane] new_tab_cwd =
 "project_home"` to pin them to `PROJECT_HOME` instead, or `"browse_dir"`
 to open them in the current listing dir.
+
+## Display & config
+
+| Key | Action |
+|-----|--------|
+| `C` | Toggle colors / mono |
+| `^L` | Redraw |
+| `^R` | Reload config (also auto-reloads on save) |
+| `Esc` (×2) | Cancel a prompt (`Esc`→Normal→`Esc`→cancel) |
+| `:activity` | Toggle the activity monitor; `:activity dump` → per-pane why-status report |
+| `:hooks` | Agent status-hook consent (`on` / `on!` / `off`) |
+| `:skill` | Agent skill: `status` / `update` / `remove` / `ask` |
+| `:lua` | Lua engine: `status` / `on` / `off` / `reload` |
+| `:notify test` | Fire every notification channel to verify setup |
+| `:date` | Show date/time (UTC) |

--- a/docs/archive/CODE_REVIEW_FOLLOWUP.md
+++ b/docs/archive/CODE_REVIEW_FOLLOWUP.md
@@ -1,6 +1,6 @@
 # Code review follow-up — finalizing the June 2026 review
 
-**Status:** ✅ COMPLETE (closed 2026-06-28). Every High/Medium finding the June 2026 deep review ([`docs/archive/CODE_REVIEW_2026-06.md`](archive/CODE_REVIEW_2026-06.md)) left is now at a clean terminal state — fixed, or closed (refuted / by-design / accepted). The last finding (`pty_host.rs:208`) closed in PR #606. Opened 2026-06-21.
+**Status:** ✅ COMPLETE (closed 2026-06-28). Every High/Medium finding the June 2026 deep review ([`docs/archive/CODE_REVIEW_2026-06.md`](CODE_REVIEW_2026-06.md)) left is now at a clean terminal state — fixed, or closed (refuted / by-design / accepted). The last finding (`pty_host.rs:208`) closed in PR #606. Opened 2026-06-21.
 
 **Goal:** drive every remaining finding to a clean terminal state — **fixed** (own cluster PR) or **closed** (refuted / by-design / accepted), keeping an honest ledger.
 

--- a/docs/archive/REFACTOR_PLAN.md
+++ b/docs/archive/REFACTOR_PLAN.md
@@ -7,7 +7,7 @@
 > directory. The rendering pass, pager-key router, colon-command
 > dispatch, and keyboard-input cluster are all out. **The MVU rewrite
 > (Phase 3) is now a pre-2.0 / road-to-2.0 track** — see the detailed
-> design in [`docs/MVU_PLAN.md`](docs/MVU_PLAN.md). This **reverses** the
+> design in [`docs/archive/MVU_PLAN.md`](MVU_PLAN.md). This **reverses** the
 > earlier "hold the MVU rewrite until 2.0 + ~2 weeks" gate (decision log,
 > 2026-05-30): 2.0 should ship *on* the cleaner foundation rather than
 > carry a refactor as launch overhang, and the strangler-fig design makes
@@ -67,7 +67,7 @@ Pick up when at least two of these are true:
   some interfaces have to be designed (e.g. the pager-key handler
   surface). Don't context-switch mid-extraction.
 - **Phase 3 (MVU)**: superseded by the strangler-fig design in
-  [`docs/MVU_PLAN.md`](docs/MVU_PLAN.md). The original framing here said
+  [`docs/archive/MVU_PLAN.md`](MVU_PLAN.md). The original framing here said
   "block out a full week; partial conversions are worse than either alone"
   — that assumed a big-bang. The strangler-fig plan instead lands ~8
   phases, **each behavior-equivalent behind green CI and independently
@@ -164,21 +164,21 @@ denies `wildcard_imports`).
 
 ## Phase 3 — MVU rewrite
 
-> **Detailed design: [`docs/MVU_PLAN.md`](docs/MVU_PLAN.md)** — a
+> **Detailed design: [`docs/archive/MVU_PLAN.md`](MVU_PLAN.md)** — a
 > strangler-fig, 8-phase (Phase -1 … 6) migration with Model/Runtime/
 > ViewState split, a single `Message` channel, a four-class `Effect`
 > vocabulary, and a `Focus` value. **Now a pre-2.0 / road-to-2.0 track**
 > (2026-05-30 decision): Phase 0 (Focus-as-one-value) lands first as a
 > daily-driver bug fix; Phases 1–6 land incrementally before launch, after
 > the test-harness de-risking. The sketch in this section is the original
-> high-level target; `docs/MVU_PLAN.md` supersedes it with concrete,
+> high-level target; `docs/archive/MVU_PLAN.md` supersedes it with concrete,
 > adversarially-vetted phases.
 
 The architectural change — but **not** the block-out-a-week big-bang the
 original framing below assumed. The strangler-fig design makes every phase
 behavior-equivalent behind green CI and independently revertable, so it lands
 incrementally pre-2.0 and interleaves with the other road-to-2.0 tracks rather
-than requiring one unbroken multi-day push. Follow `docs/MVU_PLAN.md`.
+than requiring one unbroken multi-day push. Follow `docs/archive/MVU_PLAN.md`.
 
 ### Target shape
 
@@ -300,7 +300,7 @@ the plan changed.)
   (`app::guard_tests::mod_rs_stays_decomposed`, ceiling 8,500) so `mod.rs`
   can't silently creep back toward a monolith — the test directs
   contributors to extract a module rather than raise the ceiling.
-- **2026-05-30**: Drew up the full MVU design ([`docs/MVU_PLAN.md`](docs/MVU_PLAN.md),
+- **2026-05-30**: Drew up the full MVU design ([`docs/archive/MVU_PLAN.md`](MVU_PLAN.md),
   PR #196) via a multi-agent design workflow — strangler-fig won a judge
   panel (46/50) over effect-first (45) and model-first (40); the borrow-
   checker / sync-only / scope-honesty reviewers surfaced the blockers


### PR DESCRIPTION
## What

Two docs commits, both recovered from an uncommitted stale worktree and
re-based onto current `main`.

**`docs(keybindings)`** — `docs/KEYBINDINGS.md` mirrors the `?` overlay but had
drifted behind the keymap. Fills in the count prefix, `^B`/`^F` paging, `R`, a
File operations section (`c` / `M` / `+` / `O` / `L` / `S` / `:chmod` /
`:filetype`), the missing picks+inventory verbs (`^T` / `yf` / `ya` / `z` and
the inventory-view keys), `gr` and `]g`/`[g`, the pane keys `^a ^a` / `^a i` /
`^a +`/`-` / `^a ↓` / `^z`, the capture-running keys (`^C` / `^\` / `^Z`), the
task-viewer `S`/`C` pause-continue plus the `[N⏸]` divider glyph, the
`W l|n|d` list-focus alias, and a Display & config section.

**`docs(archive)`** — links inside `docs/archive/` pointed at
`docs/MVU_PLAN.md` and `archive/CODE_REVIEW_2026-06.md`, which resolve
relative to the containing file and so landed on `docs/archive/docs/…` and
`docs/archive/archive/…`. Now point at the siblings they mean.

## Verification

Every binding was checked against the source, not transcribed from prose:

| Claim | Checked against |
|---|---|
| `^B`/`^F`, `R`, `c`, `M`, `+`, `O`, `L`, `S`, `I`, `C` | `keymap/resolver/mod.rs` |
| sort cycle `name → size → mtime → ext` | `SortMode::cycle_next`, `fs/listing.rs:68-74` |
| `t`/`T`/`^T`/`i`/`z`, `yf`, `ya` | `keymap/resolver/mod.rs` |
| inventory-view verbs (`Space`/`t`, `p`, `x`/`d`, `Esc`) | `key_dispatch/mod.rs:340-365`, incl. the bare-key guard |
| `gr`, `]g`/`[g` | `GitRestore`, `JumpNext/PrevGitChange` |
| `^a ^a`, `^a i`, `^a +`/`-`, `^a ↓` | `PaneLastTab`, `PanePipeInventory`, `resize_focused_split`, `PaneSendPrefix` |
| `^C` / `^\` / `^Z` while capturing | `capture_key_action` tests, `key_dispatch/mod.rs:881-883` |
| task-viewer `S`/`C`, `[N⏸]` | `pager_handler/motion.rs:244,254`; `help.rs:404`, `chrome.rs:233` |
| all 10 `:` commands | `COMMAND_TABLE` |

Also verified every relative markdown link in the three changed files resolves
to a real file, and that no other instance of the broken-link class remains
anywhere under `docs/`.

`make check` green.

## Note on two reconciled regions

The recovered edits predated two of `main`'s own changes to the same lines.
`main`'s wording is kept in both, with the additions layered on:

- **Pane-tab table** — kept `main`'s `^a R` "Restart tab in place, keeping its
  number (confirms first…)" and its amended `^a K`/`^a x` confirm text (#269);
  added `^a ^a` and `^z`.
- **Leader paragraph** — kept `main`'s sentence *including* `Space a` (about),
  which the older edit had dropped; appended the `W l|n|d` alias clause.

The recovered patch also inserted the new "Display & config" heading between
the leader paragraph and the `PROJECT_HOME` paragraph, orphaning `PROJECT_HOME`
under a heading about colors and redraws. Moved to the end of the file.

Generated with [Claude Code](https://claude.com/claude-code)
