### PR TITLE
feat(mouse): select and copy the prompt row and the activity HUD

### DIFF
--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -280,6 +280,10 @@ impl super::App {
             } else {
                 None
             },
+            // The renderer records every selectable chrome row each frame, so
+            // this is a lookup rather than a second hit-test — one source for
+            // "what got drawn" and "what a click can select".
+            over_chrome_row: self.chrome_col_at(ev).is_some(),
         };
 
         match route_mouse(snap, gesture) {

--- a/src/app/mouse/route.rs
+++ b/src/app/mouse/route.rs
@@ -163,6 +163,15 @@ pub struct MouseSnapshot {
     pub has_scroll_pager: bool,
     /// The active tab's child has exited — there is nothing to forward to.
     pub pane_closed: bool,
+    /// The pointer is over a row the renderer recorded as selectable chrome
+    /// (`view.chrome_rows`, via `draw_chrome_line`).
+    ///
+    /// Region-independent on purpose, because chrome is drawn OVER the layout:
+    /// the activity HUD paints on the list's rect, so `region_at` reports
+    /// `Region::List` for it and a press there used to start a row selection in
+    /// the list *underneath* the overlay. This is the same precedence problem
+    /// `covering_pager` solves for pagers, and the same answer.
+    pub over_chrome_row: bool,
     /// The pane's agent has a verified scroll keybinding
     /// ([`crate::agent::AgentProfile::wheel_scroll`]). Only consulted when the
     /// child does NOT want mouse — forwarding a real mouse report always wins.
@@ -404,6 +413,12 @@ pub const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseSink {
     if snap.is_prompting {
         return match gesture {
             Gesture::Middle => MouseSink::Paste,
+            // Selecting the prompt row's own text is the exception, and safe:
+            // the latch this arm guards against is a *chord* one — right-click
+            // arms a pending sequence the prompt's key handler never consumes.
+            // A left drag arms nothing and never reaches the resolver, so
+            // copying the command you just typed costs the guard nothing.
+            Gesture::Left if snap.over_chrome_row => MouseSink::SelectChrome,
             Gesture::Left | Gesture::Right | Gesture::Wheel => MouseSink::Swallow,
         };
     }
@@ -432,6 +447,21 @@ pub const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseSink {
             if let Some(slot) = snap.covering_pager {
                 return MouseSink::FocusAndSelect(slot);
             }
+            // A tab label means "activate me", and it has to be tested BEFORE
+            // recorded chrome: the divider is itself drawn through the chrome
+            // funnel, so over a tab both flags are true and chrome-first would
+            // silently turn every tab click back into a text selection.
+            if let Some(index) = snap.tab_under_pointer {
+                return MouseSink::PaneTab(index);
+            }
+            // Recorded chrome outranks the layout beneath it, for the same
+            // reason `covering_pager` does: it is painted on top. This is what
+            // makes the activity HUD selectable instead of selecting list rows
+            // through it, and it covers the prompt row when no prompt is open
+            // (a flash, or an armed chord).
+            if snap.over_chrome_row {
+                return MouseSink::SelectChrome;
+            }
             // Left is click-THROUGH: focus the region, and (for a mouse-aware
             // child) let the event reach it too. The pane is live and visible, so
             // swallowing the first click just to focus would read as broken.
@@ -452,11 +482,6 @@ pub const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseSink {
             }
             if matches!(region, Region::RightColumn) {
                 return MouseSink::FocusAndSelectRows(crate::app::state::Side::Right);
-            }
-            // A tab label is the one part of the divider that means "activate
-            // me", so it outranks selecting the row's text.
-            if let Some(index) = snap.tab_under_pointer {
-                return MouseSink::PaneTab(index);
             }
             // The single-line chrome surfaces hold text and no keyboard focus, so a
             // press there can only mean "select this". The divider carries the tab
@@ -593,7 +618,23 @@ mod tests {
             pane_closed: false,
             pane_scroll_keys: false,
             tab_under_pointer: None,
+            over_chrome_row: false,
         }
+    }
+
+    /// The interaction the two features create: the divider is itself a recorded
+    /// chrome row, so over a tab label BOTH flags are true in production. The tab
+    /// must win, or #279's whole point is undone by chrome selection.
+    #[test]
+    fn a_tab_label_beats_chrome_selection_on_the_same_row() {
+        let mut s = snap(Some(Region::Divider));
+        s.tab_under_pointer = Some(1);
+        s.over_chrome_row = true; // the divider is drawn through the chrome funnel
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::PaneTab(1));
+
+        // Off the labels, the same row still selects — the cwd tail stays copyable.
+        s.tab_under_pointer = None;
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::SelectChrome);
     }
 
     /// Left-clicking a tab label activates that tab instead of selecting text.
@@ -639,6 +680,65 @@ mod tests {
         s.tab_under_pointer = Some(1);
         s.modal = Some(Modal::FindPicker);
         assert_eq!(route_mouse(s, Gesture::Left), MouseSink::Swallow);
+    }
+
+    /// The `:` line is selectable WHILE prompting — the whole point, since the
+    /// command you want to copy only exists while the prompt is open.
+    #[test]
+    fn the_prompt_row_selects_while_prompting() {
+        let mut s = snap(Some(Region::Prompt));
+        s.is_prompting = true;
+        s.over_chrome_row = true;
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::SelectChrome);
+    }
+
+    /// …but only ON the prompt row. Elsewhere the prompt still swallows, so a
+    /// stray click can't act while the keyboard belongs to the prompt.
+    #[test]
+    fn prompting_still_swallows_a_press_off_the_chrome_row() {
+        let mut s = snap(Some(Region::List));
+        s.is_prompting = true;
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::Swallow);
+    }
+
+    /// The chord latch this guard exists for is right-click's, and it must
+    /// survive: arming a leader chord the prompt never consumes leaves the
+    /// which-key popup up and eats the next key, where `Space P` overwrites
+    /// PROJECT_HOME.
+    #[test]
+    fn a_right_click_on_the_prompt_row_still_arms_nothing() {
+        let mut s = snap(Some(Region::Prompt));
+        s.is_prompting = true;
+        s.over_chrome_row = true;
+        assert_eq!(route_mouse(s, Gesture::Right), MouseSink::Swallow);
+        assert_eq!(route_mouse(s, Gesture::Middle), MouseSink::Paste);
+    }
+
+    /// The activity HUD paints over the list, so a press on it must select the
+    /// HUD — not start a row selection in the list underneath.
+    #[test]
+    fn chrome_over_the_list_selects_the_chrome_not_the_rows() {
+        let mut s = snap(Some(Region::List));
+        assert_eq!(
+            route_mouse(s, Gesture::Left),
+            MouseSink::FocusAndSelectRows(Side::Left),
+            "without the overlay, the list still selects rows"
+        );
+        s.over_chrome_row = true;
+        assert_eq!(route_mouse(s, Gesture::Left), MouseSink::SelectChrome);
+    }
+
+    /// A pager still outranks recorded chrome: it is drawn over everything and
+    /// owns the pointer, which is the precedence #228 established.
+    #[test]
+    fn a_covering_pager_still_beats_recorded_chrome() {
+        let mut s = snap(Some(Region::List));
+        s.over_chrome_row = true;
+        s.covering_pager = Some(PagerSlot::Top);
+        assert_eq!(
+            route_mouse(s, Gesture::Left),
+            MouseSink::FocusAndSelect(PagerSlot::Top)
+        );
     }
 
     #[test]

