### PR TITLE
feat(mouse): click a pane tab to switch to it

### DIFF
--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -23,6 +23,7 @@ mod forward;
 mod route;
 mod scroll;
 mod selection;
+pub(super) mod tab_hit;
 
 // Re-exported so the impure half and its callers keep referring to
 // `mouse::route_mouse` / `mouse::Region` exactly as before this split.
@@ -266,6 +267,19 @@ impl super::App {
             has_scroll_pager: self.view.scroll_pager.is_some(),
             pane_closed: self.state.pane.pane_snapshot.is_closed,
             pane_scroll_keys: self.active_pane_wheel_scroll().is_some(),
+            // Only resolved over the divider: the width walk allocates, and a
+            // wheel tick over the pane has no use for it.
+            tab_under_pointer: if matches!(region, Some(route::Region::Divider)) {
+                let widths = self
+                    .runtime
+                    .pane_tabs
+                    .as_ref()
+                    .map(|t| tab_hit::tab_widths(t, t.active().is_scrolling()))
+                    .unwrap_or_default();
+                tab_hit::tab_at_point(layout.divider, &widths, ev.column, ev.row)
+            } else {
+                None
+            },
         };
 
         match route_mouse(snap, gesture) {
@@ -296,6 +310,21 @@ impl super::App {
                 self.begin_pane_selection(ev)
             }
             MouseSink::SelectChrome => self.begin_chrome_selection(ev),
+            MouseSink::PaneTab(index) => {
+                // Reuse the keyboard's own tab switch rather than calling
+                // `tabs.switch_to`: it also stashes/restores the per-tab
+                // scrollback pager, pulls focus into the pane, and handles the
+                // `^a z` fullscreen-list case. A hand-rolled switch here would
+                // start out subtly different and drift further.
+                let n = u8::try_from(index.saturating_add(1)).unwrap_or(u8::MAX);
+                match self.apply(&crate::keymap::Action::PaneTabByIndex(n)) {
+                    Ok(effects) => effects,
+                    Err(e) => {
+                        self.state.flash_error(format!("tab switch: {e:#}"));
+                        Vec::new()
+                    }
+                }
+            }
             MouseSink::Paste => vec![Effect::PasteFromClipboard],
             MouseSink::LeaderMenu => {
                 self.state.resolver.enter_leader();

--- a/src/app/mouse/route.rs
+++ b/src/app/mouse/route.rs
@@ -95,6 +95,14 @@ pub enum MouseSink {
     /// took the entire line was surprising, and it couldn't copy just the one thing
     /// you wanted out of it — a session id, a branch name.
     SelectChrome,
+    /// Switch to the 0-based pane tab the pointer is over.
+    ///
+    /// Beats [`Self::SelectChrome`] on the divider: the tab labels are the one
+    /// part of that row that means "go here" rather than "here is some text",
+    /// and a click on a tab reads as activation in every tabbed UI. The rest of
+    /// the divider — the cwd tail, the empty tail past the last tab — stays
+    /// selectable, so copying the path still works.
+    PaneTab(usize),
     /// Give the keyboard to the pane AND anchor a spyc-side text selection over its
     /// visible grid — for a child that ignores mouse reports, so nothing else can
     /// do the selecting (codex's `^T` transcript, a plain shell).
@@ -159,6 +167,15 @@ pub struct MouseSnapshot {
     /// ([`crate::agent::AgentProfile::wheel_scroll`]). Only consulted when the
     /// child does NOT want mouse — forwarding a real mouse report always wins.
     pub pane_scroll_keys: bool,
+    /// The 0-based pane tab whose label the pointer is over, from
+    /// [`super::tab_hit`]. `None` anywhere but the divider's tab bar — including
+    /// the divider's cwd tail and the empty space past the last tab, which stay
+    /// chrome-selectable.
+    ///
+    /// Resolved into the snapshot rather than inside [`route_mouse`] because the
+    /// layout it needs is a `Vec` of spans, and the router is a `const fn` over
+    /// a `Copy` snapshot.
+    pub tab_under_pointer: Option<usize>,
 }
 
 impl MouseSnapshot {
@@ -436,6 +453,11 @@ pub const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseSink {
             if matches!(region, Region::RightColumn) {
                 return MouseSink::FocusAndSelectRows(crate::app::state::Side::Right);
             }
+            // A tab label is the one part of the divider that means "activate
+            // me", so it outranks selecting the row's text.
+            if let Some(index) = snap.tab_under_pointer {
+                return MouseSink::PaneTab(index);
+            }
             // The single-line chrome surfaces hold text and no keyboard focus, so a
             // press there can only mean "select this". The divider carries the tab
             // bar, where a custom session name is the thing worth copying.
@@ -570,7 +592,53 @@ mod tests {
             has_scroll_pager: false,
             pane_closed: false,
             pane_scroll_keys: false,
+            tab_under_pointer: None,
         }
+    }
+
+    /// Left-clicking a tab label activates that tab instead of selecting text.
+    #[test]
+    fn a_left_press_on_a_tab_label_switches_to_it() {
+        let mut s = snap(Some(Region::Divider));
+        s.tab_under_pointer = Some(2);
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::PaneTab(2));
+    }
+
+    /// The rest of the divider stays selectable — the live cwd printed in its
+    /// tail is the thing worth copying from that row.
+    #[test]
+    fn the_dividers_non_tab_columns_still_select() {
+        let s = snap(Some(Region::Divider));
+        assert_eq!(s.tab_under_pointer, None);
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::SelectChrome);
+    }
+
+    /// Tab activation is LEFT only. Middle stays paste and right stays the
+    /// leader menu everywhere — a tab label is not an exception to that, and
+    /// making it one would remove the only way to reach those over the divider.
+    #[test]
+    fn middle_and_right_are_unaffected_over_a_tab() {
+        let mut s = snap(Some(Region::Divider));
+        s.tab_under_pointer = Some(0);
+        assert_eq!(route_mouse(s, Gesture::Middle), MouseSink::Paste);
+        assert_eq!(route_mouse(s, Gesture::Right), MouseSink::LeaderMenu);
+    }
+
+    /// A modal or an open prompt still wins: tab activation must not become a
+    /// hole in the guards that keep a click from reaching past an overlay or
+    /// latching a chord while prompting.
+    #[test]
+    fn a_modal_or_prompt_still_beats_tab_activation() {
+        use crate::app::modal::Modal;
+        let mut s = snap(Some(Region::Divider));
+        s.tab_under_pointer = Some(1);
+        s.is_prompting = true;
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::Swallow);
+
+        let mut s = snap(Some(Region::Divider));
+        s.tab_under_pointer = Some(1);
+        s.modal = Some(Modal::FindPicker);
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::Swallow);
     }
 
     #[test]

