### PR TITLE
fix(archive): a mount path is neither a member nor a real file

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -501,6 +501,11 @@ they land in a session-scoped staging dir that is cleaned up on exit.
   `:archive write`; the suffix carries a `+2 ~1 -3` badge meanwhile. An edit made
   outside spyc — by your editor, or by an agent in the pane — is noticed too,
   because spyc compares each extracted file against what it wrote.
+- **The archive is still a file** — where it lives, `pkg.zip` can be yanked,
+  copied, renamed and deleted like anything else, mounted or not. Leaving one and
+  pressing `Enter` again re-enters it without re-reading it, so pending changes
+  survive the round trip. Deleting or moving the archive drops its mount with it —
+  unless it carries unwritten changes, which would then have nowhere to go.
 - **Not yet supported inside an archive** — creating an empty directory or a new
   file, moving across the archive boundary in one step, `:grep`, `F`, marks,
   harpoon and shell commands are refused with a message rather than

--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -18,6 +18,14 @@ impl App {
     /// Kick a mount for `path`. `confirmed` is set on the second pass, after the
     /// user answered a size prompt.
     pub(super) fn request_mount(&mut self, path: &Path, confirmed: bool) -> Vec<Effect> {
+        // Already mounted: step back in rather than reading it again. A re-mount
+        // installs a fresh journal, so it would silently discard changes the user
+        // hasn't written back — and for a compressed tar it would re-stream the
+        // whole archive to learn what it already knows.
+        if self.state.mounts.contains(path) {
+            self.enter_mount(path);
+            return Vec::new();
+        }
         let Some(staging_root) = staging_root_for(path) else {
             self.state
                 .flash_error("archive: no state directory to stage into");
@@ -51,7 +59,7 @@ impl App {
     /// immediately; otherwise the extraction rides a worker and `then` happens
     /// when it lands. Either way the caller doesn't have to know which.
     pub(super) fn open_member(&mut self, path: &Path, then: MaterializeThen) -> Vec<Effect> {
-        let Some((mount, _)) = self.state.mounts.resolve(path) else {
+        let Some((mount, _)) = self.state.mounts.member_of(path) else {
             return Vec::new();
         };
         let Some(entry) = mount.entry_at(path).cloned() else {
@@ -574,6 +582,26 @@ impl App {
             // and the screen stays a rewriter.
             ArchiveSink::Materialize { members, then } => {
                 self.extraction_effect(&members, MaterializeThen::Retry(then))
+            }
+            // The archive file itself is going away. Its mount has to go with it,
+            // but not its unwritten changes: those would vanish with nothing to
+            // put them back into, so say so instead.
+            ArchiveSink::UnmountFirst { archives, effect } => {
+                if let Some(dirty) = archives.iter().find(|a| self.mount_is_dirty(a)) {
+                    self.state.flash_error(format!(
+                        "{}: unwritten changes — :archive write or :archive discard first",
+                        display_name(dirty)
+                    ));
+                    return None;
+                }
+                for archive in &archives {
+                    if let Some(staging) = self.state.mounts.remove(archive) {
+                        // Cleaning it is an effect, and the one effect this
+                        // returns is the user's — teardown collects it.
+                        self.state.mounts.defer_cleanup(staging);
+                    }
+                }
+                Some(*effect)
             }
             ArchiveSink::Record(changes) => {
                 self.record_pending(changes);

--- a/src/app/archive_route.rs
+++ b/src/app/archive_route.rs
@@ -88,10 +88,13 @@ pub fn route_archive_effect(
     }
     match classify(&effect, mounts, is_staged, inventory_names) {
         Verdict::Pass => ArchiveSink::PassThrough(effect),
-        Verdict::Need(members) => ArchiveSink::Materialize {
+        // Substitute what's already on disk now, and let the extraction's own
+        // result substitute the rest — an op must never see a mount path.
+        Verdict::Need { members, staged } => ArchiveSink::Materialize {
             members,
-            then: Box::new(effect),
+            then: Box::new(rewrite_paths(effect, &staged)),
         },
+        Verdict::Staged(staged) => ArchiveSink::PassThrough(rewrite_paths(effect, &staged)),
         Verdict::Refuse(why) => ArchiveSink::Refuse(why),
         Verdict::TakesContainer(archives) => ArchiveSink::UnmountFirst {
             archives,
@@ -107,7 +110,14 @@ pub fn route_archive_effect(
 /// The decision, before the effect is moved into a sink.
 enum Verdict {
     Pass,
-    Need(Vec<PathBuf>),
+    /// Extract `members`; `staged` names the ones already on disk, whose paths are
+    /// substituted before the effect is held back.
+    Need {
+        members: Vec<PathBuf>,
+        staged: HashMap<PathBuf, PathBuf>,
+    },
+    /// Every member named is on disk already — only the paths need substituting.
+    Staged(HashMap<PathBuf, PathBuf>),
     Refuse(&'static str),
     TakesContainer(Vec<PathBuf>),
     Record(Vec<PendingChange>),
@@ -398,23 +408,50 @@ fn join_inner(dir: &str, name: &str) -> String {
     }
 }
 
-/// The members among `paths` that aren't extracted yet.
+/// Sort the members among `paths` into "needs extracting" and "already on disk,
+/// here is where".
 ///
-/// A mounted archive named here is a real file already, so it needs nothing — a
-/// read of `pkg.zip` itself is a read of `pkg.zip`, mounted or not.
+/// A member's bytes are **never** at its mount path — extracted, they live in the
+/// staging tree, so an op naming one has to be pointed there whether or not
+/// anything had to be extracted first. Skipping the substitution because nothing
+/// needed extracting is how a yank inside a streamed `.tar.gz` (where the mount
+/// stages every member up front) reached the OS as
+/// `demo.tar.gz/src/main.rs: Not a directory`.
+///
+/// A mounted archive named here is a real file already and needs neither: a read
+/// of `pkg.zip` itself is a read of `pkg.zip`, mounted or not.
 fn need(paths: &[PathBuf], mounts: &Mounts, is_staged: &dyn Fn(&Path) -> bool) -> Verdict {
-    let members: Vec<PathBuf> = paths
-        .iter()
-        .filter(|p| mounts.holds_member(p) && !is_staged(p))
-        .cloned()
-        .collect();
-    if members.is_empty() {
-        // Either nothing is in an archive, or every member is already extracted —
-        // in both cases the effect's paths are real files right now.
-        Verdict::Pass
-    } else {
-        Verdict::Need(members)
+    let mut wanted: Vec<PathBuf> = Vec::new();
+    let mut staged: HashMap<PathBuf, PathBuf> = HashMap::new();
+    for path in paths.iter().filter(|p| mounts.holds_member(p)) {
+        match staging_path(path, mounts).filter(|_| is_staged(path)) {
+            Some(real) => {
+                staged.insert(path.clone(), real);
+            }
+            // Not extracted — or extracted somewhere we can't name, in which case
+            // extracting it again is how it gets a path we can.
+            None => wanted.push(path.clone()),
+        }
     }
+    if wanted.is_empty() {
+        if staged.is_empty() {
+            // Nothing in `paths` is in an archive.
+            Verdict::Pass
+        } else {
+            Verdict::Staged(staged)
+        }
+    } else {
+        Verdict::Need {
+            members: wanted,
+            staged,
+        }
+    }
+}
+
+/// Where a member's extracted bytes live, or would.
+fn staging_path(member: &Path, mounts: &Mounts) -> Option<PathBuf> {
+    let (mount, _) = mounts.member_of(member)?;
+    mount.entry_at(member).map(|e| mount.staging_path(e))
 }
 
 fn graveyard_paths(op: &super::graveyard_ops::GraveyardOp) -> Vec<PathBuf> {

--- a/src/app/archive_route.rs
+++ b/src/app/archive_route.rs
@@ -33,6 +33,14 @@ pub enum ArchiveSink {
     },
     /// Can't be done inside an archive; the string is shown to the user.
     Refuse(&'static str),
+    /// The op takes the archive *file* — deleting, moving or renaming it. Drop
+    /// these mounts first, then run it: a mount keyed on a path that no longer
+    /// holds that archive would resolve a future file's members against a stale
+    /// index.
+    UnmountFirst {
+        archives: Vec<PathBuf>,
+        effect: Box<Effect>,
+    },
     /// The op means something different inside a container: record it as a pending
     /// change rather than touching the filesystem. Deleting or renaming a member
     /// is an index edit, which is why either costs nothing however large it is.
@@ -85,6 +93,10 @@ pub fn route_archive_effect(
             then: Box::new(effect),
         },
         Verdict::Refuse(why) => ArchiveSink::Refuse(why),
+        Verdict::TakesContainer(archives) => ArchiveSink::UnmountFirst {
+            archives,
+            effect: Box::new(effect),
+        },
         Verdict::Record(changes) => ArchiveSink::Record(changes),
         Verdict::RewriteAndRecord { effect, changes } => {
             ArchiveSink::RewriteAndRecord { effect, changes }
@@ -97,6 +109,7 @@ enum Verdict {
     Pass,
     Need(Vec<PathBuf>),
     Refuse(&'static str),
+    TakesContainer(Vec<PathBuf>),
     Record(Vec<PendingChange>),
     RewriteAndRecord {
         effect: Box<Effect>,
@@ -123,7 +136,7 @@ fn classify(
         // container, which is a different feature.
         Effect::FileOp(FileOp::Copy { paths, dest }) => {
             if mounts.contains(dest) {
-                if paths.iter().any(|p| mounts.contains(p)) {
+                if paths.iter().any(|p| mounts.holds_member(p)) {
                     return Verdict::Refuse("archive: copy out first, then in");
                 }
                 return bring_in(paths, dest, mounts);
@@ -139,7 +152,12 @@ fn classify(
         // A move out of an archive removes the member, and a rename inside it
         // rewrites the container.
         Effect::FileOp(FileOp::Move { paths, dest }) => {
-            let sources_in = paths.iter().filter(|p| mounts.contains(p)).count();
+            if !mounts.contains(dest)
+                && let Some(verdict) = takes_container(paths, mounts)
+            {
+                return verdict;
+            }
+            let sources_in = paths.iter().filter(|p| mounts.holds_member(p)).count();
             let dest_in = mounts.contains(dest);
             if sources_in == 0 && !dest_in {
                 return Verdict::Pass;
@@ -153,9 +171,17 @@ fn classify(
             Verdict::Refuse("archive: move in or out isn't a single step — copy, then delete")
         }
         Effect::FileOp(FileOp::RenameEach { pairs, .. }) => {
+            // Renaming the archive file itself is an ordinary rename, once its
+            // mount stops claiming the old name.
+            if !pairs.iter().any(|(_, dst)| mounts.contains(dst)) {
+                let srcs: Vec<PathBuf> = pairs.iter().map(|(src, _)| src.clone()).collect();
+                if let Some(verdict) = takes_container(&srcs, mounts) {
+                    return verdict;
+                }
+            }
             let touching = pairs
                 .iter()
-                .filter(|(src, dst)| mounts.contains(src) || mounts.contains(dst))
+                .filter(|(src, dst)| mounts.holds_member(src) || mounts.contains(dst))
                 .count();
             if touching == 0 {
                 return Verdict::Pass;
@@ -205,8 +231,19 @@ fn classify(
         // different recovery stories (the graveyard vs. the journal).
         Effect::Graveyard(op) => {
             let paths = graveyard_paths(op);
+            // A restore writes a new file, which is a write into the container.
+            if matches!(op, super::graveyard_ops::GraveyardOp::Restore { .. }) {
+                return if paths.iter().any(|p| mounts.contains(p)) {
+                    Verdict::Refuse("archive: restore outside the archive, then copy it in")
+                } else {
+                    Verdict::Pass
+                };
+            }
+            if let Some(verdict) = takes_container(&paths, mounts) {
+                return verdict;
+            }
             let (members, outside): (Vec<&PathBuf>, Vec<&PathBuf>) =
-                paths.iter().partition(|p| mounts.contains(p));
+                paths.iter().partition(|p| mounts.holds_member(p));
             if members.is_empty() {
                 return Verdict::Pass;
             }
@@ -218,7 +255,7 @@ fn classify(
             let changes = members
                 .iter()
                 .filter_map(|p| {
-                    let (mount, _) = mounts.resolve(p)?;
+                    let (mount, _) = mounts.member_of(p)?;
                     let entry = mount.entry_at(p)?;
                     Some(PendingChange::Delete {
                         archive: mount.archive().to_path_buf(),
@@ -298,7 +335,7 @@ fn rename_within(paths: &[PathBuf], dest: &Path, mounts: &Mounts) -> Verdict {
     }
     let mut changes = Vec::new();
     for path in paths {
-        let Some((src_mount, from)) = mounts.resolve(path) else {
+        let Some((src_mount, from)) = mounts.member_of(path) else {
             return Verdict::Refuse("archive: rename members within the archive, not across it");
         };
         if src_mount.archive() != mount.archive() {
@@ -319,10 +356,33 @@ fn rename_within(paths: &[PathBuf], dest: &Path, mounts: &Mounts) -> Verdict {
     Verdict::Record(changes)
 }
 
+/// The mounted archive *files* among `paths`, when the op would move or remove
+/// them — a container going away has to take its mount with it.
+///
+/// `None` when nothing in `paths` is a mount root, which is the common case.
+fn takes_container(paths: &[PathBuf], mounts: &Mounts) -> Option<Verdict> {
+    let archives: Vec<PathBuf> = paths
+        .iter()
+        .filter(|p| mounts.get(p).is_some())
+        .cloned()
+        .collect();
+    if archives.is_empty() {
+        return None;
+    }
+    if paths.iter().any(|p| mounts.holds_member(p)) {
+        // One is a change to a container, the other a change to what's inside
+        // one: different recovery stories, so not in a single step.
+        return Some(Verdict::Refuse(
+            "archive: select members or whole archives, not both",
+        ));
+    }
+    Some(Verdict::TakesContainer(archives))
+}
+
 /// One `(src, dst)` pair as a rename, when both sides are the same container.
 fn rename_change(src: &Path, dst: &Path, mounts: &Mounts) -> Option<PendingChange> {
-    let (src_mount, from) = mounts.resolve(src)?;
-    let (dst_mount, to) = mounts.resolve(dst)?;
+    let (src_mount, from) = mounts.member_of(src)?;
+    let (dst_mount, to) = mounts.member_of(dst)?;
     (src_mount.archive() == dst_mount.archive()).then(|| PendingChange::Rename {
         archive: src_mount.archive().to_path_buf(),
         from,
@@ -339,10 +399,13 @@ fn join_inner(dir: &str, name: &str) -> String {
 }
 
 /// The members among `paths` that aren't extracted yet.
+///
+/// A mounted archive named here is a real file already, so it needs nothing — a
+/// read of `pkg.zip` itself is a read of `pkg.zip`, mounted or not.
 fn need(paths: &[PathBuf], mounts: &Mounts, is_staged: &dyn Fn(&Path) -> bool) -> Verdict {
     let members: Vec<PathBuf> = paths
         .iter()
-        .filter(|p| mounts.contains(p) && !is_staged(p))
+        .filter(|p| mounts.holds_member(p) && !is_staged(p))
         .cloned()
         .collect();
     if members.is_empty() {
@@ -813,5 +876,78 @@ mod tests {
             panic!("shape preserved");
         };
         assert_eq!(path, PathBuf::from("/dev/zero"));
+    }
+
+    // ── the container itself ─────────────────────────────────────────────
+
+    /// The archive file is a real file: reading it is not a member read, so it
+    /// passes straight through however it's named.
+    #[test]
+    fn reading_the_archive_file_itself_passes_through() {
+        let mounts = mounts_with(&["a.txt"]);
+        let container = PathBuf::from("/src/pkg.zip");
+        for effect in [
+            Effect::Inventory(InventoryOp::Yank {
+                paths: vec![container.clone()],
+            }),
+            Effect::FileOp(FileOp::FileType {
+                paths: vec![container.clone()],
+            }),
+            Effect::FileOp(FileOp::Copy {
+                paths: vec![container],
+                dest: PathBuf::from("/elsewhere"),
+            }),
+        ] {
+            assert!(
+                matches!(
+                    route_archive_effect(effect, &mounts, &nothing_staged, &no_names),
+                    ArchiveSink::PassThrough(_)
+                ),
+                "a mounted archive is still an ordinary file to read"
+            );
+        }
+    }
+
+    /// Deleting, moving or renaming the archive takes the mount with it — left
+    /// behind, it would resolve a future file at that path against a stale index.
+    #[test]
+    fn an_op_that_takes_the_container_unmounts_it_first() {
+        let mounts = mounts_with(&["a.txt"]);
+        let container = PathBuf::from("/src/pkg.zip");
+        for effect in [
+            Effect::Graveyard(crate::app::graveyard_ops::GraveyardOp::Archive {
+                paths: vec![container.clone()],
+            }),
+            Effect::FileOp(FileOp::Move {
+                paths: vec![container.clone()],
+                dest: PathBuf::from("/elsewhere"),
+            }),
+            Effect::FileOp(FileOp::RenameEach {
+                pairs: vec![(container.clone(), PathBuf::from("/src/renamed.zip"))],
+                is_move: false,
+            }),
+        ] {
+            let sink = route_archive_effect(effect, &mounts, &nothing_staged, &no_names);
+            let ArchiveSink::UnmountFirst { archives, .. } = sink else {
+                panic!("expected an unmount, got {sink:?}");
+            };
+            assert_eq!(archives, std::slice::from_ref(&container));
+        }
+    }
+
+    /// One is a change to a container, the other a change to what's inside one.
+    /// They recover differently, so they aren't done in a single step.
+    #[test]
+    fn deleting_a_container_and_a_member_together_is_refused() {
+        let mounts = mounts_with(&["a.txt"]);
+        let sink = route_archive_effect(
+            Effect::Graveyard(crate::app::graveyard_ops::GraveyardOp::Archive {
+                paths: vec![PathBuf::from("/src/pkg.zip"), member("a.txt")],
+            }),
+            &mounts,
+            &nothing_staged,
+            &no_names,
+        );
+        assert!(matches!(sink, ArchiveSink::Refuse(_)), "got {sink:?}");
     }
 }

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -552,11 +552,16 @@ fn settle(app: &mut App, effects: Vec<Effect>) {
                     let outcome = crate::app::file_ops::run_file_op(op);
                     app.runtime.file_results.lock().unwrap().push(outcome);
                 }
+                Effect::Graveyard(op) => {
+                    let outcome = crate::app::graveyard_ops::run_graveyard_op(op);
+                    app.runtime.graveyard_results.lock().unwrap().push(outcome);
+                }
                 _ => {}
             }
         }
         let (_, fx) = app.apply_archive_outcomes();
         next.extend(fx);
+        app.apply_graveyard_outcomes();
         app.apply_inventory_outcomes();
         let (_, file_fx) = app.apply_file_outcomes();
         next.extend(file_fx);
@@ -1142,5 +1147,203 @@ fn an_external_edit_makes_the_mount_dirty_and_is_written_back() {
         let check = tmp.path().join("check");
         let real = crate::archive::read::materialize(&archive, entry, &check).unwrap();
         assert_eq!(std::fs::read(real).unwrap(), b"edited outside spyc");
+    });
+}
+
+// ── the archive file itself is not a member of itself ─────────────────────
+
+/// The reported bug: leaving an archive and coming back reported
+/// "archive: no such member".
+///
+/// The cursor lands on the archive file, whose path is the live mount's *root* —
+/// so asking "is this path in a mount?" said yes and the member branch asked the
+/// index for the entry named `""`. A container is not a member of itself.
+#[test]
+fn leaving_an_archive_and_coming_back_re_enters_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir.clone());
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+        assert_eq!(app.state.cur().listing.dir, dir, "out of the archive");
+
+        let fx = app.apply(&Action::EnterOrDisplay).unwrap();
+        settle(&mut app, fx);
+
+        assert_eq!(
+            app.state.cur().listing.dir,
+            archive,
+            "back inside: {:?}",
+            app.state.flash.as_ref().map(|f| f.text.clone())
+        );
+        assert_eq!(row_names(&app), ["src/", "README.md"]);
+    });
+}
+
+/// Re-entering must not re-read the archive: a fresh mount installs a fresh
+/// journal, so a pending delete would vanish — and for a compressed tar it would
+/// re-stream the whole thing to learn what it already knew.
+#[test]
+fn re_entering_keeps_unwritten_changes() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Delete `README.md`, then leave and come back.
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::RemovePrompt(None)).unwrap();
+        let fx = if fx.is_empty() {
+            app.handle_remove_confirm_key(crossterm::event::KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::empty(),
+            ))
+        } else {
+            fx
+        };
+        settle(&mut app, fx);
+        assert!(app.mount_is_dirty(&archive), "dirty before leaving");
+
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+        let fx = app.apply(&Action::EnterOrDisplay).unwrap();
+        settle(&mut app, fx);
+
+        assert!(
+            app.mount_is_dirty(&archive),
+            "the pending delete survived the round trip"
+        );
+        assert!(
+            !app.state
+                .cur()
+                .rows
+                .iter()
+                .any(|r| r.display.contains("README")),
+            "and the listing still reflects it"
+        );
+    });
+}
+
+/// A mounted archive is still an ordinary file where it lives: reading it reads
+/// the container's own bytes, not a member's.
+#[test]
+fn yanking_a_mounted_archive_takes_the_container_itself() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Step out so the cursor is on the archive file, and yank it.
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+
+        let held: Vec<String> = app
+            .state
+            .inventory
+            .items()
+            .map(|i| i.filename.clone())
+            .collect();
+        assert_eq!(held, ["pkg.zip"], "the archive itself is what got yanked");
+    });
+}
+
+/// Deleting the archive drops its mount with it. Left registered, it would claim
+/// the path — so a *new* file created there would be browsed through the old
+/// archive's index.
+#[test]
+fn deleting_a_mounted_archive_drops_the_mount() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+        let fx = app.apply(&Action::RemovePrompt(None)).unwrap();
+        let fx = if fx.is_empty() {
+            app.handle_remove_confirm_key(crossterm::event::KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::empty(),
+            ))
+        } else {
+            fx
+        };
+        settle(&mut app, fx);
+
+        assert!(!archive.exists(), "the archive is gone from disk");
+        assert!(
+            !app.state.mounts.contains(&archive),
+            "and so is its mount: {:?}",
+            app.state.flash.as_ref().map(|f| f.text.clone())
+        );
+    });
+}
+
+/// ...unless it holds changes nobody wrote back. Those would go with it and have
+/// nowhere to be put, so the delete is refused instead.
+#[test]
+fn deleting_a_dirty_mounted_archive_is_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Delete a member, climb out, then try to delete the archive.
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::RemovePrompt(None)).unwrap();
+        let fx = if fx.is_empty() {
+            app.handle_remove_confirm_key(crossterm::event::KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::empty(),
+            ))
+        } else {
+            fx
+        };
+        settle(&mut app, fx);
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+
+        let fx = app.apply(&Action::RemovePrompt(None)).unwrap();
+        let fx = if fx.is_empty() {
+            app.handle_remove_confirm_key(crossterm::event::KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::empty(),
+            ))
+        } else {
+            fx
+        };
+        settle(&mut app, fx);
+
+        assert!(archive.exists(), "the archive is still there");
+        assert!(app.state.mounts.contains(&archive), "still mounted");
+        let flash = app.state.flash.as_ref().map(|f| f.text.clone());
+        assert!(
+            flash.as_deref().is_some_and(|t| t.contains("unwritten")),
+            "and the refusal says why: {flash:?}"
+        );
     });
 }

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -1347,3 +1347,162 @@ fn deleting_a_dirty_mounted_archive_is_refused() {
         );
     });
 }
+
+// ── an extracted member's bytes are in staging, never at its mount path ───
+
+/// Same three members, as a `.tar.gz` — a *streamed* mount, which extracts every
+/// member as it reads because a compressed tar can't be listed any other way.
+fn build_tar_gz(path: &Path) {
+    let enc = flate2::write::GzEncoder::new(
+        std::fs::File::create(path).unwrap(),
+        flate2::Compression::default(),
+    );
+    let mut b = tar::Builder::new(enc);
+    for (name, body) in [
+        ("README.md", "# pkg\n"),
+        ("src/main.rs", "fn main() {}\n"),
+        ("src/deep/mod.rs", "pub fn helper() {}\n"),
+    ] {
+        let mut h = tar::Header::new_gnu();
+        h.set_size(body.len() as u64);
+        h.set_mode(0o644);
+        h.set_mtime(1_000_000);
+        h.set_entry_type(tar::EntryType::Regular);
+        b.append_data(&mut h, name, body.as_bytes()).unwrap();
+    }
+    b.into_inner().unwrap().finish().unwrap();
+}
+
+/// The reported bug: `y` inside a `.tar.gz` failed with
+/// `demo.tar.gz/src/main.rs: Not a directory`.
+///
+/// A streamed mount stages every member up front, so nothing needed extracting —
+/// and the screen took "nothing to extract" to mean "these paths are real", when
+/// a member's bytes are in the staging tree and its mount path is never a file.
+#[test]
+fn yanking_a_member_of_a_streamed_archive_captures_its_contents() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.tar.gz");
+        build_tar_gz(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+
+        let item = app
+            .state
+            .inventory
+            .items()
+            .find(|i| i.filename == "README.md")
+            .unwrap_or_else(|| {
+                panic!(
+                    "the member should be in the inventory; flash: {:?}",
+                    app.state.flash.as_ref().map(|f| f.text.clone())
+                )
+            });
+        assert_eq!(
+            app.state.inventory.read_content(&item.id).as_deref(),
+            Some(b"# pkg\n".as_slice()),
+            "and it carries the member's real bytes"
+        );
+    });
+}
+
+/// The same hole with a seekable archive: reading a member stages it, so the
+/// *second* read is the one that finds nothing to extract.
+#[test]
+fn reading_a_member_twice_still_reads_its_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+        app.apply(&Action::Down(1)).unwrap();
+
+        // First read extracts it; second finds it staged.
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+        app.state.flash = None;
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+
+        // The second yank is the one under test, so its *outcome* is what has to
+        // be clean — an inventory item from the first read would hide a failure.
+        assert!(
+            !matches!(
+                app.state.flash.as_ref().map(|f| f.kind),
+                Some(crate::app::FlashKind::Error)
+            ),
+            "the second yank failed: {:?}",
+            app.state.flash.as_ref().map(|f| f.text.clone())
+        );
+        let held: Vec<_> = app
+            .state
+            .inventory
+            .items()
+            .filter(|i| i.filename == "README.md")
+            .map(|i| app.state.inventory.read_content(&i.id))
+            .collect();
+        assert!(!held.is_empty(), "and the member is in the inventory");
+        for content in held {
+            assert_eq!(
+                content.as_deref(),
+                Some(b"# pkg\n".as_slice()),
+                "every copy carries the member's bytes"
+            );
+        }
+    });
+}
+
+/// A mixed selection is the subtle half: extracting only what's missing means the
+/// worker's own result can't be the whole substitution, so the already-staged
+/// member would keep its mount path.
+#[test]
+fn a_mixed_selection_rewrites_the_staged_member_too() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Stage `README.md` by yanking it, then yank it together with a member
+        // that is still only an index entry.
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+
+        let readme = archive.join("README.md");
+        let main = archive.join("src/main.rs");
+        let fx = app.screen_archive_effect(Effect::Inventory(
+            crate::app::inventory_ops::InventoryOp::Yank {
+                paths: vec![readme.clone(), main.clone()],
+            },
+        ));
+        let Some(Effect::Archive(ArchiveOp::MaterializeMany { then, .. })) = fx else {
+            panic!("expected the extraction to be held back, got {fx:?}");
+        };
+        let crate::app::archive_ops::MaterializeThen::Retry(effect) = then else {
+            panic!("a held-back read retries the original effect");
+        };
+        let Effect::Inventory(crate::app::inventory_ops::InventoryOp::Yank { paths }) = *effect
+        else {
+            panic!("shape preserved");
+        };
+        assert!(
+            !paths.contains(&readme),
+            "the staged member is already pointed at staging: {paths:?}"
+        );
+        assert!(
+            paths.contains(&main),
+            "and the unextracted one still waits for the worker: {paths:?}"
+        );
+    });
+}

--- a/src/app/navigate.rs
+++ b/src/app/navigate.rs
@@ -236,7 +236,9 @@ impl App {
 
         // A member of a mounted archive: its bytes aren't on disk yet, so read
         // it through the mount rather than opening a path that doesn't exist.
-        if self.state.mounts.contains(&path) {
+        // A *mounted archive* is not a member of itself — it falls through to the
+        // container branch below, so leaving one and coming back re-enters it.
+        if self.state.mounts.holds_member(&path) {
             return match intent {
                 ActivateIntent::Display => self.open_member(
                     &path,

--- a/src/app/pager_handler/mod.rs
+++ b/src/app/pager_handler/mod.rs
@@ -517,7 +517,7 @@ impl App {
         }
         // A member has no bytes on disk yet, so it is extracted first and the
         // editor opens on the extracted copy.
-        if self.state.mounts.contains(&path) {
+        if self.state.mounts.holds_member(&path) {
             return self.open_member(
                 &path,
                 crate::app::archive_ops::MaterializeThen::Edit { in_pane: true },

--- a/src/archive/mount.rs
+++ b/src/archive/mount.rs
@@ -84,21 +84,24 @@ impl ArchiveMount {
 /// The mounted archives, newest activity last.
 #[derive(Debug, Default)]
 pub struct Mounts {
-    mounts: Vec<ArchiveMount>,
+    live: Vec<ArchiveMount>,
+    /// Staging trees left behind by a mount dropped mid-session, still owed a
+    /// removal at teardown.
+    orphaned: Vec<PathBuf>,
     tick: u64,
 }
 
 impl Mounts {
     pub const fn is_empty(&self) -> bool {
-        self.mounts.is_empty()
+        self.live.is_empty()
     }
 
     pub const fn len(&self) -> usize {
-        self.mounts.len()
+        self.live.len()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &ArchiveMount> {
-        self.mounts.iter()
+        self.live.iter()
     }
 
     /// The mount containing `path`, with the inner path within it.
@@ -107,23 +110,42 @@ impl Mounts {
     /// another resolves to the inner one rather than whichever was registered
     /// first.
     pub fn resolve(&self, path: &Path) -> Option<(&ArchiveMount, String)> {
-        self.mounts
+        self.live
             .iter()
             .filter_map(|m| m.index.inner_of(path).map(|inner| (m, inner)))
             .max_by_key(|(m, _)| m.archive().as_os_str().len())
     }
 
-    /// Whether `path` is inside any mount.
+    /// Whether `path` is at or inside any mount.
+    ///
+    /// True for the archive file itself, which is what makes it a valid
+    /// *destination* — putting a file into `pkg.zip` means its root directory.
+    /// Asking "is this a member?" is [`Self::holds_member`].
     pub fn contains(&self, path: &Path) -> bool {
         self.resolve(path).is_some()
     }
 
+    /// The mount `path` is a **member** of, excluding the mount root.
+    ///
+    /// A mounted archive is still an ordinary file where it lives: it can be
+    /// entered, yanked, copied, renamed and deleted like any other. Treating it
+    /// as a member of itself asks the index for the entry named `""`, which is
+    /// how re-entering a mounted archive once failed with "no such member".
+    pub fn member_of(&self, path: &Path) -> Option<(&ArchiveMount, String)> {
+        self.resolve(path).filter(|(_, inner)| !inner.is_empty())
+    }
+
+    /// Whether `path` names a member inside a mount, rather than a container.
+    pub fn holds_member(&self, path: &Path) -> bool {
+        self.member_of(path).is_some()
+    }
+
     pub fn get(&self, archive: &Path) -> Option<&ArchiveMount> {
-        self.mounts.iter().find(|m| m.archive() == archive)
+        self.live.iter().find(|m| m.archive() == archive)
     }
 
     pub fn get_mut(&mut self, archive: &Path) -> Option<&mut ArchiveMount> {
-        self.mounts.iter_mut().find(|m| m.archive() == archive)
+        self.live.iter_mut().find(|m| m.archive() == archive)
     }
 
     /// Mark a mount as just used, which is what keeps it off the eviction block.
@@ -148,30 +170,30 @@ impl Mounts {
         mount.last_used = self.tick;
         // Re-mounting an archive replaces its entry rather than duplicating it.
         if let Some(pos) = self
-            .mounts
+            .live
             .iter()
             .position(|m| m.archive() == mount.archive())
         {
-            let old = std::mem::replace(&mut self.mounts[pos], mount);
-            return if old.staging_root == self.mounts[pos].staging_root {
+            let old = std::mem::replace(&mut self.live[pos], mount);
+            return if old.staging_root == self.live[pos].staging_root {
                 Vec::new()
             } else {
                 vec![old.staging_root]
             };
         }
-        self.mounts.push(mount);
+        self.live.push(mount);
 
         let mut evicted = Vec::new();
-        while self.mounts.len() > MAX_MOUNTS {
+        while self.live.len() > MAX_MOUNTS {
             let victim = self
-                .mounts
+                .live
                 .iter()
                 .enumerate()
                 .filter(|(_, m)| !protected.iter().any(|p| p == m.archive()) && !m.is_dirty())
                 .min_by_key(|(_, m)| m.last_used)
                 .map(|(i, _)| i);
             match victim {
-                Some(i) => evicted.push(self.mounts.remove(i).staging_root),
+                Some(i) => evicted.push(self.live.remove(i).staging_root),
                 // Everything is in use or dirty: hold them all rather than
                 // discard state the user still needs.
                 None => break,
@@ -182,17 +204,28 @@ impl Mounts {
 
     /// Drop a mount, returning its staging root to clean up.
     pub fn remove(&mut self, archive: &Path) -> Option<PathBuf> {
-        let pos = self.mounts.iter().position(|m| m.archive() == archive)?;
-        Some(self.mounts.remove(pos).staging_root)
+        let pos = self.live.iter().position(|m| m.archive() == archive)?;
+        Some(self.live.remove(pos).staging_root)
+    }
+
+    /// Hand back a staging root whose mount is gone but which nobody has removed
+    /// yet, so teardown still gets to it.
+    ///
+    /// The caller that drops a mount can't always emit the removal itself — the
+    /// effect screen returns one effect, and it's the user's.
+    pub fn defer_cleanup(&mut self, root: PathBuf) {
+        self.orphaned.push(root);
     }
 
     /// Drop every mount, returning all staging roots — the quit path.
     pub fn drain_all(&mut self) -> Vec<PathBuf> {
-        self.mounts.drain(..).map(|m| m.staging_root).collect()
+        let mut roots: Vec<PathBuf> = self.live.drain(..).map(|m| m.staging_root).collect();
+        roots.append(&mut self.orphaned);
+        roots
     }
 
     pub fn dirty_count(&self) -> usize {
-        self.mounts.iter().filter(|m| m.is_dirty()).count()
+        self.live.iter().filter(|m| m.is_dirty()).count()
     }
 }
 
@@ -229,6 +262,40 @@ mod tests {
 
         let (_, root) = mounts.resolve(Path::new("/src/pkg.zip")).unwrap();
         assert_eq!(root, "", "the archive's own path is the mount root");
+    }
+
+    /// A container is not a member of itself. Conflating the two asks the index
+    /// for the entry named `""`, which is how re-entering a mounted archive once
+    /// failed with "no such member" — and it's why a mounted `pkg.zip` can still
+    /// be yanked, copied, renamed and deleted like the file it is.
+    #[test]
+    fn a_mount_root_is_not_one_of_its_own_members() {
+        let mut mounts = Mounts::default();
+        mounts.insert(mount_at("/src/pkg.zip", &["a/b.txt"]), &[]);
+
+        let root = Path::new("/src/pkg.zip");
+        assert!(mounts.contains(root), "the root is at a mount");
+        assert!(!mounts.holds_member(root), "but it is not a member");
+        assert!(mounts.member_of(root).is_none());
+
+        let member = Path::new("/src/pkg.zip/a/b.txt");
+        assert!(mounts.holds_member(member));
+        assert_eq!(
+            mounts.member_of(member).map(|(_, inner)| inner),
+            Some("a/b.txt".to_string())
+        );
+    }
+
+    /// A staging tree handed over when its mount was dropped mid-session is still
+    /// owed a removal, so teardown has to hand it back.
+    #[test]
+    fn a_deferred_staging_tree_is_still_returned_at_teardown() {
+        let mut mounts = Mounts::default();
+        mounts.insert(mount_at("/src/pkg.zip", &["a.txt"]), &[]);
+        let orphan = mounts.remove(Path::new("/src/pkg.zip")).unwrap();
+        mounts.defer_cleanup(orphan.clone());
+
+        assert_eq!(mounts.drain_all(), vec![orphan]);
     }
 
     #[test]


### PR DESCRIPTION
First bug from hand-driving the archive feature: enter either test archive, leave it, press `Enter` again → **`archive: no such member`**.

## Root cause

The cursor lands on the archive file, and that path *is* the live mount's root. `Mounts::contains` answers "at or inside a mount", which is true of the root — so `activate` took the member branch and asked the index for the entry named `""`.

One accessor was being asked two different questions. `contains` is right for a **destination** (putting a file into `pkg.zip` means its root directory) and wrong for **"is this a member"**. The member sites now ask `holds_member`, which excludes the root; destination sites keep `contains`.

## Two more defects fell out of the same confusion

Both were reachable the moment re-entry worked, so fixing only the reported symptom would have shipped the second one:

- **Every ordinary op on a mounted archive** was broken or misleadingly refused. `y` / `c` / `f` / `L` tried to extract member `""`; `R` and `M` on the archive were refused with the wrong reason. A mounted `pkg.zip` is still an ordinary file where it lives.
- **Re-entry silently discarded pending changes.** A re-mount installs a fresh `Journal`, and `Mounts::insert` *replaces* the entry — so a pending delete would vanish with no sign. Re-entry now enters the existing mount without re-reading it, which also means a `.tar.gz` doesn't re-stream to learn what it already knew.

## Deleting the container

An op that takes the archive away — delete, move, rename — has to drop its mount. Left registered, the mount claims a path it no longer holds, and a **new** file created there would be browsed through the old archive's index.

The pure router classifies it (`Verdict::TakesContainer` → `ArchiveSink::UnmountFirst`); the screen, which can stat, refuses when the mount carries unwritten changes rather than losing them. Cleaning the staging tree is an effect and the one effect the screen returns is the user's, so `Mounts` keeps the orphaned root and teardown collects it.

Also here: restoring a graveyard entry into a mount now says so, instead of reporting the same misleading "no such member".

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- Six new tests. The ones worth reading: `leaving_an_archive_and_coming_back_re_enters_it` (the report), `re_entering_keeps_unwritten_changes` (the data-loss one — delete a member, leave, come back, the change is still pending), `deleting_a_mounted_archive_drops_the_mount` and `deleting_a_dirty_mounted_archive_is_refused` (the two container outcomes), plus `a_mount_root_is_not_one_of_its_own_members` stating the invariant where it lives.
- `settle()` gained a `Graveyard` arm so a delete actually reaches the filesystem in the harness — the previous member-delete tests only exercised the journal, which is why this class of bug had no coverage.
- A release binary is built for hand-driving, but I haven't driven it — the bug this fixes was found by hand-driving, which is the point.

Generated with [Claude Code](https://claude.com/claude-code)
