### PR TITLE
feat(agent): report agy's blocked dot from its ask_question hook

### DIFF
--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -61,12 +61,22 @@ prompt off the pane).
 
 agy's `done` needs **agy >= 1.1.10**: earlier versions evaluated `hooks.json` after
 their own termination checks, so the `Stop` handler spyc installs was unreachable
-and that half silently degraded to output timing. Its whole event vocabulary is
-`PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop` — none of
-which fires on a user-approval prompt, so the scrape is not a stopgap awaiting a
-better event. `PreToolUse` is not the missing one: it must answer with a `decision`,
-so it arbitrates permissions rather than observing them, and leaving that answer out
-makes agy re-drive the tool instead of finishing the turn.
+and that half silently degraded to output timing.
+
+agy waits on the user in **two** different ways, and they need different instruments:
+
+| agy waits via | signal | why |
+|---|---|---|
+| its `ask_question` tool | `PreToolUse` hook, matcher `ask_question` | it's a real tool, so a hook sees it exactly when it's called |
+| its tool-permission prompt (`Requesting permission for:`) | screen scrape | no event fires for it, in any agy version |
+
+`PreToolUse` cannot be widened to cover the second. A handler must answer with a
+`decision` (`allow`/`deny`/`ask`/`force_ask`), so matching every tool would put spyc
+in charge of agy's permissions; scoped to `ask_question` the `allow` is a no-op,
+because that tool was always going to wait for you. Omitting the answer is worse
+than either: agy re-drives the tool, which ran a probe turn to 17 invocations before
+it timed out, never reaching `Stop`. spyc's handler therefore prints its decision
+unconditionally and discards the reporter's own output to keep stdout pure JSON.
 It asks first — a `[Y/n]` on the first launch per repo, saved; change it later
 with **`:hooks on|on!|off`**.
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -551,18 +551,22 @@ impl AgentProfile for CodexProfile {
 /// P1-2: agy DOES have `status_hooks()`, but its event vocabulary is
 /// `PreToolUse` / `PostToolUse` / `PreInvocation` / `PostInvocation` / `Stop`
 /// (agy's own `agy-customizations/docs/hooks.md`) — none of which fires when
-/// agy asks the *user* to approve a tool call. `PreToolUse` is the nearest
-/// thing and is the wrong instrument: it runs *instead of* the prompt and must
-/// answer with an `allow`/`deny`/`ask` decision, so hanging a status report on
-/// it would make spyc arbitrate agy's permissions. Hence `blocked` — the one
-/// state that actually earns the user's attention — comes from this screen
-/// scrape instead.
+/// agy asks the *user* to approve a tool call. `PreToolUse` covers the OTHER way
+/// agy waits on you, its `ask_question` tool (see `mcp::hooks`), but it can't cover
+/// this one: matching every tool would put spyc in charge of agy's permissions,
+/// since a `PreToolUse` handler must answer with `allow`/`deny`/`ask`. So the
+/// approval prompt is read off the screen instead.
 ///
 /// Both phrases are required (see [`detect_rules::Matcher::All`]): an agent
 /// discussing permissions prints either one readily, and a false red "needs me"
-/// square is worse than no fallback. Every needle must be a string agy actually
-/// prints — a third one here (`esc to cancel`) that it never does made the
-/// conjunction unsatisfiable, silently killing agy's only `blocked` signal.
+/// square is worse than no fallback. They're the dialog's own two lines, which is
+/// why the footer key-hint is deliberately NOT a third needle: agy renders that
+/// from `"%s to cancel"` and gives each dialog a different one, so it discriminates
+/// nothing and rots on any UI change.
+///
+/// Verify a needle against a real pane, not the binary's string table — a
+/// runtime-formatted string is absent from it, which is exactly how `esc to cancel`
+/// got mistaken for a phrase agy never prints.
 static AGY_DETECTION_RULES: &[DetectionRule] = &[DetectionRule {
     region: detect_rules::Region::BottomNonEmptyLines(15),
     matcher: detect_rules::Matcher::All(&["Requesting permission for:", "Do you want to proceed?"]),
@@ -648,8 +652,9 @@ impl AgentProfile for AgyProfile {
     }
     fn status_hooks(&self) -> Option<StatusHookSupport> {
         // A named hook-set in `.agents/hooks.json`, read at startup → written
-        // pre-spawn. Covers `working` + `done` only; `blocked` has no event to
-        // hang on and comes from AGY_DETECTION_RULES instead.
+        // pre-spawn. Covers `working`, `done`, and `blocked` for the `ask_question`
+        // tool; the tool-permission prompt has no event and comes from
+        // AGY_DETECTION_RULES instead.
         //
         // `done` needs agy >= 1.1.10: before it, `Stop` sat unreachable behind
         // agy's built-in termination checks, so the hook was installed and never
@@ -794,12 +799,13 @@ pub fn detect(cmd: &str) -> &'static dyn AgentProfile {
 mod tests {
     use super::*;
 
-    /// agy's approval prompt must scrape as `Blocked` — the state that earns the
-    /// user's attention, and the only one agy fires no hook for.
+    /// agy's tool-permission prompt must scrape as `Blocked` — the one way agy
+    /// waits on the user that fires no hook.
     ///
-    /// `detect_rules` tested the `All` conjunction; nothing tested the RULE, which
-    /// is how a needle agy never prints shipped and made it unsatisfiable. The
-    /// prompt lines below are agy 1.1.11's own literals.
+    /// `detect_rules` covered the `All` matcher; nothing covered the RULE, so a
+    /// needle could go stale against agy's real output and nothing would fail. The
+    /// sample is transcribed from a live agy 1.1.11 pane, footer included, so it
+    /// stays a check on agy's actual dialog rather than on a guess about it.
     #[test]
     fn agy_approval_prompt_scrapes_as_blocked() {
         let scan = |ls: &[&str]| {
@@ -808,10 +814,17 @@ mod tests {
         };
         assert_eq!(
             scan(&[
+                "\u{25cf} Bash(uname -a) (ctrl+o to expand)",
+                "Command",
                 "Requesting permission for:",
-                "  echo hello",
+                "  uname -a",
                 "Do you want to proceed?",
-                "> 1. Yes, accept this change",
+                "> 1. Yes",
+                "  2. Yes, and always allow in this conversation for commands that start with 'uname'",
+                "  3. Yes, and always allow for commands that start with 'uname' (Persist to settings.json)",
+                "  4. No",
+                "\u{2191}/\u{2193} Navigate \u{b7} tab Amend \u{b7} ctrl+g edit/expand command",
+                "esc to cancel                          Gemini 3.1 Pro \u{b7} high",
             ]),
             Some((
                 crate::pane::AgentActivity::Blocked,

--- a/src/mcp/hooks.rs
+++ b/src/mcp/hooks.rs
@@ -19,9 +19,9 @@
 //!   `.codex/config.toml` we write the MCP entry into; read once at startup, so
 //!   they must be written BEFORE the pane spawns (see the codex section).
 //! * **agy** (Antigravity) — a `spyc-status` named set in `.agents/hooks.json`;
-//!   PARTIAL (working/done only — no agy event fires on a user-approval prompt,
-//!   so `blocked` comes from the screen scrape instead; `done` needs agy
-//!   >= 1.1.10). See the agy section.
+//!   PARTIAL (working/done, plus blocked for its `ask_question` tool — no agy event
+//!   fires on a tool-permission prompt, so that half of `blocked` comes from the
+//!   screen scrape instead; `done` needs agy >= 1.1.10). See the agy section.
 //!
 //! Event → state (verified against the Claude Code hooks docs):
 //! * `UserPromptSubmit`  → `working` (the agent just got a prompt)
@@ -490,16 +490,19 @@ pub fn cleanup_codex_status_hooks(dir: &Path) -> ConfigCleanup {
 // `{hooks,matcher}` group. spyc owns one set, `spyc-status`.
 // Read once at startup (written pre-spawn like codex).
 //
-// PARTIAL — `working` + `done` only. No event fires when agy asks the USER to
-// approve a tool call, so there's no hook-based `blocked`; that comes from the
-// screen scrape in `agent::AGY_DETECTION_RULES`.
+// PARTIAL — `working` + `done`, plus `blocked` for the `ask_question` tool. No
+// event fires when agy asks the USER to approve a *tool call*, so that half of
+// `blocked` comes from the screen scrape in `agent::AGY_DETECTION_RULES`.
 //
-// Don't reach for `PreToolUse` to close that gap. It answers with a REQUIRED
-// `decision` (`allow`/`deny`/`ask`/`force_ask`), so every valid reply moves agy's
-// permission behavior — and an invalid one (spyc's reporter prints nothing) makes
-// agy re-drive the tool: an unanswered `PreToolUse` was observed running a turn to
-// 17 invocations until it timed out, never reaching `Stop`. `PreInvocation` and
-// `Stop` are safe with empty output — only `"continue"` holds a `Stop` open.
+// `PreToolUse` closes that gap for ONE tool only, `ask_question` — the tool whose
+// purpose is to wait for the user, where a decision of `allow` changes nothing that
+// wasn't already going to happen. It is the wrong instrument for anything else: it
+// answers with a REQUIRED `decision` (`allow`/`deny`/`ask`/`force_ask`), so a
+// broader matcher would put spyc in charge of agy's permissions, and omitting the
+// decision makes agy re-drive the tool — an unanswered `PreToolUse` was observed
+// running a turn to 17 invocations until it timed out, never reaching `Stop`.
+// `PreInvocation` and `Stop` are safe with empty output — only `"continue"` holds a
+// `Stop` open.
 
 /// Agy's (event, reported-state).
 ///
@@ -510,7 +513,32 @@ pub fn cleanup_codex_status_hooks(dir: &Path) -> ConfigCleanup {
 ///
 /// `Stop` requires agy >= 1.1.10, which moved `hooks.json` ahead of agy's built-in
 /// termination checks; before that it was unreachable and `done` never fired.
-const AGY_STATUS_HOOKS: [(&str, &str); 2] = [("PreInvocation", "working"), ("Stop", "done")];
+///
+/// `ask_question` is the tool agy calls to put a question to the USER, so it is the
+/// one waiting-on-you state a hook can see. Its tool-permission *prompt* still has
+/// no event and comes from `agent::AGY_DETECTION_RULES`.
+///
+/// An empty matcher marks a lifecycle event (flat handler list); a non-empty one
+/// marks a tool event (the claude/codex `{matcher, hooks}` group).
+const AGY_STATUS_HOOKS: [(&str, &str, &str); 3] = [
+    ("PreInvocation", "", "working"),
+    ("PreToolUse", "ask_question", "blocked"),
+    ("Stop", "", "done"),
+];
+
+/// A tool-event handler for agy. Unlike the lifecycle events, `PreToolUse` REQUIRES
+/// a `decision` on stdout and re-drives the tool without one, so the decision is
+/// printed UNCONDITIONALLY — even when the reporter is missing — and the reporter's
+/// own output is discarded to keep stdout pure JSON. `allow` is a no-op for
+/// `ask_question`, whose whole purpose is to wait for the user: spyc observes the
+/// wait, it never arbitrates it.
+fn agy_tool_reporter_command(exe: &str, state: &str, trace: bool) -> String {
+    let trace = if trace { " --status-trace" } else { "" };
+    let exe = crate::shell::shell_quote(exe);
+    format!(
+        "{exe} --report-status {state}{trace} >/dev/null 2>&1 || true; printf '{{\"decision\":\"allow\"}}'"
+    )
+}
 
 /// The named hook-set spyc owns in agy's `hooks.json` (our namespace there).
 const AGY_HOOK_SET: &str = "spyc-status";
@@ -573,12 +601,21 @@ fn merged_agy_status_hooks_json(existing: Option<&str>, exe: &str, trace: bool) 
     let mut root = merge_root_json(existing)?;
     let obj = root.as_object_mut()?;
     let mut set = serde_json::Map::new();
-    for (event, state) in AGY_STATUS_HOOKS {
-        // Flat handler list directly under the event key (no matcher/group) —
-        // that shape is only for the tool events, which spyc doesn't register.
+    for (event, matcher, state) in AGY_STATUS_HOOKS {
+        let handler = if matcher.is_empty() {
+            json!({ "type": "command", "command": reporter_command(exe, state, trace) })
+        } else {
+            json!({ "type": "command", "command": agy_tool_reporter_command(exe, state, trace) })
+        };
+        // Lifecycle events take a flat handler list; tool events wrap it in a
+        // `{matcher, hooks}` group.
         set.insert(
             event.to_string(),
-            json!([{ "type": "command", "command": reporter_command(exe, state, trace) }]),
+            if matcher.is_empty() {
+                json!([handler])
+            } else {
+                json!([{ "matcher": matcher, "hooks": [handler] }])
+            },
         );
     }
     // We own the whole `spyc-status` key, so an insert replaces a prior ours
@@ -998,10 +1035,22 @@ mod tests {
         assert!(ensure_agy_status_hooks(dir));
         let path = dir.join(".agents/hooks.json");
         let v = read(&path);
-        for (event, state) in AGY_STATUS_HOOKS {
-            // Flat handler list directly under the event key (no matcher/group).
+        for (event, matcher, state) in AGY_STATUS_HOOKS {
+            // Lifecycle events sit in a flat handler list; a tool event is wrapped
+            // in a `{matcher, hooks}` group, so its handler is one level deeper.
+            let base = if matcher.is_empty() {
+                format!("/{AGY_HOOK_SET}/{event}/0")
+            } else {
+                assert_eq!(
+                    v.pointer(&format!("/{AGY_HOOK_SET}/{event}/0/matcher"))
+                        .and_then(Value::as_str),
+                    Some(matcher),
+                    "{event} lost its tool matcher"
+                );
+                format!("/{AGY_HOOK_SET}/{event}/0/hooks/0")
+            };
             let cmd = v
-                .pointer(&format!("/{AGY_HOOK_SET}/{event}/0/command"))
+                .pointer(&format!("{base}/command"))
                 .and_then(Value::as_str)
                 .unwrap_or_default();
             assert!(
@@ -1009,8 +1058,7 @@ mod tests {
                 "{event} → {state}: got {cmd:?}"
             );
             assert_eq!(
-                v.pointer(&format!("/{AGY_HOOK_SET}/{event}/0/type"))
-                    .and_then(Value::as_str),
+                v.pointer(&format!("{base}/type")).and_then(Value::as_str),
                 Some("command")
             );
         }
@@ -1059,6 +1107,62 @@ mod tests {
         );
     }
 
+    /// agy re-drives a tool whose `PreToolUse` handler returns no `decision`, so
+    /// the ONLY thing this command must never do is fail to print one. Both
+    /// hazards are structural, which is why they're asserted on the string:
+    /// the reporter is chained with `;` (not `&&`) and has its stdout discarded,
+    /// so a missing or chatty spyc can neither skip the decision nor corrupt it.
+    /// Getting this wrong cost a 17-invocation runaway turn during development.
+    #[test]
+    fn agy_tool_hook_always_answers_with_a_clean_decision() {
+        let cmd = agy_tool_reporter_command("spyc", "blocked", false);
+        assert_eq!(
+            cmd,
+            "'spyc' --report-status blocked >/dev/null 2>&1 || true; printf '{\"decision\":\"allow\"}'"
+        );
+        // The decision is unconditional: sequenced with `;`, never gated on the
+        // reporter succeeding.
+        let (reporter, decision) = cmd.split_once("; ").expect("reporter then decision");
+        assert!(
+            !reporter.contains("&&"),
+            "decision must not depend on the reporter: {cmd:?}"
+        );
+        assert!(decision.starts_with("printf "), "got {decision:?}");
+        // stdout carries the decision and nothing else.
+        assert!(
+            reporter.contains(">/dev/null 2>&1"),
+            "reporter stdout would pollute the JSON: {cmd:?}"
+        );
+        // Trace mode rides along without disturbing either property.
+        let traced = agy_tool_reporter_command("spyc", "blocked", true);
+        assert!(
+            traced.contains(" --status-trace >/dev/null 2>&1 || true; printf "),
+            "{traced:?}"
+        );
+    }
+
+    /// Running the built command through a real shell is the only way to prove the
+    /// quoting survives: agy parses stdout as JSON, and a stray quote or an
+    /// unescaped brace is a runaway turn rather than a visible error.
+    #[test]
+    fn agy_tool_hook_emits_parseable_json_through_a_shell() {
+        // A binary name that cannot exist, so the `|| true` branch is what runs —
+        // the missing-spyc case, where printing the decision matters most.
+        let cmd = agy_tool_reporter_command("/nonexistent/spyc-does-not-exist", "blocked", false);
+        let out = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(&cmd)
+            .output()
+            .expect("run hook command");
+        assert!(out.status.success(), "hook command failed: {cmd:?}");
+        let parsed: Value = serde_json::from_slice(&out.stdout)
+            .expect("hook stdout must be JSON even with no spyc");
+        assert_eq!(
+            parsed.pointer("/decision").and_then(Value::as_str),
+            Some("allow")
+        );
+    }
+
     #[test]
     fn cleanup_agy_hooks_is_a_noop_when_nothing_of_ours() {
         let tmp = tempfile::tempdir().unwrap();
@@ -1079,11 +1183,30 @@ mod tests {
         assert_eq!(once, twice, "re-applying the merge changed a byte");
         assert!(once.contains("--report-status working"));
         assert!(once.contains("--report-status done"));
-        assert!(
-            !once.contains("blocked"),
-            "agy has no user-approval event — `blocked` is the scrape fallback's \
-             job, and a hook claiming to supply it would mask that"
-        );
+        // `blocked` may ride ONE hook and no other: `PreToolUse` matched to
+        // `ask_question`. agy has no event for its tool-permission prompt, and a
+        // live report suppresses the scrape outright (`effective_activity`), so a
+        // broader `blocked` hook would mask the only signal that prompt has. A
+        // `Blocked` report is also latched — output never clears it, only the
+        // user's keypress does — so claiming it where the user isn't actually being
+        // asked would pin the dot red.
+        let parsed: Value = serde_json::from_str(&once).expect("merged config parses");
+        let events = parsed
+            .get(AGY_HOOK_SET)
+            .and_then(Value::as_object)
+            .expect("our set");
+        for (event, handlers) in events {
+            let text = handlers.to_string();
+            if !text.contains("blocked") {
+                continue;
+            }
+            assert_eq!(event, "PreToolUse", "`blocked` escaped onto {event}");
+            assert_eq!(
+                handlers.pointer("/0/matcher").and_then(Value::as_str),
+                Some("ask_question"),
+                "`blocked` must be scoped to the ask_question tool: {text}"
+            );
+        }
         assert!(
             !once.contains("--status-trace"),
             "trace off → no baked flag"


### PR DESCRIPTION
Option 2 from the investigation. agy waits on the user in **two** ways and spyc only saw one:

| agy waits via | before | now |
|---|---|---|
| tool-permission prompt (`Requesting permission for:`) | screen scrape ✅ | unchanged |
| its `ask_question` tool (numbered-choice dialog) | **invisible** — a live pane with a pending question reported `idle (output-timing)` | `PreToolUse` hook, matcher `ask_question` |

`ask_question` is a real tool, so a hook sees it exactly when it fires — no second dialog to scrape, no dependence on wording agy is free to change.

## Why the matcher must stay narrow

A `PreToolUse` handler answers with a **required** `decision`. Matching every tool would put spyc in charge of agy's permissions; scoped to `ask_question` the `allow` is a no-op, because that tool was always going to wait for you.

Omitting the answer is worse than either — agy re-drives the tool. A probe that returned no decision ran a turn to **17 invocations before timing out**, never reaching `Stop`. So the handler:

- prints its decision **unconditionally**, sequenced with `;`, never gated on the reporter succeeding
- discards the reporter's own stdout, so stdout is pure JSON

Both are pinned by tests, including one that runs the built command through a real shell with a nonexistent binary and parses the output — the missing-spyc case, where printing the decision matters most.

## A guard I had to narrow rather than delete

`agy_merge_is_byte_idempotent` asserted agy's config contains no `blocked` at all, because "a hook claiming to supply it would mask the scrape". That concern is correct and has real teeth: `effective_activity` shows a live report **suppresses the scrape outright**, and a `Blocked` report is **latched** — output never clears it, only the user's keypress does. So the assertion is now scoped instead of dropped: `blocked` must appear on `PreToolUse`/`ask_question` and nowhere else. Answering the dialog (`enter`) or skipping it (`esc`) goes through the same clear path claude's permission prompt already uses.

## Correcting #285

**#285's premise was wrong and it fixed nothing.** It claimed agy never prints `esc to cancel`; agy renders that from `"%s to cancel"` at runtime, which is why the literal is absent from the binary's string table — and the phrase is on the real dialog. Replaying a transcribed live prompt through spyc's own matcher:

```
PROBE two-needle   = true
PROBE three-needle = true      ← the old rule matched too
```

Two needles is still the better rule, for the reason that should have been given the first time: the footer key-hint discriminates nothing (every dialog has one) and rots on any UI change, so it doesn't belong in the conjunction. The comment now says that, plus **verify a needle against a real pane, not the binary's string table** — the mistake that produced the false claim. The rule's test sample is now a transcription of a live agy 1.1.11 prompt, footer included, so it checks agy's actual dialog rather than a guess about it.

## Verification

Probes against agy 1.1.11 with a hook set in the shape spyc writes:

- matcher `ask_question` fires for `ask_question` and **not** for `view_file` in the same turn (the turn read a file and only the question tripped it)
- that turn still reached `Stop`, so `allow` leaves the flow intact
- `tool=ask_question` confirms the name derivation (`CORTEX_STEP_TYPE_ASK_QUESTION` → lowercase, prefix stripped)

`make check-ci` → `=== GATE: PASS ===`.

**Still needs one live confirmation:** print mode soft-denies `ask_question`, so I could verify the hook fires and the matcher filters, but not that the interactive dialog behaves normally with a hook attached. Trigger a question in an agy pane (the phrasing that did it: *"do something like run xargs where you need my permission first"*) — the dot should go hot-red while it waits, and answering should clear it.