### PR TITLE
docs(features): the git gutter's glyphs are spyc's, not porcelain's

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -73,14 +73,24 @@ do from here?", modeled on Neovim's which-key.
   on it; Esc cancels. No persistent index — walks lazily on open.
 - Multi-column layout that adapts to terminal width
 - Color-coded entries: directories, executables, symlinks, files
-- **Git status markers** — two-character left-gutter pair mirroring
-  `git status -s`: column 0 = staged side, column 1 = unstaged side.
-  `M ` ready-to-commit, ` M` working-tree-only, `MM` partially
-  staged + further edits, ` ?` untracked, `R~` staged rename +
-  unstaged tweaks, `!!` conflicted. Each char colored independently
-  (modified=amber, added/untracked=green, deleted=red, renamed=
-  lavender, conflicted=bold red). Directories containing changes
-  are tinted too.
+- **Git status markers** — two-character left-gutter pair whose *positions*
+  mirror `git status -s`: column 0 = staged side, column 1 = unstaged side.
+  The glyphs are spyc's own, not git's letters: `~` modified, `+` added,
+  `-` deleted, `>` renamed, `!` conflicted, `?` untracked. So `~ ` is
+  ready-to-commit, ` ~` working-tree-only, `~~` partially staged with
+  further edits, `>~` a staged rename with unstaged tweaks, ` ?` untracked
+  (the leading space keeps `?` in the unstaged column), and `!!` conflicted
+  — a conflict sets both halves. Each char is colored independently
+  (modified=amber, added/untracked=green, deleted=red, renamed=lavender,
+  conflicted=bold red). Directories containing changes are tinted too.
+
+  > **`!!` here means CONFLICTED, not ignored.** In `git status -s`, `!!` is
+  > an ignored file — the least urgent state there is; in spyc's gutter it's a
+  > merge conflict, the most urgent. Only the two-column *layout* is borrowed
+  > from porcelain, so don't read the pair as git codes. Nothing on screen is
+  > actually ambiguous — ignored files are dropped when status is decoded and
+  > never reach the gutter — but the notation inverts git's urgency, which is
+  > worth knowing before you skim past one.
 - **`]g` / `[g`** jump the cursor to the next / previous file or dir
   with a non-clean git status. Wraps end-to-end so the chord is
   hold-to-cycle. Flashes "no git changes in this directory" when

