### PR TITLE
fix(mouse): send codex's transcript close key once, not once per wheel tick

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -915,13 +915,14 @@ pub struct ViewState {
     /// step and so a short one can't open the view by accident — see
     /// `App::send_agent_view_scroll_keys`. `None` outside a gesture.
     pub pane_scroll_streak: Option<mouse::PaneScrollStreak>,
-    /// Set right after spyc sends an agent's `transcript_toggle_key`, so a fast
-    /// follow-up wheel tick — arriving before the child has redrawn — doesn't see
-    /// the OLD (still-closed) screen and send the toggle again, which would close
-    /// what the first tick just opened. Cleared once a scrape confirms the view is
-    /// open, or after `TOGGLE_SETTLE` if it never does (self-healing rather than
-    /// stuck refusing to retry).
-    pub pane_toggle_sent_at: Option<std::time::Instant>,
+    /// Set right after spyc sends an agent's `transcript_toggle_key` or
+    /// `transcript_close_key`, so a fast follow-up wheel tick — arriving before the
+    /// child has redrawn — doesn't act on the STALE screen and send the same key
+    /// again. Retired once a scrape confirms the send landed, which is
+    /// direction-specific (`mouse::pending_view_confirmed`: marker present for an
+    /// `Open`, absent for a `Close`), or after `TOGGLE_SETTLE` if it never does
+    /// (self-healing rather than stuck refusing to retry).
+    pub pane_view_sent: Option<(std::time::Instant, mouse::PendingViewIntent)>,
     /// Whether an agent-transcript scrollback (`^a v`) renders the agent's
     /// tool-use / tool-result lines. `t` toggles it; the transcript is
     /// re-rendered with the new value. Session-scoped (persists across
@@ -1022,7 +1023,7 @@ impl ViewState {
             chrome_selection: None,
             chrome_rows: std::cell::RefCell::new(Vec::new()),
             pane_scroll_streak: None,
-            pane_toggle_sent_at: None,
+            pane_view_sent: None,
             transcript_show_tool_calls: true,
             term_size: crossterm::terminal::size().unwrap_or((80, 24)),
         }

--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -27,7 +27,9 @@ pub(super) mod tab_hit;
 
 // Re-exported so the impure half and its callers keep referring to
 // `mouse::route_mouse` / `mouse::Region` exactly as before this split.
-pub(super) use route::{Gesture, MouseSink, MouseSnapshot, region_at, route_mouse};
+pub(super) use route::{
+    Gesture, MouseSink, MouseSnapshot, PendingViewIntent, region_at, route_mouse,
+};
 
 /// Resolve a raw mouse event kind to the gesture + wheel delta every downstream
 /// consumer (`ListCursor`, `Pager`, `PaneScrollKeys`) shares. `None` for a kind

--- a/src/app/mouse/route.rs
+++ b/src/app/mouse/route.rs
@@ -227,7 +227,7 @@ impl MouseSnapshot {
 }
 
 /// How long spyc waits, after sending an agent's `transcript_toggle_key`, before
-/// it's willing to send it again — see [`ViewState::pane_toggle_sent_at`].
+/// it's willing to send it again — see [`ViewState::pane_view_sent`].
 /// Comfortably longer than one local pty round trip, short enough to recover
 /// quickly if the scrape genuinely never confirms.
 pub const TOGGLE_SETTLE: std::time::Duration = std::time::Duration::from_millis(400);
@@ -312,13 +312,40 @@ pub enum AgentViewAction {
     Close,
 }
 
+/// Which way spyc last moved an agent's own scrollback view, and is waiting to
+/// see land on screen. Held with the send instant in
+/// [`crate::app::ViewState::pane_view_sent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PendingViewIntent {
+    /// [`AgentViewAction::Toggle`] — waiting for the marker to APPEAR.
+    Open,
+    /// [`AgentViewAction::Close`] — waiting for the marker to DISAPPEAR.
+    Close,
+}
+
+/// Pure. Has the pending send landed, judged by what's on screen right now?
+///
+/// The confirmation is direction-specific, and that's the whole point: an `Open`
+/// is confirmed by the marker appearing, a `Close` by it going away. Retiring the
+/// guard on "marker present" regardless of intent looks equivalent and isn't —
+/// after a close the marker is still there for a tick or two while the child
+/// redraws, so the guard erased itself and every further wheel tick sent the close
+/// key again. For codex that key is a bare `q`, so a single flick past the bottom
+/// typed a run of `q`s into its composer.
+pub const fn pending_view_confirmed(intent: PendingViewIntent, is_open: bool) -> bool {
+    match intent {
+        PendingViewIntent::Open => is_open,
+        PendingViewIntent::Close => !is_open,
+    }
+}
+
 /// Inputs to [`decide_agent_view_action`], bundled rather than four positional
 /// `bool`s — each has a distinct meaning, and four bare bools at a call site is
 /// exactly the shape that gets two of them silently transposed.
 #[derive(Debug, Clone, Copy)]
 pub struct AgentViewInputs {
     pub is_open: bool,
-    /// `pane_toggle_sent_at`'s guard already resolved to a bool (elapsed vs.
+    /// `pane_view_sent`'s guard already resolved to a bool (elapsed vs.
     /// [`TOGGLE_SETTLE`]) — kept out of this function so it stays clock-free
     /// and trivially testable. Reused for BOTH directions of the open/close
     /// transition (see `send_agent_view_scroll_keys`'s doc): the same debounce
@@ -596,7 +623,8 @@ pub fn clamp_to_area(view: &crate::ui::pager::PagerView, col: u16, row: u16) -> 
 mod tests {
     use super::{
         AgentViewAction, AgentViewInputs, Gesture, MouseSink, MouseSnapshot, OPEN_AFTER_UP_TICKS,
-        Region, decide_agent_view_action, region_at, route_mouse, scroll_streak_step,
+        PendingViewIntent, Region, decide_agent_view_action, pending_view_confirmed, region_at,
+        route_mouse, scroll_streak_step,
     };
     use crate::app::App;
     use crate::app::pager_handler::PagerSlot;
@@ -1607,6 +1635,64 @@ mod tests {
                 "{ticks} up ticks"
             );
         }
+    }
+
+    /// One flick past the bottom must send the close key ONCE, not once per wheel
+    /// tick — codex's close key is a bare `q`, so every extra send types a
+    /// character into its composer.
+    ///
+    /// Models `send_agent_view_scroll_keys`'s per-tick bookkeeping, because that
+    /// is where this broke: the decision fn was already right (`Close` needs
+    /// `!toggle_pending`), and the caller retired the guard on `is_open` alone.
+    /// The child keeps the marker on screen for a tick or two after the view
+    /// closes, so that read is stale exactly when the guard matters, and it
+    /// erased itself every tick.
+    #[test]
+    fn one_flick_past_the_bottom_sends_the_close_key_once() {
+        let mut pending: Option<PendingViewIntent> = None;
+        let mut closes_sent = 0;
+        // Five down-ticks while the marker is still up: the close landed, codex's
+        // redraw hasn't.
+        for _ in 0..5 {
+            let is_open = true;
+            let action = decide_agent_view_action(
+                AgentViewInputs {
+                    is_open,
+                    // Every tick here is inside TOGGLE_SETTLE.
+                    toggle_pending: pending.is_some(),
+                    escalate: false,
+                    at_bottom: true,
+                    streak_ticks: 1,
+                },
+                PaneScrollView::Native,
+                1,
+            );
+            if matches!(action, AgentViewAction::Close) {
+                closes_sent += 1;
+                pending = Some(PendingViewIntent::Close);
+            }
+            if let Some(intent) = pending
+                && pending_view_confirmed(intent, is_open)
+            {
+                pending = None;
+            }
+        }
+        assert_eq!(
+            closes_sent, 1,
+            "close key sent {closes_sent}× on one flick — each extra one is a `q` in codex's composer"
+        );
+        // Self-healing: once the redraw drops the marker the guard retires, so a
+        // later deliberate close still works.
+        assert!(pending_view_confirmed(PendingViewIntent::Close, false));
+        assert!(!pending_view_confirmed(PendingViewIntent::Close, true));
+    }
+
+    /// The other direction, which the old `if is_open` clear got right and must
+    /// keep getting right: an open is confirmed by the marker APPEARING.
+    #[test]
+    fn an_open_is_confirmed_by_the_marker_appearing() {
+        assert!(pending_view_confirmed(PendingViewIntent::Open, true));
+        assert!(!pending_view_confirmed(PendingViewIntent::Open, false));
     }
 
     /// A toggle already in flight (within TOGGLE_SETTLE) must NOT be re-sent —

