### PR TITLE
fix(git): worktree-removal refusals name their cause

### DIFF
--- a/src/app/worktree_clean.rs
+++ b/src/app/worktree_clean.rs
@@ -43,8 +43,26 @@ pub struct SafeRemoveReport {
 /// changing nothing — when `path` isn't a readable git worktree, is claimed
 /// (locked), or archiving fails.
 pub fn safe_remove_worktree(path: &Path) -> std::io::Result<SafeRemoveReport> {
-    let statuses = status::repo_status(path)
-        .ok_or_else(|| std::io::Error::other("not a git worktree, or its status can't be read"))?;
+    // Distinguish the three ways this can fail, because they need different
+    // responses from whoever reads the message: a wrong path, a directory that
+    // isn't a worktree, or a status read that failed for a reason of its own
+    // (a lock held by a concurrent git, a permissions problem). The single
+    // collapsed message this replaced blamed the path in all three cases, so a
+    // transient failure looked structural.
+    let statuses = if !path.exists() {
+        return Err(std::io::Error::other(format!(
+            "no such path: {}",
+            path.display()
+        )));
+    } else if !path.join(".git").exists() {
+        return Err(std::io::Error::other(format!(
+            "not a git worktree (no .git): {}",
+            path.display()
+        )));
+    } else {
+        status::repo_status_result(path)
+            .map_err(|e| std::io::Error::other(format!("reading worktree status: {e}")))?
+    };
 
     // Honor a lease BEFORE archiving — don't archive then refuse. A claim is
     // respected even by safe-remove; release it first.
@@ -284,5 +302,50 @@ mod tests {
             );
             assert!(wt.exists(), "leased worktree left intact");
         });
+    }
+
+    /// A refusal must say WHICH failure it hit and name the path.
+    ///
+    /// These three used to share one message — "not a git worktree, or its
+    /// status can't be read" — which blames the target in every case. That is
+    /// how a transient status failure got investigated as a structural bug.
+    #[test]
+    fn safe_remove_refusals_name_their_cause_and_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("nope");
+        let err = safe_remove_worktree(&missing).unwrap_err().to_string();
+        assert!(err.contains("no such path"), "missing path: {err}");
+        assert!(err.contains("nope"), "names the path: {err}");
+
+        // Exists, but isn't a worktree.
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir(&plain).unwrap();
+        let err = safe_remove_worktree(&plain).unwrap_err().to_string();
+        assert!(err.contains("not a git worktree"), "plain dir: {err}");
+        assert!(err.contains("plain"), "names the path: {err}");
+        assert!(
+            !err.contains("no such path"),
+            "must not claim the path is missing: {err}"
+        );
+    }
+
+    /// `repo_status_result` carries the cause the `Option` variant discards,
+    /// and the `Option` variant still answers `None` for the same input — the
+    /// marker hot path keeps its behavior.
+    #[test]
+    fn repo_status_result_reports_why_and_option_still_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let plain = tmp.path().join("not-a-repo");
+        std::fs::create_dir(&plain).unwrap();
+
+        let err = crate::git::status::repo_status_result(&plain)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("open"), "names the failing step: {err}");
+        assert!(err.contains("not-a-repo"), "names the path: {err}");
+        assert!(
+            crate::git::status::repo_status(&plain).is_none(),
+            "the Option variant is unchanged for the hot path"
+        );
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -27,6 +27,25 @@ pub mod worktree;
 #[cfg(test)]
 pub mod test_support;
 
+/// Render an error with every `source()` behind it, so a wrapper whose Display
+/// omits the cause still reports one.
+///
+/// gix's error types nest several layers deep and the outermost Display is
+/// routinely the useless half ("could not open repository"), which is why the
+/// facade formats causes rather than passing `{e}` up. The app-layer equivalent
+/// is anyhow's `{e:#}` (see the `flashed_errors_render_their_whole_chain`
+/// guard); this is the same rule for the non-anyhow half.
+pub fn error_chain(e: &dyn std::error::Error) -> String {
+    let mut out = e.to_string();
+    let mut src = e.source();
+    while let Some(cause) = src {
+        out.push_str(" -> ");
+        out.push_str(&cause.to_string());
+        src = cause.source();
+    }
+    out
+}
+
 #[cfg(test)]
 mod no_subprocess_git_in_production {
     //! Strangler-fig closing guard: production code must never spawn the `git`

--- a/src/git/status.rs
+++ b/src/git/status.rs
@@ -192,13 +192,26 @@ pub fn make_status_platform(
     repo: &gix::Repository,
     untracked: gix::status::UntrackedFiles,
 ) -> Option<gix::status::Platform<'_, gix::progress::Discard>> {
+    make_status_platform_result(repo, untracked).ok()
+}
+
+/// [`make_status_platform`] keeping the failure cause.
+///
+/// Callers that only paint git markers want the `Option` — a failure just means
+/// "no markers this tick". A caller about to REFUSE a destructive operation
+/// needs to say why, which is what this is for.
+pub fn make_status_platform_result(
+    repo: &gix::Repository,
+    untracked: gix::status::UntrackedFiles,
+) -> std::io::Result<gix::status::Platform<'_, gix::progress::Discard>> {
     use gix::status::tree_index::TrackRenames;