--- a/src/app/state/git.rs
+++ b/src/app/state/git.rs
@@ -40,7 +40,7 @@ impl AppState {
     /// ([`Self::refresh_git_state_for`]) can't see such a change (no
     /// `.git/index`/`HEAD` mtime moves), and the listing-refresh path only
     /// invalidates the **focused** column — so without this an UNFOCUSED
-    /// column's `~`/` M` markers stay stale after an external edit until a git
+    /// column's `~ `/` ~` markers stay stale after an external edit until a git
     /// op or chdir. Sets the existing `pending_worktree_rewalk` escape hatch,
     /// which the next 1 Hz poll honors (re-walking once, off-thread). Flagging
     /// the focused column too is harmless — its listing refresh clears the flag
@@ -78,7 +78,7 @@ impl AppState {
         // A throttled working-tree change (refresh_listing deferred its
         // invalidation) forces a re-walk: the mtime key can't see an unstaged
         // edit, so honoring this flag is the only thing that converges a stale
-        // ` M`/clean marker without waiting for a chdir.
+        // ` ~`/clean marker without waiting for a chdir.
         let force_rewalk =
             std::mem::take(&mut self.col_mut(side).git_cache.pending_worktree_rewalk);
         if !force_rewalk && key.is_some() && key == self.col(side).git_cache.git_poll_cache {
@@ -115,7 +115,7 @@ impl AppState {
     ///
     /// `force` requests a fresh walk even when the mtime cache would be reused —
     /// a working-tree edit moves no `.git/index`/`HEAD` mtime, so the poll and
-    /// the listing refresh flag it to converge a stale ` M`/clean marker. When a
+    /// the listing refresh flag it to converge a stale ` ~`/clean marker. When a
     /// walk is needed and the worker is live, it runs off-thread and this returns
     /// the CURRENT cache's markers (stale but same-repo), NOT an empty map, and
     /// does not clear the cache — [`Self::apply_git_worker_result`] swaps in the

--- a/src/app/state/listing.rs
+++ b/src/app/state/listing.rs
@@ -245,7 +245,7 @@ impl AppState {
         // updates when the user changes directories. Event-
         // driven refresh would normally invalidate the raw
         // cache (file mtimes moved but `.git/index` may not
-        // have — and we need fresh content for ` M`
+        // have — and we need fresh content for ` ~`
         // markers).
         //
         // But: an active filesystem (claude writing findings, build
@@ -254,7 +254,7 @@ impl AppState {
         // burst doesn't re-walk `git status` on every event. The 1 Hz
         // safety poll in `refresh_git_state` still catches `.git/index`
         // changes immediately; the only trade-off is up to ~1 s lag in
-        // working-tree ` M` markers for edits within the window.
+        // working-tree ` ~` markers for edits within the window.
         let throttle = std::time::Duration::from_secs(1);
         let should_invalidate = self
             .col(side)

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -370,7 +370,7 @@ pub struct GitCache {
     /// `refresh_listing` every 3 s and burn CPU on
     /// back-to-back worker runs. The 1 s / 10 s safety poll still
     /// invalidates on actual `.git/index` mtime changes, so the only
-    /// trade-off is a small lag in working-tree ` M` markers for
+    /// trade-off is a small lag in working-tree ` ~` markers for
     /// edits within the throttle window.
     pub last_git_invalidation: Option<std::time::Instant>,
     /// When the last git worker request was *sent* (after dedup, etc.).
@@ -379,7 +379,7 @@ pub struct GitCache {
     /// (which on huge trees can be 200-500 ms).
     pub last_git_request_at: Option<std::time::Instant>,
     /// A working-tree fs-event arrived but `refresh_listing` *throttled* its
-    /// cache invalidation, so the new ` M`/clean state was never re-walked.
+    /// cache invalidation, so the new ` ~`/clean state was never re-walked.
     /// The 1 Hz poll's own mtime short-circuit can't cover it — an unstaged
     /// edit moves no `.git/index`/`HEAD` mtime — so without this flag a change
     /// landing inside the throttle window (with no trailing event) would stay

--- a/src/ui/list_view.rs
+++ b/src/ui/list_view.rs
@@ -459,14 +459,19 @@ fn change_glyph(change: GitChange, theme: &Theme) -> (char, Style) {
 }
 
 /// Two-character marker for the left gutter: column 0 = staged side,
-/// column 1 = unstaged side. Mirrors `git status -s`. Untracked files
-/// have no staged side (porcelain `??`) and render as ` ?` so the `?`
-/// lines up with the unstaged column.
+/// column 1 = unstaged side. The *positions* mirror `git status -s`; the
+/// glyphs are [`change_glyph`]'s, not git's letters. Untracked files have no
+/// staged side (porcelain `??`) and render as ` ?` so the `?` lines up with
+/// the unstaged column.
 ///
 /// Each char carries its own style — staged and unstaged colors don't
 /// have to match, which is the whole point: at a glance the user can
-/// tell `M ` (ready to commit) from ` M` (still working) from `MM`
+/// tell `~ ` (ready to commit) from ` ~` (still working) from `~~`
 /// (partially staged + further edits).
+///
+/// Note `!!` (conflicted, both halves) means the OPPOSITE urgency to
+/// porcelain's `!!` (ignored). Ignored files are dropped in
+/// `git::status`, so they never reach this function.
 fn git_marker_pair(git: GitFileStatus, theme: &Theme) -> [(char, Style); 2] {
     if git.is_clean() {
         return [(' ', Style::default()), (' ', Style::default())];


### PR DESCRIPTION
## The note asked for

`!!` in spyc's gutter means **conflicted**. In `git status -s` it means
**ignored** — the least urgent state porcelain has, against the most urgent state
spyc has. Only the two-column *layout* is borrowed from git.

Nothing on screen is actually ambiguous: ignored entries are skipped in the gix
status walk (`git/status.rs`, the `IwItem::DirectoryContents` arm) and never
become a `StatusEntry`, so they can't reach the gutter. But the notation inverts
git's urgency, which is worth knowing before you skim past one.

## What I found while writing it

The surrounding examples were wrong, in a way that would have made the note read
as nonsense. `FEATURES.md` illustrated the gutter with **git's letters**:

```
`M ` ready-to-commit, ` M` working-tree-only, `MM` partially staged …, `R~` staged rename …
```

`change_glyph` renders `~ + - > ! ?` — never `M`, `A`, `D`, `R`. So the docs
showed markers spyc has never painted, and `!!` was the one example that happened
to be right. Corrected to `~ `, ` ~`, `~~`, `>~`, ` ?`, `!!`, with the glyph
vocabulary now stated explicitly rather than implied by example.

Same defect in three other places, all fixed:

| site | was | now |
|---|---|---|
| `FEATURES.md` gutter bullet | git letters | spyc glyphs + the `!!` note |
| `git_marker_pair` doc comment | "tell `M ` from ` M` from `MM`" | `~ ` / ` ~` / `~~`, plus the `!!` caveat |
| `state/{mod,git,listing}.rs` × 4 | ` M` as shorthand for unstaged-modify | ` ~` |

## Deliberately left alone

- **`git/status/tests.rs`** — its `M `/`MM` comments annotate literal porcelain
  *input* strings (`parse(" M AGENTS.md\n", …)`). Those are genuinely git
  notation and correct as written. I nearly swept them with the rest; checking
  each site individually is what caught it.
- **`CHANGELOG.md`** — historical entries describing the markers of their day.
  Frozen hand-written history, per the CHANGELOG contract.

## Verification

`make check` green — unpiped (`make exit: 0` **and** `=== GATE: PASS ===`).
No test reads `FEATURES.md`, so the compile only covers the comment edits; the
`comments_carry_no_reasoning_leakage` guard passes on the new text.

Generated with [Claude Code](https://claude.com/claude-code)
