### PR TITLE
fix(cli): --version prints the git SHA the docs promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,11 @@ it's heading for.
 
 ```sh
 $ spyc --version
-spyc 2.1.0-CURRENT
+spyc <x.y.z>-CURRENT (<sha>)
 ```
+
+The trailing SHA is the exact build: the version line is static for a whole
+minor cycle, so it's the only thing that tells two CURRENT builds apart.
 
 That suffix is how you tell a development build from the release of the same
 number — `2.1.0-CURRENT` is *on the way to* 2.1.0, never 2.1.0 itself. The

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,16 @@ use crate::app::App;
 
 /// spyc — vi-keyboard-driven file commander
 #[derive(Parser)]
-#[command(name = "spyc", version, about = "vi-keyboard-driven file commander")]
+// `version = VERSION`, not clap's bare `version`: the bare form prints
+// `CARGO_PKG_VERSION` alone, which on the CURRENT stream is the SAME string for
+// every build of a whole minor cycle. The SHA is the only thing distinguishing
+// them, and it is what RELEASE_ENGINEERING.md offers in place of the retired
+// bump-every-PR rule.
+#[command(
+    name = "spyc",
+    version = VERSION,
+    about = "vi-keyboard-driven file commander"
+)]
 struct Cli {
     /// Open the saved-session restore picker on startup
     #[arg(short, long)]
@@ -166,7 +175,10 @@ struct Cli {
     #[arg(long, value_name = "STATE")]
     report_status: Option<String>,
 
-    /// Show extended build info with --version
+    /// Print extended build info (sha, build time, rustc, TERM, os) and exit.
+    /// Standalone, NOT a modifier for --version: clap handles --version itself
+    /// and exits before this is read, so `--version --verbose` prints the plain
+    /// version line.
     #[arg(long)]
     verbose: bool,
 
@@ -926,6 +938,40 @@ pub fn force_full_repaint(terminal: &mut Tui) -> Result<()> {
     let area = ratatui::layout::Rect::from(terminal.size()?);
     terminal.resize(area)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod version_flag_tests {
+    /// `--version` must carry the git SHA.
+    ///
+    /// RELEASE_ENGINEERING.md offers exact build identity via the SHA as the
+    /// replacement for the retired bump-every-PR rule, and on the CURRENT
+    /// stream `CARGO_PKG_VERSION` is identical for every build of a whole minor
+    /// cycle — so clap's bare `version` leaves two builds months apart
+    /// indistinguishable. This shipped broken once: the SHA reached `VERSION`
+    /// (which MCP reports, so `get_spyc_context` showed it) while `--version`
+    /// kept printing the bare package version, and the docs claimed otherwise.
+    #[test]
+    fn the_version_flag_carries_the_git_sha() {
+        use clap::CommandFactory as _;
+        let rendered = super::Cli::command()
+            .get_version()
+            .expect("clap knows a version")
+            .to_string();
+        assert_eq!(rendered, super::VERSION, "--version must print VERSION");
+        assert!(
+            rendered.contains(env!("CARGO_PKG_VERSION")),
+            "keeps the package version: {rendered}"
+        );
+        assert!(
+            rendered.contains(env!("SPYC_GIT_SHA")),
+            "must name the build's SHA: {rendered}"
+        );
+        assert!(
+            rendered.len() > env!("CARGO_PKG_VERSION").len(),
+            "the bare package version is not enough: {rendered}"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## The bug

`docs/RELEASE_ENGINEERING.md:64` states:

> A dev build is self-identifying: `spyc --version` prints `2.1.0-CURRENT (<sha>)`.
> The SHA gives exact build identity, **which is what the former bump-every-PR
> rule provided.**

It printed:

```
$ spyc --version
spyc 2.1.0-CURRENT
```

The SHA reached `crate::VERSION` — which MCP reports, so `get_spyc_context` has
been showing it all along — but clap's bare `version` renders `CARGO_PKG_VERSION`
alone. On the CURRENT stream that string is **static for a whole minor cycle**, so
every build of 2.1 identified itself identically. The exact-build-identity
guarantee the version scheme rests on didn't exist at the CLI.

Found while trying to confirm which commit a test binary was built from — the
precise job the flag exists to do.

## The fix

Point clap at `VERSION` instead of the bare attribute:

```
$ spyc --version
spyc 2.1.0-CURRENT (309f838)     # matches git rev-parse --short HEAD
$ spyc -V
spyc 2.1.0-CURRENT (309f838)
```

A test pins the contract: clap's rendered version must equal `VERSION`, contain
`SPYC_GIT_SHA`, and be longer than the bare package version. It shipped broken
once in a way that no test would have noticed, and the failure mode is silent —
you don't discover it until you need the SHA and it isn't there.

## Also fixed: `--verbose`'s help was wrong

It read "Show extended build info with --version". clap handles `--version`
itself and exits before the flag is read, so `--version --verbose` prints the
plain line — the extended block only appears for a **standalone** `--verbose`.
The flag works; its description didn't. (This is what sent me looking, since
`--version --verbose` looked broken.) Behaviour unchanged, help text corrected.

## Compatibility

Nothing in CI, the brew formula, or apt packaging parses `spyc --version` — I
grepped `.github/`, `Makefile`, `scripts/`, `INSTALL.md`. The only consumers are
prose: `README.md` (documented the *broken* output — updated, with an `<x.y.z>`
placeholder per the no-hardcoded-versions rule) and the bug-report template,
which just asks for the string and now gets a more useful one.

`RELEASE_ENGINEERING.md` already described the intended behaviour and needed no
change — the code now matches the doc rather than the reverse.

## Verification

`make check` green — unpiped (`make exit: 0` **and** `=== GATE: PASS ===`).
Output compared before/after against `git rev-parse --short HEAD`, and
`--verbose` re-checked standalone.

Generated with [Claude Code](https://claude.com/claude-code)