-    Some(
-        repo.status(gix::progress::Discard)
-            .ok()?
-            .untracked_files(untracked)
-            .tree_index_track_renames(TrackRenames::Given(gix::diff::Rewrites::default())),
-    )
+    Ok(repo
+        .status(gix::progress::Discard)
+        .map_err(|e| {
+            std::io::Error::other(format!("build status: {}", crate::git::error_chain(&e)))
+        })?
+        .untracked_files(untracked)
+        .tree_index_track_renames(TrackRenames::Given(gix::diff::Rewrites::default())))
 }
 
 /// The live status backend (run by the background git worker, bootstrap.rs):
@@ -225,18 +238,38 @@ pub fn make_status_platform(
 ///   column.
 #[must_use]
 pub fn repo_status(repo_root: &Path) -> Option<Vec<StatusEntry>> {
+    repo_status_result(repo_root).ok()
+}
+
+/// [`repo_status`] keeping the failure cause.
+///
+/// The `Option` above is right for the marker hot path — a failed tick just
+/// paints nothing and the next poll retries. It is wrong for a caller that
+/// REFUSES work on failure: `safe_remove_worktree` used to collapse every cause
+/// into "not a git worktree, or its status can't be read", which names the
+/// target path as the suspect no matter what actually went wrong. A transient
+/// failure then reads as a structural one, and the operator has nothing to go
+/// on. (That is not hypothetical — it sent one investigation down a wrong path
+/// entirely.)
+pub fn repo_status_result(repo_root: &Path) -> std::io::Result<Vec<StatusEntry>> {
     use gix::bstr::ByteSlice;
     use gix::diff::index::ChangeRef;
     use gix::status::index_worktree::Item as IwItem;
     use gix::status::plumbing::index_as_worktree::{Change, EntryStatus};
     use gix::status::{Item, UntrackedFiles};
 
-    let repo = gix::open(repo_root).ok()?;
+    let repo = gix::open(repo_root).map_err(|e| {
+        std::io::Error::other(format!(
+            "open {}: {}",
+            repo_root.display(),
+            crate::git::error_chain(&e)
+        ))
+    })?;
     // `-unormal`: collapse a fully-untracked dir to one `dir/` entry, but list
     // an untracked file inside a tracked dir individually. See the doc comment
     // above for why this is `Collapsed`, not `Files`. Rename-detection config
     // is shared with `collect_worktree_plan` via `make_status_platform`.
-    let platform = make_status_platform(&repo, UntrackedFiles::Collapsed)?;
+    let platform = make_status_platform_result(&repo, UntrackedFiles::Collapsed)?;
 
     // Accumulate per repo-relative path: the staged column (TreeIndex) and the
     // unstaged/untracked column (IndexWorktree) for the same path merge into
@@ -253,7 +286,9 @@ pub fn repo_status(repo_root: &Path) -> Option<Vec<StatusEntry>> {
         })
     }
 
-    let iter = platform.into_iter(None).ok()?;
+    let iter = platform.into_iter(None).map_err(|e| {
+        std::io::Error::other(format!("walk status: {}", crate::git::error_chain(&e)))
+    })?;
     for item in iter {
         // Tolerate a single bad item: one path that fails to decode (e.g. an
         // unreadable worktree entry) must not blank the *entire* repo's git
@@ -354,7 +389,7 @@ pub fn repo_status(repo_root: &Path) -> Option<Vec<StatusEntry>> {
         }
     }
 
-    Some(by_path.into_values().collect())
+    Ok(by_path.into_values().collect())
 }
 
 /// [`repo_status`] guarded against the racy-snapshot pitfall, returning the

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -316,7 +316,7 @@ fn write_index_with_lock_retry(index: &mut gix::index::File) -> std::io::Result<
                 return Err(std::io::Error::other(format!(
                     "write index ({} attempt(s)): {}{}",
                     attempt,
-                    error_chain(&e),
+                    crate::git::error_chain(&e),
                     describe_index_parent(index.path())
                 )));
             }
