### PR TITLE
fix(pager): size the fit-to-content box from visual rows, not line count

### DIFF
--- a/src/ui/pager/layout.rs
+++ b/src/ui/pager/layout.rs
@@ -354,15 +354,15 @@ const fn centered_rect(area: Rect, percent_w: u16, percent_h: u16) -> Rect {
 }
 
 /// Same x / y / width as the standard centered pager, but shrinks from
-/// the bottom: height = lines + borders + status row, capped at the
-/// standard 92% height. Top edge stays where the user expects (matching
-/// the regular pager origin); short summaries don't sit inside a
+/// the bottom: height = the rows the content needs + borders + status row,
+/// capped at the standard 92% height. Top edge stays where the user expects
+/// (matching the regular pager origin); short summaries don't sit inside a
 /// near-full-screen frame.
 pub(super) fn fit_height_rect(area: Rect, view: &PagerView) -> Rect {
     const MIN_H: u16 = 5;
 
     let centered = centered_rect(area, CENTERED_W_PCT, 92);
-    let need_h = (view.lines.len() as u16).saturating_add(3);
+    let need_h = fit_content_rows(centered.width, centered.height, view).saturating_add(3);
     let height = need_h.clamp(MIN_H.min(centered.height), centered.height);
 
     Rect {
@@ -371,6 +371,39 @@ pub(super) fn fit_height_rect(area: Rect, view: &PagerView) -> Rect {
         width: centered.width,
         height,
     }
+}
+
+/// Rows the content occupies at the fit-to-content box's width — VISUAL rows,
+/// not logical lines, because one line wider than the body wraps to several and
+/// a line-count height then hides the overflow inside an under-sized box (the
+/// `L` long listing does this: its rows run past 200 columns).
+///
+/// `box_w` is the outer width; the body loses the two border columns and the
+/// line-number gutter. Stops accumulating at `cap` — the caller clamps there
+/// anyway, so the walk costs a screenful regardless of how long the content is.
+fn fit_content_rows(box_w: u16, cap: u16, view: &PagerView) -> u16 {
+    let logical = u16::try_from(view.lines.len()).unwrap_or(u16::MAX);
+    if !view.wrap {
+        return logical;
+    }
+    let gutter_w = if view.show_line_numbers {
+        view.lines.len().max(1).ilog10() as usize + 2
+    } else {
+        0
+    };
+    let body_w = (box_w as usize).saturating_sub(2).saturating_sub(gutter_w);
+    if body_w == 0 {
+        return logical;
+    }
+    let cap = cap as usize;
+    let mut rows = 0usize;
+    for line in &view.lines {
+        rows = rows.saturating_add(visual_rows(line, body_w, view.tab_width));
+        if rows >= cap {
+            break;
+        }
+    }
+    u16::try_from(rows).unwrap_or(u16::MAX)
 }
 
 #[cfg(test)]

--- a/src/ui/pager/tests/mod.rs
+++ b/src/ui/pager/tests/mod.rs
@@ -283,6 +283,55 @@ fn pager_inner_area_top_pane_uses_area_as_is() {
     assert_eq!(pager_inner_area(slot, &view), slot);
 }
 
+/// The fit-to-content box (the `L` long listing) sized itself from the LOGICAL
+/// line count, so content wider than the body wrapped to several rows each and
+/// the overflow was hidden inside an under-sized frame — the reported symptom
+/// was a long listing of 3 files showing a clipped, seemingly-garbled table.
+/// The height must come from visual rows.
+#[test]
+fn fit_to_content_height_counts_wrapped_rows_not_lines() {
+    // A 160-col terminal ⇒ a 90% box of 144 ⇒ a 142-col body. Long-listing rows
+    // run past 200 columns, so each wraps to 2 visual rows.
+    let area = Rect::new(0, 0, 160, 60);
+    let wide: Vec<String> = (0..4).map(|i| format!("{i}{}", "x".repeat(200))).collect();
+    let mut view = PagerView::new_plain("long listing — /tmp", wide);
+    view.fit_to_content = true;
+    assert!(view.wrap, "the fit-to-content pager wraps");
+
+    let rect = pager_inner_area(area, &view);
+    // 4 lines × 2 visual rows + 2 borders + 1 status row.
+    assert_eq!(
+        rect.height, 11,
+        "the box must fit all 8 visual rows, not 4+3=7"
+    );
+
+    // Narrow content of the same line count still gets the compact box, so the
+    // fix doesn't just inflate every fit-to-content pager.
+    let narrow: Vec<String> = (0..4).map(|i| format!("line {i}")).collect();
+    let mut view = PagerView::new_plain("summary", narrow);
+    view.fit_to_content = true;
+    assert_eq!(pager_inner_area(area, &view).height, 7);
+}
+
+/// The fit-to-content box never exceeds the standard 92% height — the whole
+/// point of the mode is that a short summary doesn't get a near-full-screen
+/// frame, and wrap-aware sizing must not turn wide content into a full screen.
+#[test]
+fn fit_to_content_height_stays_capped_at_the_centered_height() {
+    let area = Rect::new(0, 0, 160, 60);
+    let many: Vec<String> = (0..500)
+        .map(|i| format!("{i}{}", "x".repeat(400)))
+        .collect();
+    let mut view = PagerView::new_plain("huge", many);
+    view.fit_to_content = true;
+    let capped = pager_inner_area(area, &view);
+    assert_eq!(
+        capped.height,
+        60 * 92 / 100,
+        "capped at the centered height"
+    );
+}
+
 #[test]
 fn pager_inner_area_top_pane_ignores_full_width_and_fit() {
     // Pane mounts deliberately ignore the overlay sizing


### PR DESCRIPTION
## The bug

Reported from an `L` (long listing) on 3 picked files with long names: the pager box was too small and the table looked garbled. The user's own diagnosis was right — *"the long names spilling over overflowed the calculation of how big of a pager to show"*.

`fit_height_rect` sized the box from the **logical** line count:

```rust
let need_h = (view.lines.len() as u16).saturating_add(3);   // + borders + status row
```

Long-listing rows carry `INODE MODE OCT LINKS OWNER GROUP SIZE BYTES BLOCKS MTIME ATIME CTIME BIRTH NAME` and run past 200 columns. The overlay is 90% of the terminal, so on a 178-column terminal the body is ~158 columns and every row wraps to 2 visual rows. 4 lines → 8 visual rows needed, `4 + 3 = 7` granted → a 4-row body. The overflow wasn't dropped, just pushed below the frame, which is what made the table read as garbled: each row's tail appeared as a separate half-row and the columns stopped lining up.

`fit_to_content` is only used by the `L` pager, so the blast radius is that one view.

## The fix

Sum `visual_rows` at the box's own body width — the same quantity the renderer measures, with the borders and line-number gutter subtracted:

```rust
let need_h = fit_content_rows(centered.width, centered.height, view).saturating_add(3);
```

Three things kept intact:

- **Still not full-screen.** The existing 92%-height clamp is untouched, so the mode still does its job of keeping a short summary out of a near-full-screen frame. That was an explicit ask.
- **Compact stays compact.** Narrow content of the same line count gets the same small box it always did — wrap-aware sizing only grows the box when lines actually wrap. Asserted in the test.
- **Bounded cost.** `fit_height_rect` runs every frame, so the walk stops accumulating once it reaches the height cap. Work is a screenful regardless of how long the content is.

## Tests

- `fit_to_content_height_counts_wrapped_rows_not_lines` — 4 lines of 200 columns in a 160-column terminal must produce an 11-row box (8 visual rows + 3), and the narrow-content half of the same test asserts the compact box is unchanged. Verified to fail with the old formula: `left: 7, right: 11`.
- `fit_to_content_height_stays_capped_at_the_centered_height` — 500 lines of 400 columns still stops at the 92% cap.

`make check-ci` → `=== GATE: PASS ===` (1910 tests).

## Still worth a look, separately

This fixes the *sizing*. The wrapped long listing is now fully visible but still wraps, because `NAME` is the **last** column — after ~160 columns of metadata. Wrap makes it a two-row-per-file table; turning wrap off would push filenames off the right edge entirely (the pager has no horizontal scroll). Making `L` readable at a glance probably means reordering or trimming its columns, which is a design call rather than a bug fix.