### PR TITLE
fix(agent): restore agy's blocked dot by dropping a needle agy never prints

### DIFF
--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -58,6 +58,15 @@ needs-permission→blocked, turn-end→done): **claude** (`.claude/settings.json
 **codex** (`.codex/config.toml`), **agy** (`.agents/hooks.json` — working/done only;
 agy has no approval event, so its `blocked` comes from spyc reading the approval
 prompt off the pane).
+
+agy's `done` needs **agy >= 1.1.10**: earlier versions evaluated `hooks.json` after
+their own termination checks, so the `Stop` handler spyc installs was unreachable
+and that half silently degraded to output timing. Its whole event vocabulary is
+`PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop` — none of
+which fires on a user-approval prompt, so the scrape is not a stopgap awaiting a
+better event. `PreToolUse` is not the missing one: it must answer with a `decision`,
+so it arbitrates permissions rather than observing them, and leaving that answer out
+makes agy re-drive the tool instead of finishing the turn.
 It asks first — a `[Y/n]` on the first launch per repo, saved; change it later
 with **`:hooks on|on!|off`**.
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -558,16 +558,14 @@ impl AgentProfile for CodexProfile {
 /// state that actually earns the user's attention — comes from this screen
 /// scrape instead.
 ///
-/// All three phrases are required (see [`detect_rules::Matcher::All`]): an
-/// agent discussing permissions prints any one of them readily, and a false
-/// red "needs me" square is worse than no fallback.
+/// Both phrases are required (see [`detect_rules::Matcher::All`]): an agent
+/// discussing permissions prints either one readily, and a false red "needs me"
+/// square is worse than no fallback. Every needle must be a string agy actually
+/// prints — a third one here (`esc to cancel`) that it never does made the
+/// conjunction unsatisfiable, silently killing agy's only `blocked` signal.
 static AGY_DETECTION_RULES: &[DetectionRule] = &[DetectionRule {
     region: detect_rules::Region::BottomNonEmptyLines(15),
-    matcher: detect_rules::Matcher::All(&[
-        "Requesting permission for:",
-        "Do you want to proceed?",
-        "esc to cancel",
-    ]),
+    matcher: detect_rules::Matcher::All(&["Requesting permission for:", "Do you want to proceed?"]),
     state: crate::pane::AgentActivity::Blocked,
     visible_blocker: Some("awaiting tool-execution approval"),
 }];
@@ -652,6 +650,10 @@ impl AgentProfile for AgyProfile {
         // A named hook-set in `.agents/hooks.json`, read at startup → written
         // pre-spawn. Covers `working` + `done` only; `blocked` has no event to
         // hang on and comes from AGY_DETECTION_RULES instead.
+        //
+        // `done` needs agy >= 1.1.10: before it, `Stop` sat unreachable behind
+        // agy's built-in termination checks, so the hook was installed and never
+        // ran. On an older agy that half degrades to output timing.
         Some(StatusHookSupport {
             ensure: crate::mcp::ensure_agy_status_hooks,
             cleanup: crate::mcp::cleanup_agy_status_hooks,
@@ -791,6 +793,37 @@ pub fn detect(cmd: &str) -> &'static dyn AgentProfile {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// agy's approval prompt must scrape as `Blocked` — the state that earns the
+    /// user's attention, and the only one agy fires no hook for.
+    ///
+    /// `detect_rules` tested the `All` conjunction; nothing tested the RULE, which
+    /// is how a needle agy never prints shipped and made it unsatisfiable. The
+    /// prompt lines below are agy 1.1.11's own literals.
+    #[test]
+    fn agy_approval_prompt_scrapes_as_blocked() {
+        let scan = |ls: &[&str]| {
+            let owned: Vec<String> = ls.iter().copied().map(String::from).collect();
+            detect_rules::scan(&owned, detect("agy").detection_rules())
+        };
+        assert_eq!(
+            scan(&[
+                "Requesting permission for:",
+                "  echo hello",
+                "Do you want to proceed?",
+                "> 1. Yes, accept this change",
+            ]),
+            Some((
+                crate::pane::AgentActivity::Blocked,
+                Some("awaiting tool-execution approval")
+            )),
+            "agy's approval prompt left the dot unlit"
+        );
+        // Either phrase ALONE is prose an agent writes readily — a false red
+        // "needs me" square is worse than no fallback.
+        assert_eq!(scan(&["asking: Do you want to proceed?"]), None);
+        assert_eq!(scan(&["Requesting permission for: ls"]), None);
+    }
 
     /// Which agents claim a wheel scroll key, and what it encodes to on the wire.
     ///

--- a/src/mcp/hooks.rs
+++ b/src/mcp/hooks.rs
@@ -20,7 +20,8 @@
 //!   they must be written BEFORE the pane spawns (see the codex section).
 //! * **agy** (Antigravity) — a `spyc-status` named set in `.agents/hooks.json`;
 //!   PARTIAL (working/done only — no agy event fires on a user-approval prompt,
-//!   so `blocked` comes from the screen scrape instead). See the agy section.
+//!   so `blocked` comes from the screen scrape instead; `done` needs agy
+//!   >= 1.1.10). See the agy section.
 //!
 //! Event → state (verified against the Claude Code hooks docs):
 //! * `UserPromptSubmit`  → `working` (the agent just got a prompt)
@@ -492,12 +493,23 @@ pub fn cleanup_codex_status_hooks(dir: &Path) -> ConfigCleanup {
 // PARTIAL — `working` + `done` only. No event fires when agy asks the USER to
 // approve a tool call, so there's no hook-based `blocked`; that comes from the
 // screen scrape in `agent::AGY_DETECTION_RULES`.
+//
+// Don't reach for `PreToolUse` to close that gap. It answers with a REQUIRED
+// `decision` (`allow`/`deny`/`ask`/`force_ask`), so every valid reply moves agy's
+// permission behavior — and an invalid one (spyc's reporter prints nothing) makes
+// agy re-drive the tool: an unanswered `PreToolUse` was observed running a turn to
+// 17 invocations until it timed out, never reaching `Stop`. `PreInvocation` and
+// `Stop` are safe with empty output — only `"continue"` holds a `Stop` open.
 
 /// Agy's (event, reported-state).
 ///
 /// `Stop` (execution loop terminated), not `PostInvocation` (after each round of
 /// tool calls): a turn makes many invocations, so `PostInvocation` would report
-/// `done` mid-turn, over and over.
+/// `done` mid-turn, over and over. Confirmed by probe on agy 1.1.11 — a two-tool
+/// turn fired `PostInvocation` twice and `Stop` once.
+///
+/// `Stop` requires agy >= 1.1.10, which moved `hooks.json` ahead of agy's built-in
+/// termination checks; before that it was unreachable and `done` never fired.
 const AGY_STATUS_HOOKS: [(&str, &str); 2] = [("PreInvocation", "working"), ("Stop", "done")];
 
 /// The named hook-set spyc owns in agy's `hooks.json` (our namespace there).


### PR DESCRIPTION
agy released hook improvements (1.1.10, 1.1.11). Investigating what they unlock turned up a live defect in the opposite direction.

## The defect

agy has no hook event for a user-approval prompt, so its `blocked` — the one state that earns the user's attention — comes entirely from reading the prompt off the pane. #195 tightened that rule from a single `Contains` into a three-phrase `All` conjunction and added `esc to cancel`.

**agy does not print `esc to cancel`.** It is absent from agy 1.1.11's string table; the other two phrases are both present, adjacent to their sibling dialog literals (`Yes, accept this change`, `Allow access to this file?`). The only matches for the phrase are Go handler identifiers (`handleEscCancel`). A conjunction containing a phrase that never appears can never match — so **agy's tab dot has not gone hot-red on an approval prompt since #195**.

Dropping the needle can only make matching *more* likely, and the two remaining phrases together still satisfy the false-positive concern that motivated #195 — either one alone does not match.

## The test gap that let it ship

`detect_rules` tested the `All` matcher; nothing exercised `AGY_DETECTION_RULES` itself. Adds that test at the requirement level, and **verified it fails against the three-needle rule** before the fix:

```
assertion `left == right` failed: agy's approval prompt left the dot unlit
  left: None
 right: Some((Blocked, Some("awaiting tool-execution approval")))
```

## What agy 1.1.10/1.1.11 actually change (documented, no code needed)

| | |
|---|---|
| `Stop` now fires | The `done` hook spyc already installs works. Before 1.1.10, `hooks.json` was evaluated *after* agy's built-in termination checks, so the handler was unreachable and `done` silently fell back to output timing. Recorded as an **agy >= 1.1.10** floor so a user on an older agy doesn't file it against spyc. |
| `blocked` still has no event | agy's whole vocabulary is `PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop`. The scrape is the permanent answer, not a stopgap. |
| `PreToolUse` is a trap | It answers with a **required** `decision`, so every valid reply moves agy's permission behavior — spyc would be arbitrating permissions, not observing them. Leaving the answer out is worse: a probe returning no decision ran a turn to **17 invocations before timing out**, never reaching `Stop`. Documented so this isn't "improved" into a runaway loop later. |

## Verification

Sources are agy's own embedded hooks documentation (extracted from the binary) plus probe runs against agy 1.1.11 — a hook set writing to a log in the shape spyc writes:

```
PreInvocation → PreToolUse (tool=view_file) → PostInvocation → PreInvocation → PostInvocation → Stop
```

That also confirms spyc's choice of `Stop` over `PostInvocation`: `PostInvocation` fired twice in a two-round turn, `Stop` once. And that spyc's empty-stdout reporter is safe on both events it uses — only `"continue"` holds a `Stop` open.

Separately confirmed the hooks are discovered in real use: a live session shows `workspaceDirs=[/Users/derekmarshall/src/spyc]` and `loaded 1 named hooks from 1 hooks.json file(s)`, which is spyc's `spyc-status` set.

`make check-ci` → `=== GATE: PASS ===`.

## One thing worth a live look

The needle evidence is a binary string-table absence — strong, but not a screen capture. I could not drive agy's TUI far enough to photograph a real prompt. If you trigger one approval prompt in an agy pane and the dot goes red, that closes it; if the prompt shows some *other* third line, it can be added back (verified this time).