--- a/src/app/mouse/scroll.rs
+++ b/src/app/mouse/scroll.rs
@@ -9,7 +9,8 @@
 
 use super::super::Effect;
 use super::route::{
-    AgentViewAction, AgentViewInputs, TOGGLE_SETTLE, decide_agent_view_action, scroll_streak_step,
+    AgentViewAction, AgentViewInputs, PendingViewIntent, TOGGLE_SETTLE, decide_agent_view_action,
+    pending_view_confirmed, scroll_streak_step,
 };
 
 impl super::super::App {
@@ -66,7 +67,7 @@ impl super::super::App {
     /// investigation, so scrollback has nothing to scrape). Cheap enough to run
     /// every tick — a plain substring search over one screen's worth of text —
     /// so no debounce is needed for the scrape itself; only the toggle-send
-    /// needs one (see `pane_toggle_sent_at`'s doc).
+    /// needs one (see `pane_view_sent`'s doc).
     ///
     /// Opening it takes a sustained scroll UP (`OPEN_AFTER_UP_TICKS`); a
     /// downward gesture never opens it, only scrolls or closes one already open.
@@ -88,10 +89,8 @@ impl super::super::App {
         let app_cursor = tabs.active().application_cursor();
         let is_open = visible.iter().any(|l| l.contains(marker));
         let at_bottom = is_open && profile.transcript_at_bottom(&visible);
-        let toggle_pending = self
-            .view
-            .pane_toggle_sent_at
-            .is_some_and(|sent| sent.elapsed() < TOGGLE_SETTLE);
+        let pending = self.view.pane_view_sent;
+        let toggle_pending = pending.is_some_and(|(sent, _)| sent.elapsed() < TOGGLE_SETTLE);
 
         let now = std::time::Instant::now();
         // Stepped on every tick, open or closed: while open its elapsed time
@@ -115,8 +114,14 @@ impl super::super::App {
         // State mutation lives here, once, keyed to the decision — not scattered
         // across the branches that produce it.
         self.view.pane_scroll_streak = Some(streak);
-        if is_open {
-            self.view.pane_toggle_sent_at = None; // confirmed open; drop the guard
+        // Retire the guard only when the screen shows what was actually asked for.
+        // Testing `is_open` alone retires a pending CLOSE on the stale marker the
+        // guard exists to ride out, which turns one close into one close key per
+        // wheel tick — `q` each time, into codex's composer.
+        if let Some((_, intent)) = pending
+            && pending_view_confirmed(intent, is_open)
+        {
+            self.view.pane_view_sent = None;
         }
 
         match action {
@@ -129,19 +134,19 @@ impl super::super::App {
                 let Some((code, mods)) = profile.transcript_toggle_key() else {
                     return Vec::new();
                 };
-                self.view.pane_toggle_sent_at = Some(now);
+                self.view.pane_view_sent = Some((now, PendingViewIntent::Open));
                 Self::repeat_key_effect(code, mods, 1, app_cursor)
             }
-            // Reuses the SAME debounce field `Toggle` sets: the next tick or two
-            // will still read `is_open == true` (codex hasn't redrawn the
-            // composer yet), and without this a fast flick continuing past the
-            // bottom would send `q` again into what may already be the
-            // composer's own text input.
+            // Shares the debounce field with `Toggle`, but records the opposite
+            // intent: for the next tick or two the scrape still reads
+            // `is_open == true` (codex hasn't redrawn the composer yet), so the
+            // guard must survive that stale read or a fast flick past the bottom
+            // sends `q` again into what is by then the composer's text input.
             AgentViewAction::Close => {
                 let Some((code, mods)) = profile.transcript_close_key() else {
                     return Vec::new();
                 };
-                self.view.pane_toggle_sent_at = Some(now);
+                self.view.pane_view_sent = Some((now, PendingViewIntent::Close));
                 Self::repeat_key_effect(code, mods, 1, app_cursor)
             }
             AgentViewAction::Scroll { fast } => {


### PR DESCRIPTION
Reported: wheeling in and out of codex's scroll quickly leaves a run of `q`s in its composer.

**Those `q`s are spyc's, not typed.** codex's `transcript_close_key` is a bare `q`, and spyc was sending it on every tick of the gesture.

## Root cause

The pure decision was already correct — `Close` requires `!toggle_pending`, and that field's own doc says it's "Reused for BOTH directions of the open/close transition". The **caller** defeated it:

```rust
if is_open {
    self.view.pane_toggle_sent_at = None; // "confirmed open; drop the guard"
}
```

"Marker present" is the right confirmation for an **Open** and the exact wrong one for a **Close**. After a close, codex keeps `T R A N S C R I P T` on screen for a tick or two while it redraws — *precisely the window the guard exists to ride out*. So the guard erased itself, `toggle_pending` went false, and the next tick read at-bottom-and-still-scrolling and sent `q` again. One flick → one `q` per tick.

## Fix

Confirmation becomes direction-specific. `pane_toggle_sent_at` → `pane_view_sent`, carrying **which way** the view was moved, and `pending_view_confirmed` retires the guard on the marker *appearing* for an `Open` and *disappearing* for a `Close`. `TOGGLE_SETTLE` still bounds it, so a child that never redraws self-heals rather than getting stuck refusing to retry.

## Test

The defect was in the caller's per-tick bookkeeping, not the pure fn — so a test of `decide_agent_view_action` alone would have passed against the bug. The regression test models the tick loop instead: five down-ticks against a stale marker must send the close key **once**.

Verified it fails against the old logic before fixing:

```
assertion `left == right` failed: close key sent 5× on one flick
  — each extra one is a `q` in codex's composer
```

That 5 is the same shape as the reported `qqqqqqq`.

`make check-ci` → `=== GATE: PASS ===`.

## Note on blast radius

This is the "spyc drives another agent's UI by synthesizing keys" seam, where a stale screen read doesn't fail loudly — it types. Worth knowing the same class of bug would be invisible for any agent whose close key is a printable character; agy is unaffected (no `transcript_open_marker`, so none of this machinery runs for it).