### PR TITLE
fix(pager): restore the [EOF] end-of-file signal at the exact-fit boundary

### DIFF
--- a/src/ui/pager/render.rs
+++ b/src/ui/pager/render.rs
@@ -31,9 +31,7 @@ pub fn render(frame: &mut Frame, area: Rect, view: &PagerView, theme: &Theme) {
     //     a border eats two rows of usable content and visually
     //     disrupts the layout the user just had on-screen.
     // The title bar and position indicator only exist on the bordered
-    // block, so build them inside that branch — borderless mode discarded
-    // them before (and fed `position_indicator` an `inner-2` viewport that
-    // doesn't match a border-free body anyway).
+    // block, so build them inside that branch.
     // Multi-column partition is viewport-independent, so compute it ONCE here
     // and share it with the position indicator and the body layout below.
     // Previously each of `position_indicator`, `render_multi_column` (and
@@ -43,15 +41,27 @@ pub fn render(frame: &mut Frame, area: Rect, view: &PagerView, theme: &Theme) {
     let ncols = view.columns.max(1) as usize;
     let multi_col_chunks = (ncols > 1).then(|| partition_lines_static(&view.lines, ncols));
 
+    // Reserve the bottom row for the search/status bar. In multi-column
+    // views (help) the row is always reserved so the viewport height stays
+    // constant when search is activated — otherwise the column layout
+    // would reflow. In single-column views it's only shown when active.
+    // Decided before the block because the position indicator must be measured
+    // against the same viewport the body gets: read off `inner - 2` it ignored
+    // this row and could label a view "All" with a line still off-screen.
+    let show_search_row = view.status_text().is_some() || ncols > 1;
+
     let borderless = view.full_width || matches!(view.mount, Mount::LowerPane);
     let block = if borderless {
         Block::default()
     } else {
+        // The height `content_area` gets below: borders, plus the search row.
+        let content_h = inner_area
+            .height
+            .saturating_sub(2)
+            .saturating_sub(u16::from(show_search_row));
         let pos = match &multi_col_chunks {
-            Some(chunks) => {
-                view.position_indicator_multi(chunks, inner_area.height.saturating_sub(2))
-            }
-            None => view.position_indicator(inner_area.height.saturating_sub(2)),
+            Some(chunks) => view.position_indicator_multi(chunks, content_h),
+            None => view.position_indicator(content_h),
         };
         let title_style = Style::default()
             .fg(theme.prompt_prefix)
@@ -90,11 +100,6 @@ pub fn render(frame: &mut Frame, area: Rect, view: &PagerView, theme: &Theme) {
     let body_area = block.inner(inner_area);
     frame.render_widget(block, inner_area);
 
-    // Reserve the bottom row for the search/status bar. In multi-column
-    // views (help) the row is always reserved so the viewport height stays
-    // constant when search is activated — otherwise the column layout
-    // would reflow. In single-column views it's only shown when active.
-    let show_search_row = view.status_text().is_some() || ncols > 1;
     let (content_area, search_area) = if show_search_row {
         (
             Rect {

--- a/src/ui/pager/scroll_search.rs
+++ b/src/ui/pager/scroll_search.rs
@@ -99,16 +99,41 @@ impl PagerView {
         }
         let base = self.scroll_max_content(viewport_height);
         // Reserve one extra row at the true bottom so the `[EOF]` / `~` end
-        // marker is reachable for files TALLER than the viewport — short files
-        // (`base == 0`) already show it because there's spare room; this gives
-        // long files the same end-of-file signal (the doc scrolls one row past
-        // the last line, like vim/less). Skipped while streaming (no marker
-        // yet) or when `[EOF]` is already a content line (`eof_in_content`).
-        if base > 0 && !self.streaming && !self.eof_in_content {
+        // marker is reachable when the content leaves no spare row for it (the
+        // doc scrolls one row past the last line, like vim/less). Skipped while
+        // streaming (no marker yet) or when `[EOF]` is already a content line.
+        //
+        // `fills_viewport`, not `base > 0`: `base` is 0 both for a doc shorter
+        // than the viewport (spare row, marker renders unaided) and for one that
+        // fills it exactly (no spare row, and no reservation to make one).
+        if self.fills_viewport(viewport_height) && !self.streaming && !self.eof_in_content {
             base.saturating_add(1)
         } else {
             base
         }
+    }
+
+    /// True when the document occupies the whole viewport at its content-pinned
+    /// bottom — i.e. there is no spare row for the `[EOF]` / `~` end marker.
+    /// Wrap-aware, and walks from the end so it stops at `viewport_height` rows
+    /// instead of measuring the whole document.
+    fn fills_viewport(&self, viewport_height: u16) -> bool {
+        let vh = viewport_height as usize;
+        if vh == 0 {
+            return false;
+        }
+        let body_w = self.last_body_w.get() as usize;
+        if !self.wrap || body_w == 0 {
+            return self.lines.len() >= vh;
+        }
+        let mut acc = 0usize;
+        for line in self.lines.iter().rev() {
+            acc = acc.saturating_add(visual_rows(line, body_w, self.tab_width));
+            if acc >= vh {
+                return true;
+            }
+        }
+        false
     }
 
     /// The greatest scroll that pins the last line to the bottom row (the
@@ -210,10 +235,16 @@ impl PagerView {
         longest.saturating_sub(viewport_height as usize)
     }
 
-    /// The "Top" / "Bot" / "All" / "NN%" label from a scroll position and its
-    /// max. Shared by the single- and multi-column indicator paths.
-    fn indicator_string(scroll: usize, max_scroll: usize) -> String {
-        if max_scroll == 0 {
+    /// The "Top" / "Bot" / "All" / "NN%" label from a scroll position, its max,
+    /// and whether the whole document is on screen. Shared by the single- and
+    /// multi-column indicator paths.
+    ///
+    /// `all_visible` is passed in rather than inferred from `max_scroll == 0`:
+    /// a document that exactly fills the viewport is fully visible *and* has a
+    /// reserved end-marker row to scroll into, so the two are no longer the
+    /// same question.
+    fn indicator_string(scroll: usize, max_scroll: usize, all_visible: bool) -> String {
+        if all_visible {
             return "All".to_string();
         }
         if scroll == 0 {
@@ -226,12 +257,28 @@ impl PagerView {
         format!("{pct}%")
     }
 
+    /// True when every content line is on screen right now — the "All" label.
+    /// Distinct from `scroll_max(vh) == 0`, which the end-marker reservation
+    /// makes non-zero for a document that exactly fills the viewport.
+    fn all_content_visible(&self, viewport_height: u16) -> bool {
+        if self.columns.max(1) as usize > 1 {
+            // Multi-col scrolls each chunk independently; "all visible" is
+            // "the longest chunk fits", which is exactly its scroll_max == 0.
+            return self.scroll_max(viewport_height) == 0;
+        }
+        self.scroll == 0 && self.scroll_max_content(viewport_height) == 0
+    }
+
     /// Position indicator: "Top", "Bot", "All", or "NN%".
     /// Percentage is based on scroll progress through the "effective"
     /// document length — in multi-col that's the longest chunk, not the
     /// total line count, since each column's chunk scrolls independently.
     pub fn position_indicator(&self, viewport_height: u16) -> String {
-        Self::indicator_string(self.scroll, self.scroll_max(viewport_height))
+        Self::indicator_string(
+            self.scroll,
+            self.scroll_max(viewport_height),
+            self.all_content_visible(viewport_height),
+        )
     }
 
     /// Like [`Self::position_indicator`] but for a multi-column layout whose
@@ -243,10 +290,8 @@ impl PagerView {
         chunks: &[(usize, usize)],
         viewport_height: u16,
     ) -> String {
-        Self::indicator_string(
-            self.scroll,
-            Self::multi_col_max_scroll(chunks, viewport_height),
-        )
+        let max = Self::multi_col_max_scroll(chunks, viewport_height);
+        Self::indicator_string(self.scroll, max, max == 0)
     }
 
     // ---- Search ----------------------------------------------------------

--- a/src/ui/pager/tests/mod.rs
+++ b/src/ui/pager/tests/mod.rs
@@ -634,6 +634,69 @@ fn long_file_shows_eof_marker_at_bottom() {
     );
 }
 
+/// A document whose line count EXACTLY equals the viewport height used to lose
+/// the `[EOF]` marker: `scroll_max` gated its end-marker row on `base > 0`, and
+/// `base` (= `lines - viewport_h`) is 0 both for a document *shorter* than the
+/// viewport (which has a spare row, so the marker renders anyway) and for one
+/// that fills it exactly (which has no spare row and could not scroll to make
+/// one). Reported on a 136-line file in a 136-row pager viewport.
+#[test]
+fn exact_fit_file_can_still_reach_the_eof_marker() {
+    use ratatui::{Terminal, backend::TestBackend};
+    // 20 terminal rows ⇒ a centered 18-row overlay ⇒ a 16-row content viewport.
+    let lines: Vec<String> = (0..16).map(|i| format!("line {i}")).collect();
+    let mut view = PagerView::new_plain("exact.txt", lines);
+    let theme = Theme::default();
+    let mut term = Terminal::new(TestBackend::new(40, 20)).unwrap();
+    term.draw(|f| render(f, f.area(), &view, &theme)).unwrap();
+    assert_eq!(
+        usize::from(view.last_viewport_h.get()),
+        view.lines.len(),
+        "the test's geometry must actually be an exact fit"
+    );
+    view.scroll_to_bottom_auto();
+    term.draw(|f| render(f, f.area(), &view, &theme)).unwrap();
+    let buf = term.backend().buffer().clone();
+    let mut text = String::new();
+    for y in 0..20 {
+        for x in 0..40 {
+            text.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        text.push('\n');
+    }
+    assert!(
+        text.contains("[EOF]"),
+        "an exactly-viewport-height file must still signal its end:\n{text}"
+    );
+}
+
+/// The end-marker row reservation must not cost an exact-fit document its "All"
+/// label: every line IS on screen at scroll 0. "All" therefore asks "is the
+/// whole document visible right now?", which the reservation makes a different
+/// question from `scroll_max == 0`.
+#[test]
+fn exact_fit_keeps_the_all_label_until_it_scrolls_to_the_marker() {
+    let mut view = PagerView::new_plain("exact.txt", (0..16).map(|i| i.to_string()).collect());
+    assert_eq!(
+        view.scroll_max(16),
+        1,
+        "one row reserved for the end marker"
+    );
+    assert_eq!(view.position_indicator(16), "All");
+    view.scroll = 1;
+    assert_eq!(
+        view.position_indicator(16),
+        "Bot",
+        "on the marker row the first line is gone — no longer 'All'"
+    );
+
+    // A document shorter than the viewport has a spare row already, so it needs
+    // no reservation and can't scroll at all.
+    let short = PagerView::new_plain("short.txt", (0..10).map(|i| i.to_string()).collect());
+    assert_eq!(short.scroll_max(16), 0);
+    assert_eq!(short.position_indicator(16), "All");
+}
+
 // ---- PR4: scroll math (u16 saturation, wrap-row reachability) -----------
 
 /// Finding `ui/pager/mod.rs:141` / `pager_handler/mod.rs:311`: `scroll` was a

--- a/src/ui/pager/tests/mod.rs
+++ b/src/ui/pager/tests/mod.rs
@@ -697,6 +697,38 @@ fn exact_fit_keeps_the_all_label_until_it_scrolls_to_the_marker() {
     assert_eq!(short.position_indicator(16), "All");
 }
 
+/// The position indicator used to be measured against `inner - 2` (the borders)
+/// while the body ALSO gave up a row to the search/status bar — so a
+/// search-active pager, and every multi-column one (which always reserves that
+/// row), did its scroll math one row too tall and could label the view "All"
+/// with a line still off-screen.
+#[test]
+fn indicator_is_measured_against_the_same_viewport_as_the_body() {
+    use ratatui::{Terminal, backend::TestBackend};
+    let lines: Vec<String> = (0..16).map(|i| format!("line {i}")).collect();
+    let mut view = PagerView::new_plain("jump.txt", lines);
+    view.jump_buf = Some("1".into()); // reserves the status row
+    let theme = Theme::default();
+    let mut term = Terminal::new(TestBackend::new(40, 20)).unwrap();
+    term.draw(|f| render(f, f.area(), &view, &theme)).unwrap();
+    let buf = term.backend().buffer().clone();
+    let mut text = String::new();
+    for y in 0..20 {
+        for x in 0..40 {
+            text.push_str(buf.cell((x, y)).unwrap().symbol());
+        }
+        text.push('\n');
+    }
+    assert!(
+        !text.contains("line 15"),
+        "premise: the status row pushes the last line off-screen at scroll 0:\n{text}"
+    );
+    assert!(
+        !text.contains("All"),
+        "the indicator must not claim the whole document is visible:\n{text}"
+    );
+}
+
 // ---- PR4: scroll math (u16 saturation, wrap-row reachability) -----------
 
 /// Finding `ui/pager/mod.rs:141` / `pager_handler/mod.rs:311`: `scroll` was a


### PR DESCRIPTION
## What

Two off-by-one defects in the pager's end-of-content signalling, found from a user report that `[EOF]` was missing on one specific file (`rmatrix/src/charset.rs`, 136 lines) in a very tall terminal.

### 1. `[EOF]` vanished when a file exactly filled the viewport

`scroll_max` reserved a row past the last line — so the end marker is reachable — but gated it on `base > 0`, i.e. "the content is taller than the viewport". `base` is `0` for **two** different documents:

| content vs viewport | `base` | spare row for the marker? | result |
|---|---|---|---|
| shorter | 0 | yes | `[EOF]` renders ✅ |
| **exactly equal** | **0** | **no, and no reservation to make one** | **marker silently gone ❌** |
| taller | >0 | reservation gives one | `[EOF]` renders ✅ |

So the end-of-file signal disappeared at exactly one terminal height per file — which is why it looked like a one-file quirk. Reproduced verbatim at 16 lines in a 16-row viewport:

```
  ┌  exact.txt   (16 lines)  ────────┐
  │ 1 line 0                         │
  ...
  │16 line 15                        │
  └───────────────────────────  All  ┘   ← no [EOF] anywhere
```

Fixed by replacing the proxy with the predicate it stood for: `fills_viewport`, which asks whether the content occupies the whole viewport at its content-pinned bottom. Wrap-aware, and walks from the end so it stops at `viewport_height` rows instead of measuring the whole document.

Knock-on: `scroll_max == 0` no longer means "the whole document is visible", so `"All"` gets its own predicate rather than inferring it. An exact-fit file still reads `All` at the top and now reads `Bot` on the marker row.

### 2. The indicator was measured against a viewport one row too tall

Independent bug found while tracing the first. The indicator read `inner_area.height - 2` (the borders) while the body *also* gives up a row to the search/status bar — so with that row reserved it sized its scroll math one row too tall and could label the view `All`/`Bot` with a line still off-screen. Single-column pagers hit it only with a search or `:N` jump active; **multi-column ones (the help overlay) reserve that row unconditionally, so they were always off by one.**

## Tests

Three added, each verified to fail with its own fix reverted and pass with it:

- `exact_fit_file_can_still_reach_the_eof_marker` — renders the exact-fit geometry and asserts `[EOF]` appears (asserts the geometry really is an exact fit first, so the test can't silently stop testing anything).
- `exact_fit_keeps_the_all_label_until_it_scrolls_to_the_marker` — pins the `All` → `Bot` labelling, and that a shorter file still needs no reservation.
- `indicator_is_measured_against_the_same_viewport_as_the_body` — with the status row reserved, asserts the last line is off-screen *and* that the indicator doesn't claim `All`.

`make check-ci` → `=== GATE: PASS ===` (1905 tests).

## Not changed

No docs touched — neither the `[EOF]` marker nor the `Top`/`Bot`/`All` indicator is described in `FEATURES.md` / `DESIGN.md` / `KEYBINDINGS.md`.