@@ -394,19 +394,6 @@ fn lock_contention_is_transient(e: &gix::index::file::write::Error) -> bool {
                 | std::io::ErrorKind::Interrupted
         ),
     }
-}
-
-/// Render an error with every `source()` behind it, so a wrapper whose Display
-/// omits the cause still reports one.
-fn error_chain(e: &dyn std::error::Error) -> String {
-    let mut out = e.to_string();
-    let mut src = e.source();
-    while let Some(cause) = src {
-        out.push_str(" -> ");
-        out.push_str(&cause.to_string());
-        src = cause.source();
-    }
-    out
 }
 
 /// Resolve `full_ref` (`refs/heads/<branch>`) to its commit id. If the branch
@@ -1284,7 +1271,7 @@ mod tests {
         let e = gix::index::file::write::Error::AcquireLock(gix::lock::acquire::Error::Io(
             std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied by fs"),
         ));
-        let rendered = super::error_chain(&e);
+        let rendered = crate::git::error_chain(&e);
         assert!(
             rendered.contains("Could not acquire lock"),
             "keeps the outer message: {rendered}"


### PR DESCRIPTION
## Context — and a correction

This started as "fix the worktree bug", where the bug was believed to be:
spyc's `list_worktrees` / `remove_worktree` go blind when the focused column is
inside a linked worktree.

**That diagnosis was wrong.** It doesn't reproduce, and the evidence against it
was already available:

- `remove_worktree` had succeeded earlier in the same session with the column
  inside a linked worktree.
- `git::worktree::list` already handles this case deliberately — it resolves the
  main worktree from `repo.common_dir()`, with a comment stating that discovery
  from inside a linked worktree would otherwise mis-list.
- Re-tested on `b34854a`: created a worktree, navigated the column into it.
  `list_worktrees` returned every worktree with `is_current:true`, and
  `remove_worktree` succeeded.

What actually happened: two `remove_worktree` calls failed with
`not a git worktree, or its status can't be read`, and a following
`list_worktrees` returned `[]`. A `navigate_to` happened to precede the
recovery, and that coincidence got read as the cause. The real correlate was
timing — both failures landed immediately after two squash-merges plus
`git fetch --prune` and `git merge --ff-only` in the main checkout, which rewrite
refs/packed-refs in the shared common dir. A transient ref/lock race there is the
leading hypothesis. It remains **unproven and unreproduced**, so this PR does not
claim to fix it.

## What this does fix

The reason a transient failure was indistinguishable from a structural one.
`status::repo_status` returns `Option`, discarding the gix error, so
`safe_remove_worktree` collapsed every cause into one message that blames the
target path. Now:

| condition | before | after |
|---|---|---|
| path doesn't exist | `not a git worktree, or its status can't be read` | `no such path: <path>` |
| exists, not a worktree | *same message* | `not a git worktree (no .git): <path>` |
| status read failed | *same message* | `reading worktree status: open <path>: <gix cause chain>` |

`repo_status_result` / `make_status_platform_result` carry the cause;
`repo_status` / `make_status_platform` remain and delegate via `.ok()`, so the
git-marker hot path is byte-identical — a failed tick there should paint nothing
and let the next poll retry, which is what `Option` is right for.

`error_chain` moves from `git::worktree` up to `git` and is shared rather than
duplicated, now that two modules format gix cause chains. It is the non-anyhow
half of the rule `flashed_errors_render_their_whole_chain` enforces via `{e:#}`.

## Verification

`make check` green — run unpiped (`make exit: 0` **and** `=== GATE: PASS ===`),
after being burned earlier this session by piping the gate into `tail` and
reading `tail`'s exit code as success.

Two new tests:
- `safe_remove_refusals_name_their_cause_and_path` — each condition produces its
  own message and names the path; asserts the missing-path case is *not* reported
  for a directory that merely isn't a worktree.
- `repo_status_result_reports_why_and_option_still_returns_none` — the Result
  variant names the failing step and path, and the `Option` variant still returns
  `None` for the same input.

## Deliberately not done

**No retry.** There's precedent for one (`write_index_with_lock_retry` exists
because gix acquires locks with `Fail::Immediately`, and the same family caused a
CI flake fixed by widening a retry) and the hypothesis above fits it. But adding
a retry to a read path while the cause is unknown means guessing at which
failures are transient. Surfacing the cause first is the prerequisite; if this
recurs, the message will say whether it's lock contention, and the retry then has
evidence behind it.

Generated with [Claude Code](https://claude.com/claude-code)
