### PR TITLE
ci(homebrew): attribute each formula sha256 to its artifact url

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -94,17 +94,30 @@ jobs:
           LA=$(sha "spyc-v${V}-linux-aarch64.tar.gz")
           [ -n "$MAC" ] && [ -n "$LX" ] && [ -n "$LA" ] || { echo "missing a checksum for v${V}"; exit 1; }
           f=tap/Formula/spyc.rb
-          # The three sha256 lines are positional: macOS, then linux intel, then
-          # linux arm — the order they appear in the formula.
-          [ "$(grep -c 'sha256 "' "$f")" = 3 ] || { echo "formula sha256 layout changed — bailing"; exit 1; }
-          awk -v v="$V" -v m="$MAC" -v x="$LX" -v a="$LA" '
-            /^  version "/ { sub(/"[^"]*"/, "\"" v "\"") }
-            /sha256 "/ { n++
-              if (n==1) sub(/"[0-9a-f]+"/, "\"" m "\"")
-              else if (n==2) sub(/"[0-9a-f]+"/, "\"" x "\"")
-              else if (n==3) sub(/"[0-9a-f]+"/, "\"" a "\"") }
-            { print }
-          ' "$f" > "$f.new" && mv "$f.new" "$f"
+          # Each sha256 is attributed to the artifact named by the url above it,
+          # so the formula's arch-block shape is free to change — macOS points
+          # both `on_arm` and `on_intel` at the one universal tarball, so its
+          # hash legitimately lands twice. awk writes to `out` so its stdout
+          # stays free for diagnostics; anything it can't attribute is fatal.
+          awk -v v="$V" -v m="$MAC" -v x="$LX" -v a="$LA" -v out="$f.new" '
+            /^  version "/                      { sub(/"[^"]*"/, "\"" v "\""); vseen = 1 }
+            /url ".*-macos-universal\.tar\.gz"/ { want = m; tag = "macos-universal" }
+            /url ".*-linux-x86_64\.tar\.gz"/    { want = x; tag = "linux-x86_64" }
+            /url ".*-linux-aarch64\.tar\.gz"/   { want = a; tag = "linux-aarch64" }
+            /sha256 "/ {
+              if (want == "") { print "line " NR ": sha256 with no artifact url above it"; bad = 1 }
+              else { sub(/"[0-9a-f]+"/, "\"" want "\""); seen[tag] = 1; want = "" }
+            }
+            { print > out }
+            END {
+              if (bad) exit 1
+              if (!vseen) { print "no `version \"...\"` line to bump"; exit 1 }
+              if (want != "") { print "url for " tag " has no sha256 under it"; exit 1 }
+              for (t in seen) n++
+              if (n != 3) { print "expected all 3 artifacts, matched " n; exit 1 }
+            }
+          ' "$f" || { rm -f "$f.new"; echo "formula layout unexpected — bailing"; exit 1; }
+          mv "$f.new" "$f"
           echo "--- updated formula ---"; grep -E 'version "|sha256 "' "$f"
 
       - name: Commit + push to the tap


### PR DESCRIPTION
`brew audit --strict` reports 4 problems on the live tap formula, two of them real: `on_macos` may not contain a bare `url` or `sha256`. The fix is to nest `on_arm`/`on_intel` inside `on_macos`, both pointing at the one universal macOS tarball — which gives the formula a **fourth** `sha256` line, with the macOS hash appearing twice.

The tap bump step rewrote those lines **positionally** (1st = macOS, 2nd = linux x86_64, 3rd = linux aarch64) behind an assertion that there are exactly three. So the audit fix would have failed the next release's tap bump. The guard would have caught it — loudly, and without corrupting the formula — but the bump still wouldn't land.

This makes the rewrite shape-agnostic: each `sha256` is attributed to the artifact named by the `url` above it, so arch-block count and order no longer matter. It hard-fails rather than writing a wrong hash on any of:

- a `sha256` with no artifact url above it
- an artifact url with no `sha256` under it
- a missing `version` line
- fewer than three of the three artifacts matched

`awk` now writes the formula to a temp file so its stdout carries diagnostics, and that temp file is removed on the failure path.

Landing this **before** the tap change means either repo can move first without a broken window — the new logic handles both the current 3-sha formula and the audit-clean 4-sha one.

## Verification

The step's `run` block was extracted from the YAML and executed against real formula files, so what ran is the shipped text:

| case | result |
|---|---|
| current 3-sha formula | version + 3 hashes rewritten correctly |
| audit-clean 4-sha formula | version + 4 hashes, macOS hash correctly twice |
| stray `sha256` | fails, exit 1, names the line |
| artifact url with no `sha256` | fails, names the artifact |
| missing `version` line | fails |
| an artifact absent | fails, reports 2 of 3 matched |
| checksum missing from `SHA256SUMS` | fails (pre-existing check) |

No `.rb.new` leftovers on any failure path. `make check` green via the pre-commit hook.