--- a/src/app/mouse/tab_hit.rs
+++ b/src/app/mouse/tab_hit.rs
@@ -1,0 +1,218 @@
+//! Pure divider tab-bar layout: column widths, and which tab a pointer column
+//! falls in.
+//!
+//! Sibling of [`super::route`]'s `region_at` — that hit-tests the pointer
+//! against `FrameLayout`'s rects, this resolves the finer question of *which
+//! tab* within the divider's one row.
+//!
+//! **`tab_widths` is the single source of truth for the tab bar's geometry**,
+//! consumed by both the renderer (`render/chrome.rs`, for its advance and
+//! overflow break) and the hit-test here. Deriving the widths twice is the
+//! obvious shortcut and it silently breaks: any drift makes a click land on the
+//! neighbouring tab, and only for the tabs *after* the one that drifted — which
+//! reads as "clicks are off by one sometimes" rather than as a width bug.
+
+use crate::pane::tabs::PaneTabs;
+
+/// A tab's clickable extent on the divider: absolute screen columns
+/// `start..end`, end exclusive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TabSpan {
+    pub index: usize,
+    pub start: u16,
+    pub end: u16,
+}
+
+/// Per-tab width in display columns, in tab order.
+///
+/// Mirrors what `render_divider` paints for each tab: the `─` separator, the
+/// `[N]` bracket, exactly one status cell, and the space-padded label.
+///
+/// The status cell is one column for every tab except a suspended one, whose
+/// 💤 is two columns wide — the one deliberate width difference in the bar (a
+/// sticky toggle, unlike the per-frame flicker the reserved blank prevents).
+pub fn tab_widths(tabs: &PaneTabs, is_scrolling: bool) -> Vec<u16> {
+    let active = tabs.active_index();
+    tabs.tabs()
+        .iter()
+        .enumerate()
+        .map(|(i, entry)| {
+            // The active tab's label is uppercased in scroll mode, and case can
+            // change display width (ß → SS), so measure the label spyc will
+            // actually paint rather than the stored one.
+            let label = if i == active && is_scrolling {
+                entry.info.label.to_uppercase()
+            } else {
+                entry.info.label.clone()
+            };
+            let cell = if entry.info.suspended { 2 } else { 1 };
+            let w = 1 // "─" separator
+                + crate::ui::display_width(&format!("[{}]", i + 1))
+                + cell
+                + crate::ui::display_width(&format!(" {label} "));
+            u16::try_from(w).unwrap_or(u16::MAX)
+        })
+        .collect()
+}
+
+/// Lay the tab bar out left-to-right from `origin_x`, dropping tabs that would
+/// overflow `width` — the same overflow rule the renderer applies, so a tab
+/// scrolled off the divider is not clickable either.
+pub fn tab_spans(origin_x: u16, width: u16, widths: &[u16]) -> Vec<TabSpan> {
+    let mut spans = Vec::with_capacity(widths.len());
+    let mut used: u16 = 0;
+    for (index, &w) in widths.iter().enumerate() {
+        // Saturating: a pathological label can't wrap the budget into "fits".
+        if used.saturating_add(w) > width {
+            break;
+        }
+        spans.push(TabSpan {
+            index,
+            start: origin_x.saturating_add(used),
+            end: origin_x.saturating_add(used).saturating_add(w),
+        });
+        used = used.saturating_add(w);
+    }
+    spans
+}
+
+/// Which tab column `x` falls in, if any.
+///
+/// The leading `─` separator counts as part of its tab: it is one column, and
+/// excluding it would leave a dead stripe between adjacent labels that reads as
+/// a missed click.
+pub fn tab_at(x: u16, spans: &[TabSpan]) -> Option<usize> {
+    spans
+        .iter()
+        .find(|s| x >= s.start && x < s.end)
+        .map(|s| s.index)
+}
+
+/// Which tab the pointer is over, given the divider's rect.
+///
+/// `None` when there is no divider (pane closed), the pointer is on another row,
+/// or it is past the last tab — all of which must stay chrome-selectable.
+pub fn tab_at_point(
+    divider: Option<ratatui::layout::Rect>,
+    widths: &[u16],
+    col: u16,
+    row: u16,
+) -> Option<usize> {
+    let d = divider?;
+    if row < d.y || row >= d.y.saturating_add(d.height) {
+        return None;
+    }
+    tab_at(col, &tab_spans(d.x, d.width, widths))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::layout::Rect;
+
+    const fn divider(y: u16) -> Rect {
+        Rect {
+            x: 0,
+            y,
+            width: 80,
+            height: 1,
+        }
+    }
+
+    #[test]
+    fn a_pointer_on_another_row_is_not_a_tab_hit() {
+        assert_eq!(tab_at_point(Some(divider(10)), &[6, 6], 2, 10), Some(0));
+        assert_eq!(
+            tab_at_point(Some(divider(10)), &[6, 6], 2, 9),
+            None,
+            "row above"
+        );
+        assert_eq!(
+            tab_at_point(Some(divider(10)), &[6, 6], 2, 11),
+            None,
+            "row below"
+        );
+    }
+
+    /// No pane → no divider → the tab bar can't be hit at all.
+    #[test]
+    fn no_divider_is_never_a_tab_hit() {
+        assert_eq!(tab_at_point(None, &[6], 2, 0), None);
+    }
+
+    /// The divider's tail (cwd, empty space) must fall through so it stays
+    /// chrome-selectable — the whole row activating a tab would make the path
+    /// uncopyable.
+    #[test]
+    fn the_dividers_tail_is_not_a_tab_hit() {
+        assert_eq!(tab_at_point(Some(divider(0)), &[6, 6], 11, 0), Some(1));
+        assert_eq!(tab_at_point(Some(divider(0)), &[6, 6], 12, 0), None, "tail");
+        assert_eq!(
+            tab_at_point(Some(divider(0)), &[6, 6], 79, 0),
+            None,
+            "far tail"
+        );
+    }
+
+    #[test]
+    fn spans_are_contiguous_from_the_origin() {
+        let spans = tab_spans(10, 100, &[8, 6, 7]);
+        assert_eq!(
+            spans,
+            vec![
+                TabSpan {
+                    index: 0,
+                    start: 10,
+                    end: 18
+                },
+                TabSpan {
+                    index: 1,
+                    start: 18,
+                    end: 24
+                },
+                TabSpan {
+                    index: 2,
+                    start: 24,
+                    end: 31
+                },
+            ]
+        );
+    }
+
+    /// A tab the renderer dropped for overflow must not be clickable — else a
+    /// click in the divider's empty tail activates an invisible tab.
+    #[test]
+    fn overflow_drops_the_tabs_the_renderer_drops() {
+        let spans = tab_spans(0, 15, &[8, 6, 7]);
+        assert_eq!(spans.len(), 2, "third tab overflows 15 cols: {spans:?}");
+        assert_eq!(spans[1].end, 14);
+        assert_eq!(tab_at(14, &spans), None, "past the last tab: no hit");
+    }
+
+    #[test]
+    fn hit_test_maps_every_column_of_a_tab_including_its_separator() {
+        let spans = tab_spans(5, 100, &[4, 4]);
+        for x in 5..9 {
+            assert_eq!(tab_at(x, &spans), Some(0), "col {x}");
+        }
+        for x in 9..13 {
+            assert_eq!(tab_at(x, &spans), Some(1), "col {x}");
+        }
+        assert_eq!(tab_at(4, &spans), None, "left of the bar");
+        assert_eq!(tab_at(13, &spans), None, "right of the bar");
+    }
+
+    #[test]
+    fn no_tabs_means_no_hits() {
+        let spans = tab_spans(0, 80, &[]);
+        assert!(spans.is_empty());
+        assert_eq!(tab_at(0, &spans), None);
+    }
+
+    /// Zero width (a fully collapsed divider) must not produce a span that
+    /// swallows the whole row.
+    #[test]
+    fn zero_width_yields_nothing() {
+        assert!(tab_spans(0, 0, &[4]).is_empty());
+    }
+}

