### PR TITLE
fix(list): a watcher refresh no longer reverts the sort order to name

### DIFF
--- a/src/app/state/listing.rs
+++ b/src/app/state/listing.rs
@@ -224,6 +224,19 @@ impl AppState {
         }
     }
 
+    /// Install a freshly-read `Listing` into `side`, ordered by that column's
+    /// sort mode.
+    ///
+    /// The only place a column's `listing` is assigned. `Listing::read` always
+    /// returns name-sorted entries, so an assignment that skips this silently
+    /// reverts the user's `sort:mtime` to name while `sort_order` — and the
+    /// status bar reading off it — still says mtime.
+    fn install_listing(&mut self, side: Side, new: Listing) {
+        self.col_mut(side).listing = new;
+        let (order, reversed) = (self.col(side).sort_order, self.col(side).sort_reversed);
+        self.col_mut(side).listing.sort(order, reversed);
+    }
+
     /// Install an already-read listing into the focused column and bring its
     /// git markers + rows up to date — the back half of [`refresh_listing`],
     /// shared with the off-thread watcher refresh (`App::spawn_listing_refresh`,
@@ -232,7 +245,7 @@ impl AppState {
     /// is for the focused column's current dir (the sync path reads it inline;
     /// the async path staleness-checks `list_generation` before calling).
     pub fn apply_refreshed_listing(&mut self, new: Listing) {
-        self.cur_mut().listing = new;
+        self.install_listing(self.focused_side(), new);
         // Event-driven refresh touches the FOCUSED column's git. With
         // dual fs-watch (PR D) both columns' trees + gitdirs fire
         // events, so the focused column refreshes here on its own edits;
@@ -328,9 +341,7 @@ impl AppState {
                 crate::fs::listing::MAX_ENTRIES
             ));
         }
-        self.col_mut(side).listing = new_listing;
-        let (order, reversed) = (self.col(side).sort_order, self.col(side).sort_reversed);
-        self.col_mut(side).listing.sort(order, reversed);
+        self.install_listing(side, new_listing);
         // Resolve + cache the repo root for the new dir *before* the git
         // calls below so they see the right root on the first run after chdir.
         self.update_repo_root(side, &canonical);

--- a/src/app/state/tests/mod.rs
+++ b/src/app/state/tests/mod.rs
@@ -67,6 +67,53 @@ fn rebuild_rows_synthesizes_struck_ghost_for_deleted_file() {
     );
 }
 
+/// The watcher-driven refresh — any fs event in the listed dir, e.g. a `touch`
+/// creating a file — used to install the freshly-read `Listing` verbatim.
+/// `Listing::read` always name-sorts, so the visible order silently reverted to
+/// name while `sort_order` (and the status bar reading off it) still said mtime.
+#[test]
+fn refreshed_listing_keeps_the_columns_sort_order() {
+    use crate::fs::{Entry, Listing};
+    use std::time::{Duration, SystemTime};
+
+    let dir = PathBuf::from("/tmp/test");
+    let mk = |name: &str, mtime_secs: u64| Entry {
+        path: dir.join(name),
+        name: name.to_string(),
+        kind: EntryKind::File,
+        size: 0,
+        mtime: SystemTime::UNIX_EPOCH + Duration::from_secs(mtime_secs),
+    };
+    // Name order is a/b/c; mtime order (newest first) is its exact reverse, so
+    // the two can't be confused for one another.
+    let mut s = test_state();
+    s.left.view = crate::app::View::Dir;
+    s.left.sort_order = SortMode::Mtime;
+    s.left.sort_reversed = false;
+
+    // What the off-thread worker hands back: a name-sorted read of the dir.
+    let entries = vec![mk("a.txt", 100), mk("b.txt", 200), mk("c.txt", 300)];
+    let mut fresh = Listing {
+        dir,
+        entries,
+        truncated: false,
+    };
+    fresh.sort(SortMode::Name, false);
+    s.apply_refreshed_listing(fresh);
+
+    let names: Vec<&str> = s.left.rows.iter().map(|r| r.display.as_str()).collect();
+    assert_eq!(
+        names,
+        ["c.txt", "b.txt", "a.txt"],
+        "a refresh must re-apply sort:mtime (newest first), not keep the read's name order"
+    );
+    assert_eq!(
+        s.left.sort_order,
+        SortMode::Mtime,
+        "the sort mode itself was never the thing that changed"
+    );
+}
+
 #[test]
 fn rebuild_rows_does_not_ghost_a_deleted_file_still_on_disk() {
     use crate::fs::Entry;


### PR DESCRIPTION
## The bug

Reported: with `sort:mtime` active, `touch ~/Downloads/test.txt` made the listing jump back to name order — while the status bar still read `sort:mtime`.

Any fs event in the listed directory schedules the off-thread `Listing::read`, and `apply_refreshed_listing` installed the result **verbatim**:

```rust
pub fn apply_refreshed_listing(&mut self, new: Listing) {
    self.cur_mut().listing = new;      // ← the read is name-sorted
```

`Listing::read_capped` ends with `listing.sort(SortMode::Name, false)`, so every fresh read arrives name-sorted and the caller has to re-apply the column's mode. `chdir_side` did:

```rust
self.col_mut(side).listing = new_listing;
let (order, reversed) = (self.col(side).sort_order, self.col(side).sort_reversed);
self.col_mut(side).listing.sort(order, reversed);
```

The refresh path never did. Only the *rows* reverted — `sort_order` was untouched, which is exactly why the status bar kept claiming mtime and made it look like a rendering glitch rather than a lost sort.

Not `touch`-specific, and not new-file-specific: a write or a delete in the directory triggers the same refresh. Anyone using a non-default sort in an active directory (a build tree, a dir an agent is writing to) has been silently reverted to name order all along.

## The fix

Put the sort where it can't be forgotten a third time. `install_listing(side, new)` is now the **only** place a column's `listing` is assigned, and it sorts as part of installing:

```rust
fn install_listing(&mut self, side: Side, new: Listing) {
    self.col_mut(side).listing = new;
    let (order, reversed) = (self.col(side).sort_order, self.col(side).sort_reversed);
    self.col_mut(side).listing.sort(order, reversed);
}
```

`chdir_side` routes through it too, dropping its hand-rolled copy. Both former assignment sites are now one.

## Test

`refreshed_listing_keeps_the_columns_sort_order` — three files whose name order is the exact reverse of their mtime order, so the two can't be confused; feeds `apply_refreshed_listing` a name-sorted read (what the worker really hands back) and asserts the rows come out newest-first. Verified to fail with the fix reverted:

```
left: ["a.txt", "b.txt", "c.txt"]
right: ["c.txt", "b.txt", "a.txt"]
```

`make check-ci` → `=== GATE: PASS ===` (1909 tests).