### PR TITLE
refactor: pure key decisions for the harpoon menu + find picker (#178)

### DIFF
--- a/src/app/find_picker.rs
+++ b/src/app/find_picker.rs
@@ -8,14 +8,75 @@
 //! sweep). Fields are `pub` (built via a struct literal). The `F` open /
 //! render / key-handler `impl App` methods live here too (`pub`, called from
 //! `actions` / `key_dispatch` / the run loop).
+//!
+//! Key handling splits the `route.rs` / `focus.rs` way: the pure
+//! [`decide_find_picker_key`] maps a `Copy` snapshot + key to a
+//! [`FindPickerAction`], and `handle_find_picker_key` only applies it. Every
+//! bound (list ends, empty query, the CONTROL/ALT chord guard) is decided in
+//! the pure half, so the key matrix is table-testable without a live walk.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use crate::ui::pager;
 
 use super::App;
+
+/// The picker state [`decide_find_picker_key`] reads. `Copy` so tests construct
+/// one inline.
+#[derive(Debug, Clone, Copy)]
+struct FindPickerSnapshot {
+    /// Cursor index into the ranked results.
+    selected: usize,
+    /// How many results the current query matched.
+    filtered_len: usize,
+    /// Whether the query buffer has anything left to delete.
+    query_is_empty: bool,
+}
+
+/// What a key does to the open `F` picker. Each variant is a complete
+/// instruction — the bounds live in [`decide_find_picker_key`], so the applier
+/// never re-guards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FindPickerAction {
+    /// Swallow it; the picker owns every key while open.
+    Ignore,
+    /// `Esc`, or `Enter` with nothing to accept — close without navigating.
+    Close,
+    /// `Enter` on a result — close, then land on the selected path.
+    Accept,
+    MoveUp,
+    MoveDown,
+    /// `Backspace` against a non-empty query.
+    Backspace,
+    /// A printable char — append to the query and re-rank.
+    Insert(char),
+}
+
+/// Decide what a key does to the `F` picker. **Pure** (the `route.rs` /
+/// `focus.rs` template), so every branch is unit-testable without a live walk.
+///
+/// Takes the whole [`KeyEvent`]: the printable-char arm has to read modifiers
+/// so a `^n` / `⌥f` doesn't get typed into the query as an `n` / `f`.
+const fn decide_find_picker_key(snap: FindPickerSnapshot, key: KeyEvent) -> FindPickerAction {
+    match key.code {
+        // `Enter` navigates only when the cursor is over a real result; against
+        // an empty result set it merely dismisses, exactly like `Esc`.
+        KeyCode::Enter if snap.selected < snap.filtered_len => FindPickerAction::Accept,
+        KeyCode::Esc | KeyCode::Enter => FindPickerAction::Close,
+        KeyCode::Up if snap.selected > 0 => FindPickerAction::MoveUp,
+        KeyCode::Down if snap.selected + 1 < snap.filtered_len => FindPickerAction::MoveDown,
+        KeyCode::Backspace if !snap.query_is_empty => FindPickerAction::Backspace,
+        KeyCode::Char(c)
+            if !key.modifiers.contains(KeyModifiers::CONTROL)
+                && !key.modifiers.contains(KeyModifiers::ALT) =>
+        {
+            FindPickerAction::Insert(c)
+        }
+        _ => FindPickerAction::Ignore,
+    }
+}
 
 pub struct FindPicker {
     /// Repo-relative paths accumulated from the walk so far.
@@ -178,76 +239,86 @@ impl App {
     /// file's parent and places the cursor on it; Up/Down move selection;
     /// printable chars + Backspace edit the query and re-rank.
     pub fn handle_find_picker_key(&mut self, key: KeyEvent) {
-        if self.runtime.find_picker.is_none() {
+        let Some(picker) = self.runtime.find_picker.as_ref() else {
             return;
-        }
-        match key.code {
-            KeyCode::Esc => {
-                self.runtime.find_picker = None;
-                self.clear_pager();
-                self.view.needs_full_repaint = true;
-            }
-            KeyCode::Enter => {
-                let target = self.runtime.find_picker.as_ref().and_then(|p| {
-                    p.filtered
-                        .get(p.selected)
-                        .cloned()
-                        .map(|rel| (p.root.clone(), rel))
-                });
-                self.runtime.find_picker = None;
-                self.clear_pager();
-                self.view.needs_full_repaint = true;
-                if let Some((root, rel)) = target {
-                    let abs = root.join(&rel);
-                    if let Some(parent) = abs.parent() {
-                        if let Err(e) = self.state.chdir(parent) {
-                            self.state.flash_error(format!("chdir: {e:#}"));
-                        } else if let Some(idx) =
-                            self.state.cur().rows.iter().position(|r| r.path == abs)
-                        {
-                            self.state.cur_mut().cursor.index = idx;
-                            let row_count = self.state.cur().rows.len();
-                            self.state.cur_mut().cursor.clamp(row_count);
-                        }
-                    }
+        };
+        let snap = FindPickerSnapshot {
+            selected: picker.selected,
+            filtered_len: picker.filtered.len(),
+            query_is_empty: picker.query.is_empty(),
+        };
+
+        match decide_find_picker_key(snap, key) {
+            FindPickerAction::Ignore => {}
+            FindPickerAction::Close => self.close_find_picker(),
+            FindPickerAction::Accept => {
+                let target = self
+                    .runtime
+                    .find_picker
+                    .as_ref()
+                    .and_then(|p| p.filtered.get(p.selected).map(|rel| p.root.join(rel)));
+                self.close_find_picker();
+                if let Some(abs) = target {
+                    self.land_on_found_path(&abs);
                 }
             }
-            KeyCode::Up => {
-                if let Some(picker) = self.runtime.find_picker.as_mut()
-                    && picker.selected > 0
-                {
-                    picker.selected -= 1;
-                    self.render_find_picker();
+            FindPickerAction::MoveUp => {
+                if let Some(picker) = self.runtime.find_picker.as_mut() {
+                    picker.selected = picker.selected.saturating_sub(1);
                 }
+                self.render_find_picker();
             }
-            KeyCode::Down => {
-                if let Some(picker) = self.runtime.find_picker.as_mut()
-                    && picker.selected + 1 < picker.filtered.len()
-                {
+            FindPickerAction::MoveDown => {
+                if let Some(picker) = self.runtime.find_picker.as_mut() {
                     picker.selected += 1;
-                    self.render_find_picker();
                 }
+                self.render_find_picker();
             }
-            KeyCode::Backspace => {
-                if let Some(picker) = self.runtime.find_picker.as_mut()
-                    && !picker.query.is_empty()
-                {
+            FindPickerAction::Backspace => {
+                if let Some(picker) = self.runtime.find_picker.as_mut() {
                     picker.query.pop();
                     picker.refilter();
-                    self.render_find_picker();
                 }
+                self.render_find_picker();
             }
-            KeyCode::Char(c)
-                if !key.modifiers.contains(KeyModifiers::CONTROL)
-                    && !key.modifiers.contains(KeyModifiers::ALT) =>
-            {
+            FindPickerAction::Insert(c) => {
                 if let Some(picker) = self.runtime.find_picker.as_mut() {
                     picker.query.push(c);
                     picker.refilter();
-                    self.render_find_picker();
                 }
+                self.render_find_picker();
             }
-            _ => {} // Swallow other keys while picker is open.
+        }
+    }
+
+    /// Tear down the picker together with the pager view it renders into.
+    fn close_find_picker(&mut self) {
+        self.runtime.find_picker = None;
+        self.clear_pager();
+        self.view.needs_full_repaint = true;
+    }
+
+    /// Cursor-land on `abs`: chdir to its parent and park the cursor on the
+    /// file itself, leaving the verb to the user — the same semantics as a
+    /// harpoon jump. A chdir failure flashes its whole cause chain.
+    fn land_on_found_path(&mut self, abs: &Path) {
+        let Some(parent) = abs.parent() else {
+            return;
+        };
+        if let Err(e) = self.state.chdir(parent) {
+            self.state.flash_error(format!("chdir: {e:#}"));
+            return;
+        }
+        if let Some(idx) = self
+            .state
+            .cur()
+            .rows
+            .iter()
+            .position(|r| r.path.as_path() == abs)
+        {
+            self.state.cur_mut().cursor.index = idx;
+            let row_count = self.state.cur().rows.len();
+            self.state.cur_mut().cursor.clamp(row_count);
         }
     }
 }
@@ -297,5 +368,151 @@ mod tests {
         p.query = "alpha".to_string();
         p.refilter();
         assert_eq!(p.selected, 0);
+    }
+}
+
+#[cfg(test)]
+mod picker_key_tests {
+    use super::{FindPickerAction, FindPickerSnapshot, decide_find_picker_key};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    /// A picker showing `filtered_len` results with the cursor at `selected`
+    /// and an empty query.
+    const fn snap(selected: usize, filtered_len: usize) -> FindPickerSnapshot {
+        FindPickerSnapshot {
+            selected,
+            filtered_len,
+            query_is_empty: true,
+        }
+    }
+
+    /// Same, but with something typed to delete.
+    const fn typed(selected: usize, filtered_len: usize) -> FindPickerSnapshot {
+        FindPickerSnapshot {
+            selected,
+            filtered_len,
+            query_is_empty: false,
+        }
+    }
+
+    fn key(code: KeyCode, mods: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, mods)
+    }
+
+    fn decide(s: FindPickerSnapshot, code: KeyCode) -> FindPickerAction {
+        decide_find_picker_key(s, key(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn esc_closes() {
+        assert_eq!(decide(snap(0, 5), KeyCode::Esc), FindPickerAction::Close);
+    }
+
+    #[test]
+    fn enter_accepts_the_selected_result() {
+        assert_eq!(decide(snap(0, 5), KeyCode::Enter), FindPickerAction::Accept);
+        assert_eq!(decide(snap(4, 5), KeyCode::Enter), FindPickerAction::Accept);
+    }
+
+    #[test]
+    fn enter_on_no_results_closes_without_navigating() {
+        // A query matching nothing still dismisses the picker — it just has no
+        // path to land on.
+        assert_eq!(decide(snap(0, 0), KeyCode::Enter), FindPickerAction::Close);
+        // Defensive: a cursor somehow past the results is not a valid accept.
+        assert_eq!(decide(snap(9, 5), KeyCode::Enter), FindPickerAction::Close);
+    }
+
+    #[test]
+    fn up_and_down_move_within_the_results() {
+        assert_eq!(decide(snap(1, 5), KeyCode::Up), FindPickerAction::MoveUp);
+        assert_eq!(
+            decide(snap(1, 5), KeyCode::Down),
+            FindPickerAction::MoveDown
+        );
+    }
+
+    #[test]
+    fn up_and_down_are_inert_at_the_ends() {
+        // Neither may run off the list: `Up` at the top would underflow
+        // `selected`, `Down` at the bottom would index past `filtered`.
+        assert_eq!(decide(snap(0, 5), KeyCode::Up), FindPickerAction::Ignore);
+        assert_eq!(decide(snap(4, 5), KeyCode::Down), FindPickerAction::Ignore);
+        assert_eq!(decide(snap(0, 0), KeyCode::Up), FindPickerAction::Ignore);
+        assert_eq!(decide(snap(0, 0), KeyCode::Down), FindPickerAction::Ignore);
+    }
+
+    #[test]
+    fn backspace_edits_only_a_non_empty_query() {
+        assert_eq!(
+            decide(typed(0, 5), KeyCode::Backspace),
+            FindPickerAction::Backspace
+        );
+        assert_eq!(
+            decide(snap(0, 5), KeyCode::Backspace),
+            FindPickerAction::Ignore
+        );
+    }
+
+    #[test]
+    fn printable_chars_type_into_the_query() {
+        assert_eq!(
+            decide(snap(0, 5), KeyCode::Char('a')),
+            FindPickerAction::Insert('a')
+        );
+        // Punctuation and digits are query text too — paths contain both.
+        assert_eq!(
+            decide(snap(0, 5), KeyCode::Char('.')),
+            FindPickerAction::Insert('.')
+        );
+        assert_eq!(
+            decide(snap(0, 5), KeyCode::Char('7')),
+            FindPickerAction::Insert('7')
+        );
+    }
+
+    #[test]
+    fn shifted_letters_still_type() {
+        // Uppercase must reach the query — the modifier guard rejects CONTROL
+        // and ALT only, never SHIFT.
+        assert_eq!(
+            decide_find_picker_key(snap(0, 5), key(KeyCode::Char('R'), KeyModifiers::SHIFT)),
+            FindPickerAction::Insert('R')
+        );
+    }
+
+    #[test]
+    fn control_and_alt_chords_do_not_type_their_letter() {
+        // The regression this guard exists for: `^c` must not append a literal
+        // `c` to the query (and `⌥f` must not append an `f`).
+        assert_eq!(
+            decide_find_picker_key(snap(0, 5), key(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            FindPickerAction::Ignore
+        );
+        assert_eq!(
+            decide_find_picker_key(snap(0, 5), key(KeyCode::Char('f'), KeyModifiers::ALT)),
+            FindPickerAction::Ignore
+        );
+    }
+
+    #[test]
+    fn unbound_keys_are_swallowed_not_leaked() {
+        // The picker owns all input while open — nothing falls through to the
+        // resolver behind it.
+        for code in [
+            KeyCode::Tab,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Home,
+            KeyCode::End,
+            KeyCode::Delete,
+            KeyCode::F(1),
+        ] {
+            assert_eq!(
+                decide(snap(1, 5), code),
+                FindPickerAction::Ignore,
+                "{code:?} must be swallowed"
+            );
+        }
     }
 }

--- a/src/app/harpoon.rs
+++ b/src/app/harpoon.rs
@@ -5,10 +5,92 @@
 //! `pub` (called from `actions` / `key_dispatch`); `harpoon_cursor_path` is
 //! an internal helper. `sync_harpoon_filter_set` lives in `actions` (pub) and
 //! resolves crate-wide.
+//!
+//! The menu's key handling splits the `route.rs` / `focus.rs` way: the pure
+//! [`decide_harpoon_menu_key`] maps a `Copy` snapshot + key to a
+//! [`HarpoonMenuAction`], and `handle_harpoon_menu_key` only applies it. Every
+//! bound (empty list, cursor at either edge, `dd` arming) is decided in the
+//! pure half, so the whole key matrix is table-testable without a live menu.
 
 use std::path::{Path, PathBuf};
 
+use crossterm::event::{KeyCode, KeyEvent};
+
 use super::{App, Effect, HarpoonMenu};
+
+/// The menu state [`decide_harpoon_menu_key`] reads. `Copy` so tests construct
+/// one inline.
+#[derive(Debug, Clone, Copy)]
+struct HarpoonMenuSnapshot {
+    /// Cursor row inside the menu (0-based).
+    cursor: usize,
+    /// Occupied slot count.
+    len: usize,
+    /// A previous `d` armed the delete, so a `d` now is the confirming second.
+    delete_armed: bool,
+}
+
+/// What a key does to the open harpoon menu. Each variant is a complete
+/// instruction — every bound is checked in [`decide_harpoon_menu_key`], so the
+/// applier never re-guards.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HarpoonMenuAction {
+    /// Swallow it; the menu owns all input while open.
+    Ignore,
+    /// `Esc` / `q`.
+    Close,
+    /// `j` / `k` / `g` / `G` — park the cursor here, already clamped.
+    MoveTo(usize),
+    /// `1`..`9` / `Enter` — jump to this 1-based slot, closing the menu.
+    Jump(u8),
+    /// `K` / `J` — reorder; the cursor follows the moved slot to `to`.
+    Swap { from: usize, to: usize },
+    /// First `d` of a `dd`.
+    ArmDelete,
+    /// Second `d` — drop this slot.
+    DeleteAt(usize),
+}
+
+/// Decide what a key does to the harpoon menu. **Pure** (the `route.rs` /
+/// `focus.rs` template), so every branch is unit-testable without a live menu.
+///
+/// Takes a bare [`KeyCode`]: modifiers are not consulted, matching the handler
+/// this was extracted from.
+const fn decide_harpoon_menu_key(snap: HarpoonMenuSnapshot, code: KeyCode) -> HarpoonMenuAction {
+    let HarpoonMenuSnapshot {
+        cursor,
+        len,
+        delete_armed,
+    } = snap;
+    match code {
+        KeyCode::Esc | KeyCode::Char('q') => HarpoonMenuAction::Close,
+        KeyCode::Char('j') | KeyCode::Down if len > 0 => {
+            let last = len - 1;
+            HarpoonMenuAction::MoveTo(if cursor >= last { last } else { cursor + 1 })
+        }
+        KeyCode::Char('k') | KeyCode::Up if len > 0 => {
+            HarpoonMenuAction::MoveTo(cursor.saturating_sub(1))
+        }
+        KeyCode::Char('g') if len > 0 => HarpoonMenuAction::MoveTo(0),
+        KeyCode::Char('G') if len > 0 => HarpoonMenuAction::MoveTo(len - 1),
+        // Deliberately unguarded on `len`: a digit is direct slot addressing,
+        // the same verb as `H5` outside the menu, so an empty slot closes and
+        // flashes rather than doing nothing.
+        KeyCode::Char(c @ '1'..='9') => HarpoonMenuAction::Jump(c as u8 - b'0'),
+        KeyCode::Enter if len > 0 => HarpoonMenuAction::Jump((cursor + 1) as u8),
+        KeyCode::Char('K') if cursor > 0 && len > 1 => HarpoonMenuAction::Swap {
+            from: cursor,
+            to: cursor - 1,
+        },
+        KeyCode::Char('J') if cursor + 1 < len => HarpoonMenuAction::Swap {
+            from: cursor,
+            to: cursor + 1,
+        },
+        KeyCode::Char('d') if delete_armed && cursor < len => HarpoonMenuAction::DeleteAt(cursor),
+        KeyCode::Char('d') => HarpoonMenuAction::ArmDelete,
+        _ => HarpoonMenuAction::Ignore,
+    }
+}
 
 impl App {
     /// Path under the cursor (file or directory) that the harpoon
@@ -184,107 +266,310 @@ impl App {
     ///   `dd` — delete slot under cursor (vim convention; first `d`
     ///          arms, second `d` confirms; any other key disarms)
     ///   `Esc`/`q` — close menu
-    pub fn handle_harpoon_menu_key(&mut self, key: crossterm::event::KeyEvent) -> Vec<Effect> {
-        use crossterm::event::KeyCode;
-        let Some(menu) = self.view.harpoon_menu.as_mut() else {
+    pub fn handle_harpoon_menu_key(&mut self, key: KeyEvent) -> Vec<Effect> {
+        let Some(menu) = self.view.harpoon_menu.as_ref() else {
             return Vec::new();
         };
-        let Some(h) = self.state.cur_mut().harpoon.as_mut() else {
-            self.view.harpoon_menu = None;
-            self.view.needs_full_repaint = true;
+        let Some(h) = self.state.cur().harpoon.as_ref() else {
+            self.close_harpoon_menu();
             return Vec::new();
         };
-        let len = h.slots.len();
-
-        // `dd` arming. The pending-d flag lives on App so it survives
-        // across this call (which can't borrow `menu` mutably across
-        // re-entry). Using a local approach: piggyback on `cursor`'s
-        // high bit would be hacky — keep it simple and use a separate
-        // bool field on `HarpoonMenu`.
-        let pending_delete = menu.delete_armed;
-        if pending_delete {
-            menu.delete_armed = false;
+        let snap = HarpoonMenuSnapshot {
+            cursor: menu.cursor,
+            len: h.slots.len(),
+            delete_armed: menu.delete_armed,
+        };
+        // Any key disarms a pending `dd`; `ArmDelete` re-arms below.
+        if let Some(m) = self.view.harpoon_menu.as_mut() {
+            m.delete_armed = false;
         }
 
-        match key.code {
-            KeyCode::Esc | KeyCode::Char('q') => {
-                self.view.harpoon_menu = None;
-                self.view.needs_full_repaint = true;
+        match decide_harpoon_menu_key(snap, key.code) {
+            HarpoonMenuAction::Ignore => {}
+            HarpoonMenuAction::Close => self.close_harpoon_menu(),
+            HarpoonMenuAction::MoveTo(idx) => {
+                if let Some(m) = self.view.harpoon_menu.as_mut() {
+                    m.cursor = idx;
+                }
             }
-            KeyCode::Char('j') | KeyCode::Down if len > 0 => {
-                menu.cursor = (menu.cursor + 1).min(len - 1);
-            }
-            KeyCode::Char('k') | KeyCode::Up if len > 0 => {
-                menu.cursor = menu.cursor.saturating_sub(1);
-            }
-            KeyCode::Char('g') if len > 0 => {
-                menu.cursor = 0;
-            }
-            KeyCode::Char('G') if len > 0 => {
-                menu.cursor = len - 1;
-            }
-            KeyCode::Char(c @ '1'..='9') => {
-                let slot = c as u8 - b'0';
-                self.view.harpoon_menu = None;
-                self.view.needs_full_repaint = true;
+            HarpoonMenuAction::Jump(slot) => {
+                self.close_harpoon_menu();
                 self.harpoon_jump(slot);
             }
-            KeyCode::Enter if len > 0 => {
-                let slot = (menu.cursor + 1) as u8;
-                self.view.harpoon_menu = None;
-                self.view.needs_full_repaint = true;
-                self.harpoon_jump(slot);
-            }
-            KeyCode::Char('K') if menu.cursor > 0 && len > 1 => {
-                h.swap(menu.cursor, menu.cursor - 1);
-                menu.cursor -= 1;
-                if let Err(e) = h.save() {
-                    self.state
-                        .flash_error(format!("harpoon save failed: {e:#}"));
+            HarpoonMenuAction::Swap { from, to } => {
+                if let Some(h) = self.state.cur_mut().harpoon.as_mut() {
+                    h.swap(from, to);
                 }
-                self.sync_harpoon_filter_set();
-            }
-            KeyCode::Char('J') if menu.cursor + 1 < len => {
-                h.swap(menu.cursor, menu.cursor + 1);
-                menu.cursor += 1;
-                if let Err(e) = h.save() {
-                    self.state
-                        .flash_error(format!("harpoon save failed: {e:#}"));
+                if let Some(m) = self.view.harpoon_menu.as_mut() {
+                    m.cursor = to;
                 }
-                self.sync_harpoon_filter_set();
+                self.save_harpoon_after_menu_edit();
             }
-            KeyCode::Char('d') => {
-                if pending_delete && menu.cursor < len {
-                    let removed_idx = menu.cursor;
-                    h.remove_at(removed_idx);
-                    if let Err(e) = h.save() {
-                        self.state
-                            .flash_error(format!("harpoon save failed: {e:#}"));
-                    }
-                    self.sync_harpoon_filter_set();
-                    if matches!(self.state.cur().temp_filter.as_deref(), Some("h")) {
-                        self.state.rebuild_rows();
-                    }
-                    // Re-fetch menu since filter sync invalidates `menu` borrow
-                    if let Some(m) = self.view.harpoon_menu.as_mut() {
-                        let new_len = self
-                            .state
-                            .cur()
-                            .harpoon
-                            .as_ref()
-                            .map_or(0, |hh| hh.slots.len());
-                        if new_len == 0 {
-                            m.cursor = 0;
-                        } else {
-                            m.cursor = removed_idx.min(new_len - 1);
-                        }
-                    }
-                } else if let Some(m) = self.view.harpoon_menu.as_mut() {
+            HarpoonMenuAction::ArmDelete => {
+                if let Some(m) = self.view.harpoon_menu.as_mut() {
                     m.delete_armed = true;
                 }
             }
-            _ => {}
+            HarpoonMenuAction::DeleteAt(idx) => self.harpoon_menu_delete(idx),
         }
         Vec::new()
+    }
+
+    /// Drop the menu overlay and force the repaint that erases it.
+    const fn close_harpoon_menu(&mut self) {
+        self.view.harpoon_menu = None;
+        self.view.needs_full_repaint = true;
+    }
+
+    /// Persist a menu-driven mutation and refresh the `=h` filter set. A write
+    /// failure flashes rather than unwinds: the in-memory list already changed,
+    /// so the menu must keep rendering what it now holds.
+    fn save_harpoon_after_menu_edit(&mut self) {
+        let err = self
+            .state
+            .cur()
+            .harpoon
+            .as_ref()
+            .and_then(|h| h.save().err());
+        if let Some(e) = err {
+            self.state
+                .flash_error(format!("harpoon save failed: {e:#}"));
+        }
+        self.sync_harpoon_filter_set();
+    }
+
+    /// `dd` — remove the slot at `idx`, then re-clamp the menu cursor against
+    /// the shortened list so it can't dangle past the end.
+    fn harpoon_menu_delete(&mut self, idx: usize) {
+        if let Some(h) = self.state.cur_mut().harpoon.as_mut() {
+            h.remove_at(idx);
+        }
+        self.save_harpoon_after_menu_edit();
+        if matches!(self.state.cur().temp_filter.as_deref(), Some("h")) {
+            self.state.rebuild_rows();
+        }
+        let new_len = self
+            .state
+            .cur()
+            .harpoon
+            .as_ref()
+            .map_or(0, |h| h.slots.len());
+        if let Some(m) = self.view.harpoon_menu.as_mut() {
+            m.cursor = if new_len == 0 {
+                0
+            } else {
+                idx.min(new_len - 1)
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod menu_key_tests {
+    use super::{HarpoonMenuAction, HarpoonMenuSnapshot, decide_harpoon_menu_key};
+    use crossterm::event::KeyCode;
+
+    /// A menu over `len` slots with the cursor parked at `cursor`, nothing armed.
+    const fn snap(cursor: usize, len: usize) -> HarpoonMenuSnapshot {
+        HarpoonMenuSnapshot {
+            cursor,
+            len,
+            delete_armed: false,
+        }
+    }
+
+    const fn armed(cursor: usize, len: usize) -> HarpoonMenuSnapshot {
+        HarpoonMenuSnapshot {
+            cursor,
+            len,
+            delete_armed: true,
+        }
+    }
+
+    fn decide(s: HarpoonMenuSnapshot, c: KeyCode) -> HarpoonMenuAction {
+        decide_harpoon_menu_key(s, c)
+    }
+
+    #[test]
+    fn esc_and_q_close() {
+        assert_eq!(decide(snap(0, 3), KeyCode::Esc), HarpoonMenuAction::Close);
+        assert_eq!(
+            decide(snap(0, 3), KeyCode::Char('q')),
+            HarpoonMenuAction::Close
+        );
+    }
+
+    #[test]
+    fn j_and_k_move_and_clamp_at_both_ends() {
+        assert_eq!(
+            decide(snap(0, 3), KeyCode::Char('j')),
+            HarpoonMenuAction::MoveTo(1)
+        );
+        // At the last slot `j` stays put — the menu does not wrap.
+        assert_eq!(
+            decide(snap(2, 3), KeyCode::Char('j')),
+            HarpoonMenuAction::MoveTo(2)
+        );
+        assert_eq!(
+            decide(snap(2, 3), KeyCode::Char('k')),
+            HarpoonMenuAction::MoveTo(1)
+        );
+        // At the top `k` stays put.
+        assert_eq!(
+            decide(snap(0, 3), KeyCode::Char('k')),
+            HarpoonMenuAction::MoveTo(0)
+        );
+    }
+
+    #[test]
+    fn arrows_mirror_j_and_k() {
+        assert_eq!(
+            decide(snap(0, 3), KeyCode::Down),
+            decide(snap(0, 3), KeyCode::Char('j'))
+        );
+        assert_eq!(
+            decide(snap(2, 3), KeyCode::Up),
+            decide(snap(2, 3), KeyCode::Char('k'))
+        );
+    }
+
+    #[test]
+    fn g_and_shift_g_jump_to_the_ends() {
+        assert_eq!(
+            decide(snap(2, 5), KeyCode::Char('g')),
+            HarpoonMenuAction::MoveTo(0)
+        );
+        assert_eq!(
+            decide(snap(0, 5), KeyCode::Char('G')),
+            HarpoonMenuAction::MoveTo(4)
+        );
+    }
+
+    #[test]
+    fn motions_are_inert_on_an_empty_list() {
+        // Every `len`-guarded motion must fall through rather than compute a
+        // cursor against `len - 1` and underflow.
+        for code in [
+            KeyCode::Char('j'),
+            KeyCode::Char('k'),
+            KeyCode::Char('g'),
+            KeyCode::Char('G'),
+            KeyCode::Down,
+            KeyCode::Up,
+            KeyCode::Enter,
+        ] {
+            assert_eq!(
+                decide(snap(0, 0), code),
+                HarpoonMenuAction::Ignore,
+                "{code:?} should be inert with no slots"
+            );
+        }
+    }
+
+    #[test]
+    fn enter_jumps_to_the_one_based_slot_under_the_cursor() {
+        assert_eq!(
+            decide(snap(0, 3), KeyCode::Enter),
+            HarpoonMenuAction::Jump(1)
+        );
+        assert_eq!(
+            decide(snap(2, 3), KeyCode::Enter),
+            HarpoonMenuAction::Jump(3)
+        );
+    }
+
+    #[test]
+    fn digits_address_slots_directly_even_past_the_end() {
+        // Deliberate asymmetry with the motion keys: a digit is the same verb
+        // as `H5` outside the menu, so an out-of-range digit still closes the
+        // menu and lets `harpoon_jump` flash "slot N empty".
+        assert_eq!(
+            decide(snap(0, 2), KeyCode::Char('5')),
+            HarpoonMenuAction::Jump(5)
+        );
+        assert_eq!(
+            decide(snap(0, 0), KeyCode::Char('1')),
+            HarpoonMenuAction::Jump(1)
+        );
+        // `0` is not a slot.
+        assert_eq!(
+            decide(snap(0, 3), KeyCode::Char('0')),
+            HarpoonMenuAction::Ignore
+        );
+    }
+
+    #[test]
+    fn shift_k_and_shift_j_reorder_and_carry_the_cursor() {
+        assert_eq!(
+            decide(snap(1, 3), KeyCode::Char('K')),
+            HarpoonMenuAction::Swap { from: 1, to: 0 }
+        );
+        assert_eq!(
+            decide(snap(1, 3), KeyCode::Char('J')),
+            HarpoonMenuAction::Swap { from: 1, to: 2 }
+        );
+    }
+
+    #[test]
+    fn reorder_is_inert_at_the_edges() {
+        // `K` at the top and `J` at the bottom have nothing to swap with.
+        assert_eq!(
+            decide(snap(0, 3), KeyCode::Char('K')),
+            HarpoonMenuAction::Ignore
+        );
+        assert_eq!(
+            decide(snap(2, 3), KeyCode::Char('J')),
+            HarpoonMenuAction::Ignore
+        );
+        // A single slot can't be reordered in either direction.
+        assert_eq!(
+            decide(snap(0, 1), KeyCode::Char('K')),
+            HarpoonMenuAction::Ignore
+        );
+        assert_eq!(
+            decide(snap(0, 1), KeyCode::Char('J')),
+            HarpoonMenuAction::Ignore
+        );
+    }
+
+    #[test]
+    fn first_d_arms_and_second_d_deletes() {
+        assert_eq!(
+            decide(snap(1, 3), KeyCode::Char('d')),
+            HarpoonMenuAction::ArmDelete
+        );
+        assert_eq!(
+            decide(armed(1, 3), KeyCode::Char('d')),
+            HarpoonMenuAction::DeleteAt(1)
+        );
+    }
+
+    #[test]
+    fn an_armed_d_over_no_slots_re_arms_instead_of_deleting() {
+        assert_eq!(
+            decide(armed(0, 0), KeyCode::Char('d')),
+            HarpoonMenuAction::ArmDelete
+        );
+    }
+
+    #[test]
+    fn unbound_keys_are_swallowed_not_leaked() {
+        // The menu owns all input while open — nothing may fall through to the
+        // resolver behind it.
+        for code in [
+            KeyCode::Char('x'),
+            KeyCode::Char('z'),
+            KeyCode::Tab,
+            KeyCode::Left,
+            KeyCode::Right,
+            KeyCode::Home,
+            KeyCode::F(1),
+        ] {
+            assert_eq!(
+                decide(snap(1, 3), code),
+                HarpoonMenuAction::Ignore,
+                "{code:?} must be swallowed"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #178.

Both modal key handlers debtmap flagged as complex-and-untested get the
`route.rs` / `focus.rs` treatment: a `Copy` snapshot, a pure `decide_*` fn, and
a handler that does nothing but apply the returned action.

| | before | after |
|---|---|---|
| `handle_harpoon_menu_key` | cyclomatic 22, **0% coverage** | 12 tests on the pure half |
| `handle_find_picker_key` | cyclomatic 20, **0% coverage** | 10 tests on the pure half |

This isn't only coverage. Pushing the guards into the decision lets
`HarpoonMenuAction::MoveTo` absorb `j`/`k`/`g`/`G` into a single applier arm and
`Swap` absorb `K`/`J`, so the branching the metric was measuring actually goes
away rather than getting a test draped over it.

### Behavior-preserving

No user-visible change — no keybinding, status, or render difference, so no doc
updates. Two things worth calling out because they read as decisions:

- **The digit keys stay unguarded on `len`**, per review. `1`..`9` in the menu is
  direct slot addressing — the same verb as `H5` outside it — so pressing `5`
  over a 2-slot list still closes the menu and lets `harpoon_jump` flash
  "slot 5 empty". Every *motion* key (`j`/`k`/`g`/`G`/`Enter`) is inert on an
  empty list; the digits deliberately aren't. There's a test naming the
  asymmetry so it doesn't read as an oversight later.
- **`Enter` on an empty find result is now an explicit `Close`** instead of an
  `Accept` whose target resolves to `None`. Identical behavior; it just becomes
  decidable in the pure half.

### Checked

- `make check-ci` → `=== GATE: PASS ===` (fmt + clippy pedantic/nursery + full suite)
- 22 new tests, weighted toward negatives — `^c` must not type a literal `c`
  into the find query, `Shift`+letter must still type, `Down` on the last result
  is inert, `K`/`J` are inert at the edges, and unbound keys stay swallowed
  rather than leaking to the resolver behind either modal.
- No bugs surfaced on the way through: `Harpoon::swap`/`remove_at` are already
  bounds-guarded, the `dd` arming clears correctly on any intervening key, and
  the menu cursor can't go stale because the menu owns all input while open. So
  there's no `fix:` commit riding along.

Generated with [Claude Code](https://claude.com/claude-code)