--- a/src/app/mouse/selection.rs
+++ b/src/app/mouse/selection.rs
@@ -119,7 +119,7 @@ impl super::super::App {
     /// Matched on the recorded row's `y`, which is its identity — each chrome
     /// surface is exactly one screen row. Reads what the renderer actually drew, so
     /// the column the user pressed maps to the character they saw.
-    fn chrome_col_at(&self, ev: MouseEvent) -> Option<(u16, u16)> {
+    pub(super) fn chrome_col_at(&self, ev: MouseEvent) -> Option<(u16, u16)> {
         let rows = self.view.chrome_rows.borrow();
         let row = rows.iter().find(|r| r.y == ev.row && ev.column >= r.x)?;
         Some((row.y, ev.column - row.x))

--- a/src/app/render/inner.rs
+++ b/src/app/render/inner.rs
@@ -310,7 +310,6 @@ impl App {
         use ratatui::{
             style::{Modifier, Style},
             text::{Line, Span},
-            widgets::Paragraph,
         };
         if let Mode::Prompting(p) = &self.state.mode {
             // HookConsent is shown as a centered pop-up (`render_hook_consent_popup`),
@@ -319,14 +318,18 @@ impl App {
             if matches!(p.kind, crate::app::PromptKind::HookConsent { .. }) {
                 return;
             }
-            PromptLine {
+            // Same wrapping PromptLine::render would do, but drawn row-by-row
+            // through the chrome funnel so the text is selectable. A long `:`
+            // command wraps, and each visible row is independently selectable.
+            let lines = PromptLine {
                 prefix: &p.prefix,
                 buffer: &p.buffer,
                 theme: &self.view.theme,
                 cursor_pos: p.editor.as_ref().map(|e| e.cursor),
                 vi_mode: p.editor.as_ref().map(|e| e.mode),
             }
-            .render(frame, rect);
+            .wrapped_lines(rect.width);
+            self.draw_chrome_rows(frame, rect, lines);
         } else if let Some(flash) = &self.state.flash {
             let color = match flash.kind {
                 FlashKind::Info => self.view.theme.take,
@@ -336,7 +339,11 @@ impl App {
                 flash.text.clone(),
                 Style::default().fg(color).add_modifier(Modifier::BOLD),
             ));
-            frame.render_widget(Paragraph::new(line), rect);
+            // A flashed error is the single most copy-worthy string spyc
+            // produces — it carries the whole `source()` chain (see the
+            // `flashed_errors_render_their_whole_chain` guard), and it is
+            // exactly what someone pastes into a bug report.
+            self.draw_chrome_line(frame, rect, line);
         } else if let Some(pending) = self.state.resolver.pending_display() {
             let line = Line::from(Span::styled(
                 pending,
@@ -344,7 +351,32 @@ impl App {
                     .fg(self.view.theme.prompt_prefix)
                     .add_modifier(Modifier::BOLD),
             ));
-            frame.render_widget(Paragraph::new(line), rect);
+            self.draw_chrome_line(frame, rect, line);
+        }
+    }
+
+    /// Draw a multi-row chrome surface: one [`Self::draw_chrome_line`] per row,
+    /// so each row records itself and paints its own selection. Rows past
+    /// `rect.height` are dropped, matching the clipping a single `Paragraph`
+    /// over the same rect would apply.
+    fn draw_chrome_rows(
+        &self,
+        frame: &mut Frame,
+        rect: ratatui::layout::Rect,
+        lines: Vec<ratatui::text::Line<'static>>,
+    ) {
+        for (i, line) in lines.into_iter().enumerate() {
+            let Ok(dy) = u16::try_from(i) else { break };
+            if dy >= rect.height {
+                break;
+            }
+            let row = ratatui::layout::Rect {
+                x: rect.x,
+                y: rect.y.saturating_add(dy),
+                width: rect.width,
+                height: 1,
+            };
+            self.draw_chrome_line(frame, row, line);
         }
     }
 

--- a/src/app/render/overlays.rs
+++ b/src/app/render/overlays.rs
@@ -267,7 +267,6 @@ impl App {
         }
         use ratatui::style::{Color, Style};
         use ratatui::text::{Line as HudLine, Span};
-        use ratatui::widgets::Paragraph as ActivityP;
 
         // Line 1 — throughput + frame timing. `pk` is the whole terminal.draw
         // (build + diff + tty emission); `r` is just the render closure (CPU).
@@ -434,7 +433,12 @@ impl App {
             // `N dps` headline used to be dimmed.
             let normal = Style::default().fg(Color::Black).bg(*bg);
             let line = HudLine::from(Span::styled(format!("{pad}{text}"), normal));
-            frame.render_widget(ActivityP::new(line), rect);
+            // Through the chrome funnel, not a bare `render_widget`: that
+            // records the row so the pointer can hit-test it and a drag can
+            // copy it. The HUD's whole purpose is reporting numbers a human
+            // then quotes — pids, timings, `:why-status` counts — so it being
+            // unselectable meant retyping them from a screenshot.
+            self.draw_chrome_line(frame, rect, line);
         }
     }
 

--- a/src/ui/prompt.rs
+++ b/src/ui/prompt.rs
@@ -1,9 +1,6 @@
 use ratatui::{
-    Frame,
-    layout::Rect,
     style::{Modifier, Style},
-    text::{Line, Span, Text},
-    widgets::Paragraph,
+    text::{Line, Span},
 };
 
 use crate::ui::line_edit::Mode as ViMode;
@@ -85,7 +82,7 @@ impl PromptLine<'_> {
     /// Word-wrap the styled runs to `width` columns, slicing each run across
     /// line breaks so styling survives the wrap. The single source of truth for
     /// both the drawn rows and the reserved height ([`Self::line_count`]).
-    fn wrapped_lines(&self, width: u16) -> Vec<Line<'static>> {
+    pub(crate) fn wrapped_lines(&self, width: u16) -> Vec<Line<'static>> {
         let runs = self.runs();
         // Byte spans of each run within the concatenated text.
         let mut full = String::new();
@@ -119,22 +116,12 @@ impl PromptLine<'_> {
             .unwrap_or(u16::MAX)
             .max(1)
     }
-
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
-        // Pre-wrapped to `area.width`, so each line already fits — render them
-        // verbatim (no further ratatui wrapping) into the rows the layout
-        // reserved. A long command line spills downward over the list bottom.
-        frame.render_widget(
-            Paragraph::new(Text::from(self.wrapped_lines(area.width))),
-            area,
-        );
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui::{Terminal, backend::TestBackend};
+    use ratatui::{Terminal, backend::TestBackend, layout::Rect, text::Text, widgets::Paragraph};
 
     fn render_prompt_to_string(prompt: &PromptLine<'_>, w: u16) -> String {
         let backend = TestBackend::new(w, 1);
@@ -142,7 +129,7 @@ mod tests {
         terminal
             .draw(|f| {
                 let area = Rect::new(0, 0, w, 1);
-                prompt.render(f, area);
+                f.render_widget(Paragraph::new(Text::from(prompt.wrapped_lines(w))), area);
             })
             .unwrap();
         let buf = terminal.backend().buffer().clone();
@@ -159,7 +146,12 @@ mod tests {
         let backend = TestBackend::new(w, h);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
-            .draw(|f| prompt.render(f, Rect::new(0, 0, w, h)))
+            .draw(|f| {
+                f.render_widget(
+                    Paragraph::new(Text::from(prompt.wrapped_lines(w))),
+                    Rect::new(0, 0, w, h),
+                );
+            })
             .unwrap();
         let buf = terminal.backend().buffer().clone();
         (0..h)


### PR DESCRIPTION
## What

Drag-select and copy the **prompt row** (the `:` command line, a flashed error, an
armed chord) and the **activity HUD**. Second half of the mouse-selection gap;
the status bar and divider already worked.

The activity HUD case wasn't merely missing — it was **actively wrong**. The HUD
paints over the list's rect, so `region_at` reported `Region::List` and a press
on it started a row selection in the list *underneath the overlay*.

## Why they were dead

`draw_chrome_line` is the funnel that records a row in `view.chrome_rows` (so the
pointer can hit-test it) and paints its selection. Only the status bar and the
divider called it. The prompt drew through `PromptLine::render`, and the HUD
through a bare `render_widget` — neither recorded anything, so there was nothing
to select.

## How

- **HUD** — its paint loop already built per-row 1-high rects, so it's a
  one-call swap to `draw_chrome_line`. Each HUD row becomes independently
  selectable, which suits the per-row selection model.
- **Prompt** — new `draw_chrome_rows` draws row-by-row through the same funnel,
  so a *wrapped* long command line is selectable on whichever row you drag.
- **Routing** — one new snapshot field, `over_chrome_row`, instead of a region
  per surface. Recorded chrome is drawn over the layout, so it has to outrank
  what `region_at` reports beneath it. That is exactly the precedence problem
  `covering_pager` already solves for pagers, and it means any chrome recorded
  in future is selectable for free.

## The one guard I deliberately opened

Selection works **while prompting**, which the `is_prompting` arm otherwise
forbids for every gesture. That guard is about a *chord* latch: right-click arms
a pending sequence the prompt's key handler never consumes, so the which-key
popup stays up and eats the next key — where `Space P` overwrites `PROJECT_HOME`.

A left drag arms nothing and never reaches the resolver, so the exception is
scoped to left-on-a-recorded-chrome-row. Right-click on the prompt row still
swallows, middle still pastes, and a left press *off* the row still swallows.
Three tests pin exactly that, because loosening this arm is the risky part of the
change, not the rendering.

## Removed

`PromptLine::render`. Production now draws through the chrome funnel, so leaving
it would keep a second draw path that could drift from the selectable one — the
same single-source-of-truth reason #279 made the renderer share the tab widths.
Its two tests render `wrapped_lines` directly.

## Verification

`make check` green — run unpiped (`make exit: 0` **and** `=== GATE: PASS ===`).

5 new routing tests: selection while prompting, swallow off-row while prompting,
right-click still arming nothing, chrome-over-list beating row selection, and a
covering pager still beating chrome.

Not verified live — needs a human with a mouse.

## Test plan

- [ ] `:` then type a command, drag across it → selects; release copies
- [ ] trigger an error (e.g. `:chmod` with junk), drag the flash → copies the whole cause chain
- [ ] `A` for the HUD, drag a row → selects the HUD row, **not** list rows under it
- [ ] `A` off, drag the same spot → list rows select again
- [ ] right-click the prompt row while `:` is open → no which-key popup, no chord armed
- [ ] middle-click the prompt row → pastes into the prompt
- [ ] a long `:` line that wraps → each visible row selectable
- [ ] status bar + divider selection unchanged

Generated with [Claude Code](https://claude.com/claude-code)