--- a/src/app/render/chrome.rs
+++ b/src/app/render/chrome.rs
@@ -77,6 +77,7 @@ impl App {
         // `prepare_panes`, #347), so no `&mut` re-borrow is involved.
         let mut active_idx: Option<usize> = None;
         if let Some(tabs) = &self.runtime.pane_tabs {
+            let tab_widths = super::super::mouse::tab_hit::tab_widths(tabs, is_scrolling);
             for (i, entry) in tabs.tabs().iter().enumerate() {
                 let is_active = i == tabs.active_index();
                 if is_active {
@@ -126,22 +127,27 @@ impl App {
                     " " // reserved blank — keeps the width fixed
                 };
                 let label_text = format!(" {label} ");
-                // Measure in display columns, not bytes — `sep` ("─") is 3
-                // bytes but 1 column, and a label can carry multibyte chars;
-                // `used`/`width` are column budgets. Bracket + 1 cell + label is
-                // constant for a given N (`dot_w` is 1 for an agent, and
-                // `shell_cell` is "" then — so the cell is always exactly 1 col).
-                let dot_w = dot
-                    .as_ref()
-                    .map_or(0, |s| crate::ui::display_width(s.content.as_ref()));
-                let tab_len = crate::ui::display_width(sep)
-                    + crate::ui::display_width(&bracket)
-                    + crate::ui::display_width(shell_cell)
-                    + dot_w
-                    + crate::ui::display_width(&label_text);
+                // Width comes from `tab_hit::tab_widths`, NOT recomputed here:
+                // the mouse hit-test lays the bar out from that same list, and
+                // any drift between the two puts clicks on the wrong tab. See
+                // the module doc on `mouse::tab_hit`.
+                let tab_len = tab_widths.get(i).copied().unwrap_or(0) as usize;
                 if used + tab_len > width {
                     break;
                 }
+                // The painted spans must add up to the budgeted width, or the
+                // bar drifts from what the hit-test believes.
+                debug_assert_eq!(
+                    tab_len,
+                    crate::ui::display_width(sep)
+                        + crate::ui::display_width(&bracket)
+                        + dot
+                            .as_ref()
+                            .map_or(0, |s| crate::ui::display_width(s.content.as_ref()))
+                        + crate::ui::display_width(shell_cell)
+                        + crate::ui::display_width(&label_text),
+                    "tab {i} paints a different width than tab_widths budgeted"
+                );
                 spans.push(Span::styled(sep, rule_style));
                 // An agent tab's eye-pull comes from the colored dot, so its
                 // label stays calm (inactive style); a shell tab keeps the teal


### PR DESCRIPTION
## What

Left-clicking a tab in the divider switches to it.

```
── [1]· claude ─[2] claude ─[3]+ zsh ─[4]+ zsh ── ~/src/spyc ──
                  ^ click → activate tab 2   (was: started a text selection)
```

The tab bar looked clickable and wasn't: `Region::Divider` routed every
left-press to `MouseSink::SelectChrome`, so the one part of that row meaning "go
here" behaved like static text.

## How

`src/app/mouse/tab_hit.rs` is the new pure half — sibling of `route.rs`'s
`region_at`, which hit-tests rects; this resolves *which tab* inside the
divider's single row:

- `tab_widths` — per-tab column budget (`─` + `[N]` + one status cell + padded label)
- `tab_spans` — left-to-right layout, with the renderer's own overflow rule
- `tab_at` / `tab_at_point` — column → tab index

**The renderer now takes its advance and its overflow break from `tab_widths`**
instead of recomputing them (`render/chrome.rs`). That matters more than it
looks: two derivations of the bar's geometry drift, and a drift lands clicks on
the neighbouring tab — but only for tabs *after* the one that drifted, so it
presents as "clicks are off by one sometimes" rather than as a width bug. A
`debug_assert` pins the painted spans against the budgeted width, so a future
status glyph of unexpected width fails loudly in tests rather than quietly
skewing the hit test.

`MouseSink::PaneTab` dispatches through `Action::PaneTabByIndex`, so a click
inherits the keyboard's whole switch — stash/restore of the per-tab scrollback
pager, focus into the pane, and the `^a z` fullscreen-list case. Hand-rolling
`tabs.switch_to` here would have started subtly different and drifted.

## Scope held deliberately narrow

| click target | behaviour |
|---|---|
| a tab label | activates that tab |
| divider's cwd tail | still `SelectChrome` — the path stays copyable |
| space past the last tab | still `SelectChrome` |
| a tab dropped for overflow | not clickable (matches what's painted) |
| middle / right over a tab | unchanged: paste / leader menu |
| any of the above under a modal or open prompt | still swallowed first |

That last row is the one worth stating: tab activation is not a hole in the
guards that stop a click reaching past an overlay, or latching a leader chord
while prompting (where `Space p`/`P` could move `PROJECT_HOME`).

## Verification

`make check` green — run unpiped (`make exit: 0` **and** `=== GATE: PASS ===`).

12 new tests: 8 on the pure layout (contiguity, the overflow break, every column
of a tab including its separator, the row guard, no-divider, the tail, empty, and
zero-width) and 4 on routing (activation, the tail still selecting, middle/right
unaffected, modal/prompt precedence).

Not yet verified live — needs a human with a mouse. Release binary built for that.

## Test plan

- [ ] click each tab → switches, focus lands in the pane
- [ ] click the cwd tail → still starts a text selection
- [ ] narrow the window until a tab is dropped, click where it was → nothing happens
- [ ] middle-click a tab → paste; right-click a tab → leader popup
- [ ] click a tab while `:` is open → nothing (prompt keeps the input)
- [ ] click the active tab → no visible change, no flicker
- [ ] `^a z` zoomed on the list, click a tab → fullscreens that tab

Generated with [Claude Code](https://claude.com/claude-code)
