### PR TITLE
docs(release): refresh the 2.1 release notes for what actually shipped

### DIFF
--- a/docs/drafts/2.1-release-notes.md
+++ b/docs/drafts/2.1-release-notes.md
@@ -5,97 +5,264 @@
 > is the narrative layer on top of it — what a user would notice, in their
 > words. Numbers in `#nnn` are PRs unless marked "issue".
 >
-> **Status when this draft was written:** several of the changes below are on
-> open PRs, not yet merged. Verify against `git log v2.0.0..HEAD` before
-> publishing, and delete anything that didn't land. Marked **[pending]** below.
+> **Verified against `git log v2.0.3..dc4ba91`** — 87 commits. Every item below
+> is merged; there are no pending entries. All 14 issues in the 2.1 milestone are
+> closed.
 
 ## The short version
 
-A launch-readiness pass. 2.1 is mostly about the first fifteen minutes: the
-papercuts a new user hits before they've formed an opinion, with particular
-attention to Linux, where most of them were hiding.
+Two big things, plus a launch-readiness pass.
+
+**The mouse works, and it's on by default.** **Agents can read a spyc manual you
+install once.** Around those, a sweep through the papercuts a new user hits in
+the first fifteen minutes — with particular attention to Linux, where most of
+them were hiding.
+
+## Added
+
+### The mouse works
+
+The wheel scrolls **whatever is under the pointer**, not whatever has keyboard
+focus — which is the whole point, since you scroll what you're looking at.
+Left-click focuses a region and clicks *through* to a mouse-aware agent;
+middle-click pastes; right-click opens the leader menu.
+
+You can drag to select text in four places, and release copies it: in a **pager**
+(content only — never the line-number gutter or the border, and in a Markdown
+view `m` chooses rendered prose or raw source), in a **pane whose agent ignores
+the mouse** (codex, plain shells — a child that speaks mouse keeps doing its own
+selection), across the **status line or tab divider** (exactly those columns, so
+you can take just a branch name or a session id), and over **file-list rows**
+(release copies their names; hold Ctrl for absolute paths — a drag never changes
+what the next file operation acts on).
+
+Over an agent pane the wheel does whatever that agent can actually receive: for
+children that ignore mouse reports spyc sends **that agent's own verified scroll
+keybinding**, escalating a sustained streak to page keys, and it drives codex's
+`^T` transcript view.
+
+**This is on by default** (`[mouse] capture`). See *Changed* below for what it
+costs and how to get it back. (#212–#214, #218, #219, #221, #224, #226–#229,
+#233, #234)
+
+### An agent skill you install once
+
+`spyc --install-skill` writes an embedded usage guide into each agent's
+**personal** skills directory — Claude Code, codex, and agy — so it applies in
+every project without touching any repo. It teaches the agent spyc's worktree,
+search, and git tools in depth, which is the layer *under* the short MCP
+instructions the agent gets on connect.
+
+spyc offers a `[Y/n]` update when its embedded copy moves past what's installed,
+detects local edits and never overwrites them unprompted, and `:skill
+status|update|remove|ask` manages it from inside the TUI. (#187)
+
+### agy joins the hosted agents
+
+agy gets the same treatment as claude and codex: MCP wiring, a live activity dot,
+session restore, and conversation pinning from its hook payload rather than from
+spawn proximity. (#194, #195, #201–#203, #216)
+
+### Smaller additions
+
+- **`:about`** (`Space a`) — build identity and environment from inside the TUI,
+  so a bug report can include what's actually running. (issue #206, #254)
+- **`[clipboard] command` / `$SPYC_CLIPBOARD`** — run a command of your choosing
+  for yanks, which is also the clean answer for WSL (point it at `clip.exe`).
+  (#261)
+- **`[mouse] invert_scroll`** — flips the wheel direction if it reads backwards on
+  your OS/terminal combination. Default is unchanged behavior. It's named for the
+  mechanism rather than for a convention on purpose: whether "down" should move
+  the content or the cursor depends on both your trackpad setting and your
+  terminal, so a `natural_scroll`-style flag would have been ambiguous in exactly
+  the case you'd reach for it. (#260, issue #225)
+- **`--version` names the exact build** everywhere a version is shown, so an
+  installed-from-source binary can be identified. (#222)
+
+## Changed
+
+**Mouse capture is on by default, and while it's on you lose your terminal's own
+click-drag text selection.** That's inherent — the terminal can't both report the
+drag to spyc and handle it itself. Hold **Shift** to select anyway (Option/Fn on
+iTerm2), or `:mouse off` to give it back immediately, no restart; it survives a
+config reload, and `:mouse auto` returns to following the config. `capture =
+false` turns it off permanently. `^a u` quick-select and `y` in the pager are the
+mouse-free yank paths.
 
 ## Fixed
 
-**Arrow keys now work in agent panes that ask for application cursor mode.**
-If a program running in spyc's pane switched its cursor keys to "application"
-mode — which full-screen TUIs do routinely — spyc kept sending the other form,
-and a strict program simply ignored it. Symptom: arrows did nothing in that
-pane while `^C` still worked, which reads as a frozen pane rather than an
-encoding mismatch. spyc now sends whichever form the program asked for, and
-modified arrows (ctrl/shift/alt) are unaffected in both modes. (#259)
+### Clipboard, on Linux
+
+**Yank to clipboard works.** Every yank chord failed with `No such file or
+directory` because the clipboard call was hardcoded to macOS's `pbcopy`. Linux
+now tries `wl-copy` (Wayland), then `xclip`, then `xsel`, and tells you what to
+install if none are present. (issue #2 — predates 2.1, verified and closed
+during this pass.)
+
+**A yank can't hang the UI.** On X11, `xclip`/`xsel` keep running after a
+successful copy — that's how they serve the selection — and spyc waited for them,
+which could freeze the whole interface. It now stops waiting and lets them go.
+(#261)
+
+### Panes and agents
+
+**Arrow keys now work in agent panes that ask for application cursor mode.** If a
+program running in spyc's pane switched its cursor keys to "application" mode —
+which full-screen TUIs do routinely — spyc kept sending the other form, and a
+strict program simply ignored it. Symptom: arrows did nothing in that pane while
+`^C` still worked, which reads as a frozen pane rather than an encoding mismatch.
+spyc now sends whichever form the program asked for, and modified arrows
+(ctrl/shift/alt) are unaffected in both modes. (#259)
+
+**`^a R` asks before restarting a live child,** and restarts in place rather than
+leaving you somewhere unexpected. (issue #151, #269)
+
+**`^a c` with a shell no longer double-sources your rc file.** The pane wrapper
+kept its own `-i` when the pane command was itself an rc-sourcing shell, and
+because the spawn `exec`s (preserving the pid), a second rc pass collided with rc
+state keyed on that pid — which broke powerlevel10k/gitstatus. (issue #275)
+
+**`^a v` picks the right codex conversation.** A resumed codex session appends to
+its *original* rollout file with frozen metadata, so ranking candidates by start
+time picked a stale one — and the first fix then made a fresh pane prefer the
+most recently *active* rollout instead of its own. Both halves are now right:
+identity first for a fresh pane, liveness for a resume. (issue #230, #250, #268)
+
+**A blocked activity dot clears when you decline a prompt,** not only when you
+answer it — and `^c` clears it too, alongside Enter and Esc. (#257, #258)
+
+**A wheel tick down no longer opens codex's transcript;** only a sustained scroll
+*up* does, which is the gesture that means "I want to see history". (#264)
+
+### Pager
+
+**Pager action messages appear in the pager,** instead of flashing in the status
+bar the pager is covering — where you couldn't see them. (issue #166, #270)
+
+**`V` highlights blank lines.** In visual-line mode a blank line painted only its
+(zero-width) content, so the selection had holes in it. (issue #120, #271)
+
+**`[EOF]` sits on the last line of a markdown file,** not the row below it.
+(#251)
+
+### Diffs
+
+**Split-diff columns keep their color to the edge.** In `gd`'s side-by-side view,
+when one side of a change wrapped to more lines than the other, the shorter
+side's leftover rows lost their background and reverted to your terminal's
+default — a ragged, half-tinted block. (#263)
+
+**The side-by-side separator stays on one column for tab-indented files,** and
+wrap width is measured in grapheme clusters rather than chars, so emoji and
+combining marks don't push it around. (#205, #215)
+
+### Git
+
+**Git status stops re-walking forever.** The 1 Hz poll keyed its cache on the raw
+`HEAD` file's mtime while the status layer resolved `HEAD` to the ref it points
+at — so on any normal branch the two disagreed permanently and the walk re-ran
+every tick. Both now read the same resolved mtime, and the shared config's mtime
+is part of the cache key too. (#193, #255)
+
+**A failed worktree removal tells you what actually went wrong.** All three causes
+— the path doesn't exist, it exists but isn't a worktree, or its status couldn't
+be read — collapsed into one message that blamed the target path. Each now says
+which, and the third carries git's own cause chain. (#278)
+
+### Errors and lifecycle
+
+**Failures name their cause.** A directory read that failed reported only which
+directory, and a flashed error printed just its outermost context — which is how
+a macOS privacy denial reached a user as an unactionable `chdir: reading
+directory <path>`. Errors now render their whole chain, with a guard to keep it
+that way. (#190, #191)
+
+**Your terminal is restored on `SIGTERM`/`SIGHUP`,** so a killed or
+hung-up session doesn't leave you in raw mode with no cursor. (#277)
 
 **`:q` saves your session, like `Q` always did.** Quitting with `:q` skipped the
 session save *and* the "N running processes — press again to quit" warning, so
 anyone who habitually typed `:q` was building no session history at all and
 `spyc -r` had nothing to restore. Both quit paths now run the same lifecycle.
-(issue #3 — the fix itself predates 2.1; verified and closed during this pass.)
+(issue #3 — predates 2.1, verified and closed during this pass.)
 
-**Yank to clipboard works on Linux.** Every yank chord failed with
-`No such file or directory` because the clipboard call was hardcoded to macOS's
-`pbcopy`. Linux now tries `wl-copy` (Wayland), then `xclip`, then `xsel`, and
-tells you what to install if none are present. (issue #2 — also predates 2.1,
-verified and closed during this pass.)
+### MCP
 
-**[pending]** **A yank can't hang the UI, and you can point it at your own
-command.** On X11, `xclip`/`xsel` keep running after a successful copy — that's
-how they serve the selection — and spyc waited for them, which could freeze the
-whole interface. It now stops waiting and lets them go. New `[clipboard]
-command` / `$SPYC_CLIPBOARD` runs a command of your choosing instead, which is
-also the clean answer for WSL (point it at `clip.exe`). (#261)
+**A `root` override is validated against the session's roots,** so a read tool
+can't be pointed outside them; an agent config spyc can't parse is left alone
+rather than overwritten; and every persistent write goes through the atomic
+writer. (#217, #237, #238)
 
-**[pending]** **Split-diff columns keep their color to the edge.** In `gd`'s
-side-by-side view, when one side of a change wrapped to more lines than the
-other, the shorter side's leftover rows lost their background and reverted to
-your terminal's default — a ragged, half-tinted block. (#263)
+## Docs
 
-## Added
+- **`docs/HARNESS.md`** — the per-agent quirks you actually hit: screen modes,
+  where each agent's scrollback lives, resume mechanics, recommended settings.
+  (issue #232, #272)
+- **`docs/KEYBINDINGS.md`** — the missing bindings filled in, so the reference
+  matches `?`. (#276)
+- **`SECURITY.md`** was rewritten to describe the distribution and signing chain
+  that 2.0 actually shipped (#236). The realistic threats are named —
+  release-pipeline compromise as the highest-consequence one, plus local misuse
+  of the per-PID MCP socket — alongside the keyless-signing posture that
+  addresses the first, and the fact that spyc parses a lot of untrusted input
+  (any file you open, any child process's escape output, git objects, images),
+  which is what `fuzz/` is for.
 
-**[pending]** **`:about`** — build identity and environment from inside the TUI,
-so a bug report can include what's actually running. (issue #206)
+  It also states plainly that **MCP is not a privilege boundary against the agent
+  you connect**: an agent with spyc's tools can do what you could do. That was
+  always true; it's now written down rather than assumed.
 
-**[pending]** **`[mouse] invert_scroll`** — flips the wheel direction if it
-reads backwards on your OS/terminal combination. Default is unchanged behavior.
-It's named for the mechanism rather than for a convention on purpose: whether
-"down" should move the content or the cursor depends on both your trackpad
-setting and your terminal, so a `natural_scroll`-style flag would have been
-ambiguous in exactly the case you'd reach for it. (#260, issue #225)
+## Under the hood
 
-## Security
+Not user-visible, but this is where the release's risk actually lived:
 
-`SECURITY.md` was rewritten to describe the distribution and signing chain that
-2.0 actually shipped (#236): the realistic threats are named — release-pipeline
-compromise as the highest-consequence one, plus local misuse of the per-PID MCP
-socket — alongside the keyless-signing posture that addresses the first, and the
-fact that spyc parses a lot of untrusted input (any file you open, any child
-process's escape output, git objects, images) which is what `fuzz/` is for.
-
-It also states plainly that **MCP is not a privilege boundary against the agent
-you connect**: an agent with spyc's tools can do what you could do. That was
-always true; it's now written down rather than assumed.
+- The **fuzz targets ran weekly instead of never** — they were configured but
+  never firing. (#240, #242)
+- Two **source-scan guards were failing open**: one read a 827-line module as 22
+  lines because a comment mentioned `#[cfg(test)]`. A guard that silently checks
+  nothing is worse than no guard. (#249)
+- The **test suite could write to the real repo** when run under a git hook, and
+  the **pre-commit hook leaked `GIT_DIR` into every tool it ran** — so
+  `cargo-deny`'s advisory-db refresh could hard-reset whatever branch you had
+  checked out. That one cost a multi-day investigation. (#248, #262)
+- **`make check-ci`** ends in a `GATE: PASS`/`GATE: FAIL` sentinel, because a
+  piped `make check` reports the *pager's* exit status and a failed gate reads as
+  green. (#253)
+- The **supply-chain gate moved off the commit path** into `audit.yml`. (#273,
+  #274)
+- `src/app/mouse/` was **decomposed into route/selection/scroll/forward** as it
+  grew. (#244–#246, #252)
 
 ## Housekeeping
 
 The issue tracker got a triage pass, since it's part of what a visitor to the
 repo reads. Several reported bugs turned out to be already fixed or not
-reproducible on current `main` and were closed with the evidence stated rather
+reproducible on current `main`, and were closed with the evidence stated rather
 than carried forward:
 
 | Issue | Outcome |
 |---|---|
 | #2 clipboard on Linux | fixed (pre-2.1); verified on `main` |
 | #3 `:q` session save | fixed (pre-2.1); verified on `main` |
+| #16 paste into pager search | no leak to the lower pane; pinned by a regression test (#265) |
 | #17 `^\` wedges the session | not reproducible across a 5-case matrix |
 | #21 mouse scroll + Enter | works; verified live, not by reading |
+| #26 `cw` in the `!` prompt | mostly correct; the one real defect split out as #267 (2.2) |
+| #35 human-friendly release notes | closed — this document is the answer |
 | #148 WSL support | WSL2 works; the one live symptom matches a fix already shipped in v2.0.1 (#169) |
+| #153 rate-limit git status re-walk | a proposed optimization, never implemented; closed because its justification had largely evaporated, stated plainly rather than as a fix |
 | #179 word-diff highlight bleed | stale duplicate of #205 / #215 |
+| #206 `:about` | shipped (#254) |
 
 Left open deliberately: #20 (waiting on an upstream codex bug) and #140 (waiting
 on an upstream GitHub Action to ship a Node-24 runtime — spyc's floating `v2` pin
 means it needs no change on our side when it does).
 
-The coverage and refactor chores (#174–#178) moved to 2.2 — they were the old
-milestone's plan, not this release's.
+**Milestones:** 2.1 is empty (14 closed). 2.0 is empty. 2.2 carries 8 — the
+coverage and refactor chores (#174–#178) that were the old milestone's plan
+rather than this release's, plus #5 (demo GIF), #12 (`:tutor`), and #267 (the
+`cw` end-of-buffer defect, which already has two `#[ignore]`d vi-correct tests
+in-tree — the fix is deleting the `#[ignore]`).
 
 ## Errata
 
@@ -106,19 +273,25 @@ post-release regressions get backported and announced under this heading.)
 
 ### Notes for the owner, delete before publishing
 
-- **Verify the `[pending]` items landed.** `gh pr list --state merged --search
-  'merged:>=2026-08-07'` is the quick check.
+- **The mouse default-on flip is the biggest behavioral change in 2.1** and the
+  thing most likely to generate a "2.1 broke my terminal" report — losing
+  click-drag selection is surprising if you don't know about Shift. Consider
+  leading the announcement with it, and mentioning `:mouse off` in the same
+  breath. It also had the most churn — three PRs to build it, then seven
+  follow-up fixes (#218, #219, #221, #226, #228, #229, #264) and four more
+  features layered on — so it's worth deliberately dogfooding before the tag.
 - **#2 and #3 are in the 2.1 milestone but were fixed in the 1.x era.** They're
   attached because they were *resolved* (verified + closed) during 2.1 prep. The
-  wording above says so; adjust if you'd rather they not appear as 2.1 items at
-  all.
-- **`:about` (#206) and DECCKM (#259) were separate sessions' work** — the
-  descriptions above are written from the issue/PR, not from having reviewed
-  them. Worth a read before publishing.
-- **The 2.0 milestone still has 3 open issues** (#5 demo GIF, #12 `:tutor`,
-  #35 human-friendly changelog) — #35 is arguably this document's job, so it may
-  want closing or moving.
-- One thing found during this pass and fixed separately, not user-facing but
-  worth knowing: the pre-commit hook leaked `GIT_DIR` into every tool it ran, so
-  `cargo-deny`'s advisory-db refresh could hard-reset whatever branch you had
-  checked out. Fixed in #262.
+  wording above says so; adjust if you'd rather they not appear as 2.1 items.
+- **Most of this release is other sessions' work** — the mouse campaign, the
+  agent skill, agy, `:about`. Those descriptions are written from the PRs and
+  from `FEATURES.md`, not from having reviewed the code. Worth a read before
+  publishing.
+- **One thing never tested on real hardware:** the Linux clipboard path (#261).
+  The 150ms helper-reap budget is a reasoned number, not a measured one — if it's
+  wrong, the symptom is a visible stall on every yank on X11.
+- **Dispatch `audit.yml` before tagging.** Supply-chain checks moved off the PR
+  path in #273, so a dependency change since then hasn't been license/ban
+  checked. `gh workflow run audit.yml`.
+- 87 commits is a lot for a minor. If the announcement wants a shorter spine:
+  mouse, agent skill, agy, Linux clipboard, and "a lot of papercuts" covers it.

--- a/docs/drafts/2.1-release-notes.md
+++ b/docs/drafts/2.1-release-notes.md
@@ -5,7 +5,7 @@
 > is the narrative layer on top of it — what a user would notice, in their
 > words. Numbers in `#nnn` are PRs unless marked "issue".
 >
-> **Verified against `git log v2.0.3..dc4ba91`** — 87 commits. Every item below
+> **Verified against `git log v2.0.3..309f838`** — 88 commits. Every item below
 > is merged; there are no pending entries. All 14 issues in the 2.1 milestone are
 > closed.
 
@@ -41,9 +41,12 @@ children that ignore mouse reports spyc sends **that agent's own verified scroll
 keybinding**, escalating a sustained streak to page keys, and it drives codex's
 `^T` transcript view.
 
+**Clicking a pane tab switches to it** — the tab bar looked clickable and wasn't,
+so the one part of that row meaning "go here" behaved like static text. (#279)
+
 **This is on by default** (`[mouse] capture`). See *Changed* below for what it
 costs and how to get it back. (#212–#214, #218, #219, #221, #224, #226–#229,
-#233, #234)
+#233, #234, #279)
 
 ### An agent skill you install once
 
@@ -293,5 +296,8 @@ post-release regressions get backported and announced under this heading.)
 - **Dispatch `audit.yml` before tagging.** Supply-chain checks moved off the PR
   path in #273, so a dependency change since then hasn't been license/ban
   checked. `gh workflow run audit.yml`.
-- 87 commits is a lot for a minor. If the announcement wants a shorter spine:
+- 88 commits is a lot for a minor. If the announcement wants a shorter spine:
   mouse, agent skill, agy, Linux clipboard, and "a lot of papercuts" covers it.
+- **Re-check the range at tag time.** This was verified at `309f838`; `#279`
+  (click a pane tab) landed while the refresh was being written, which is a sign
+  the range will move again before the tag.

--- a/docs/drafts/2.1-release-notes.md
+++ b/docs/drafts/2.1-release-notes.md
@@ -5,7 +5,7 @@
 > is the narrative layer on top of it — what a user would notice, in their
 > words. Numbers in `#nnn` are PRs unless marked "issue".
 >
-> **Verified against `git log v2.0.3..6fab158`** — 89 commits. Every item below
+> **Verified against `git log v2.0.3..4540b3f`** — 90 commits. Every item below
 > is merged; there are no pending entries. All 14 issues in the 2.1 milestone are
 > closed.
 
@@ -80,8 +80,10 @@ spawn proximity. (#194, #195, #201–#203, #216)
   the content or the cursor depends on both your trackpad setting and your
   terminal, so a `natural_scroll`-style flag would have been ambiguous in exactly
   the case you'd reach for it. (#260, issue #225)
-- **`--version` names the exact build** everywhere a version is shown, so an
-  installed-from-source binary can be identified. (#222)
+- **`--version` names the exact build** — `2.1.0-CURRENT (<sha>)` — so a
+  build from source can be identified precisely. This matters more than it used
+  to: `main` now carries a static `N.M.0-CURRENT` instead of bumping every PR, so
+  the SHA is the only thing distinguishing two dev builds. (#222, #283)
 
 ## Changed
 
@@ -297,11 +299,11 @@ post-release regressions get backported and announced under this heading.)
 - **Dispatch `audit.yml` before tagging.** Supply-chain checks moved off the PR
   path in #273, so a dependency change since then hasn't been license/ban
   checked. `gh workflow run audit.yml`.
-- 89 commits is a lot for a minor. If the announcement wants a shorter spine:
+- 90 commits is a lot for a minor. If the announcement wants a shorter spine:
   mouse, agent skill, agy, Linux clipboard, and "a lot of papercuts" covers it.
-- **Re-check the range at tag time.** Verified at `6fab158`. `#279` (click a pane
-  tab) and `#281` (select the prompt row and activity HUD) both landed *while*
-  this refresh was being written — the mouse work is still actively shipping, so
-  assume the range moves again before the tag. The mouse section is written to
-  describe surfaces rather than PRs so it survives that churn; the PR list in its
-  last line is the part that goes stale.
+- **Re-check the range at tag time.** Verified at `4540b3f`. Three PRs landed
+  *while* this refresh was being written — `#279` (click a pane tab), `#281`
+  (select the prompt row and activity HUD), `#283` (`--version` actually prints
+  the SHA) — so assume the range moves again before the tag. The mouse section is
+  deliberately written around *surfaces* rather than PRs so it survives that
+  churn; the PR list at the end of it is the part that goes stale.

--- a/docs/drafts/2.1-release-notes.md
+++ b/docs/drafts/2.1-release-notes.md
@@ -5,7 +5,7 @@
 > is the narrative layer on top of it — what a user would notice, in their
 > words. Numbers in `#nnn` are PRs unless marked "issue".
 >
-> **Verified against `git log v2.0.3..309f838`** — 88 commits. Every item below
+> **Verified against `git log v2.0.3..6fab158`** — 89 commits. Every item below
 > is merged; there are no pending entries. All 14 issues in the 2.1 milestone are
 > closed.
 
@@ -31,8 +31,9 @@ You can drag to select text in four places, and release copies it: in a **pager*
 (content only — never the line-number gutter or the border, and in a Markdown
 view `m` chooses rendered prose or raw source), in a **pane whose agent ignores
 the mouse** (codex, plain shells — a child that speaks mouse keeps doing its own
-selection), across the **status line or tab divider** (exactly those columns, so
-you can take just a branch name or a session id), and over **file-list rows**
+selection), across **any chrome row** — status line, tab divider, the `:` command
+line or a flashed error, the activity HUD — copying exactly those columns, so you
+can take just a branch name or a session id, and over **file-list rows**
 (release copies their names; hold Ctrl for absolute paths — a drag never changes
 what the next file operation acts on).
 
@@ -46,7 +47,7 @@ so the one part of that row meaning "go here" behaved like static text. (#279)
 
 **This is on by default** (`[mouse] capture`). See *Changed* below for what it
 costs and how to get it back. (#212–#214, #218, #219, #221, #224, #226–#229,
-#233, #234, #279)
+#233, #234, #279, #281)
 
 ### An agent skill you install once
 
@@ -296,8 +297,11 @@ post-release regressions get backported and announced under this heading.)
 - **Dispatch `audit.yml` before tagging.** Supply-chain checks moved off the PR
   path in #273, so a dependency change since then hasn't been license/ban
   checked. `gh workflow run audit.yml`.
-- 88 commits is a lot for a minor. If the announcement wants a shorter spine:
+- 89 commits is a lot for a minor. If the announcement wants a shorter spine:
   mouse, agent skill, agy, Linux clipboard, and "a lot of papercuts" covers it.
-- **Re-check the range at tag time.** This was verified at `309f838`; `#279`
-  (click a pane tab) landed while the refresh was being written, which is a sign
-  the range will move again before the tag.
+- **Re-check the range at tag time.** Verified at `6fab158`. `#279` (click a pane
+  tab) and `#281` (select the prompt row and activity HUD) both landed *while*
+  this refresh was being written — the mouse work is still actively shipping, so
+  assume the range moves again before the tag. The mouse section is written to
+  describe surfaces rather than PRs so it survives that churn; the PR list in its
+  last line is the part that goes stale.


### PR DESCRIPTION
The draft was written mid-engagement and scoped to that engagement: launch papercuts, with five entries marked `[pending]` because their PRs were still open. All five landed — and the release is **87 commits**, so the draft was missing both of its headline features.

Rewritten against `git log v2.0.3..dc4ba91`.

## What changed

- **Native mouse support now leads.** It's the largest user-visible change in 2.1 and it ships **on by default**. Its cost gets its own `## Changed` section, because while capture is on the terminal's own click-drag selection is gone, and Shift / `:mouse off` are how you get it back — the most likely source of a "2.1 broke my terminal" report.
- **The installable agent skill and agy support were absent entirely.**
- **Fixes are grouped by what a user would notice** — clipboard, panes/agents, pager, diffs, git, lifecycle, MCP — rather than listed flat.
- **New `## Under the hood`** for where the release's risk actually lived: guards that were failing open, the test suite writing to the real repo under a git hook, the pre-commit hook's `GIT_DIR` leak.
- **Triage table grew to eleven rows**, and milestone state is now stated: 2.1 and 2.0 empty, 2.2 carrying eight.
- **Owner notes refreshed** — the `[pending]` verification note is gone; added the mouse-default dogfooding call, the untested-on-hardware Linux clipboard path, and a reminder to dispatch `audit.yml` before tagging (supply-chain checks moved off the PR path in #273).

## Four claims corrected against the source

Carried over from the first draft and wrong:

| claim | corrected to |
|---|---|
| #278 refusals name "which claim, or which uncommitted state" | it distinguishes three *failure* causes (path absent / not a worktree / status unreadable), the third with git's cause chain |
| #153 "the justification no longer held" | a proposed optimization, never implemented; closed because its justification evaporated — the mechanism is unchanged |
| #193 "what made markers feel laggy" | a cache-key mismatch — the poll read `HEAD`'s raw mtime while the status layer read the resolved ref. The laggy-markers work was earlier and separate |
| mouse "roughly ten follow-up fixes" | seven, enumerated |

## Verification

Every `#nnn` in the file was cross-checked to resolve either to a PR in `v2.0.3..HEAD` or to a real issue in the state claimed — 84 citations, all resolving. Mouse-default-on was confirmed from `src/config/mod.rs:354` (`capture: true`) rather than from the campaign docs, and the `mlugg/setup-zig@v2` floating pin behind the #140 note was confirmed in `release.yml`.

Still a draft in `docs/drafts/` — not published, and the owner-notes section is marked for deletion before it is.