### PR TITLE
fix(pane): the image overlay was undismissable — put it on the modal axis

### DIFF
--- a/src/app/key_dispatch/mod.rs
+++ b/src/app/key_dispatch/mod.rs
@@ -250,6 +250,7 @@ impl App {
             route::InputSink::QuickSelect => return Ok(self.handle_quick_select_key(key)),
             route::InputSink::Harpoon => return Ok(self.handle_harpoon_menu_key(key)),
             route::InputSink::ImageGallery => return Ok(self.handle_image_gallery_key(key)),
+            route::InputSink::ImageView => return Ok(self.handle_image_view_key(key)),
             // ── content sinks ──
             route::InputSink::OverlayPty => {
                 // Forward the keystroke to the overlay pty via the sole
@@ -595,6 +596,7 @@ impl App {
             route::InputSink::QuickSelect
             | route::InputSink::Harpoon
             | route::InputSink::ImageGallery
+            | route::InputSink::ImageView
             | route::InputSink::PaneScroll => Vec::new(),
             // ── content sinks ──
             route::InputSink::Prompt => {

--- a/src/app/modal.rs
+++ b/src/app/modal.rs
@@ -15,6 +15,9 @@
 /// Which transient modal overlay is swallowing input, if any.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum Modal {
+    /// Full-screen image overlay (`view.image_view`). First because it is the
+    /// last surface drawn — nothing is visible beneath it to aim a key at.
+    ImageView,
     /// `F` fuzzy-finder picker (`runtime.find_picker`).
     FindPicker,
     /// A `!` capture child is running (`runtime.pending_capture`).
@@ -34,6 +37,7 @@ pub(super) enum Modal {
 /// inline. Each field is the `is_some()` / bool of a backing modal field.
 #[derive(Debug, Clone, Copy)]
 pub(super) struct ModalSnapshot {
+    pub has_image_view: bool,
     pub has_find_picker: bool,
     pub has_capture: bool,
     pub overlay_awaiting_dismiss: bool,
@@ -45,13 +49,15 @@ pub(super) struct ModalSnapshot {
 /// Decide which [`Modal`] (if any) owns input. **Pure** — no mutation, no I/O.
 ///
 /// Branch order is the precedence the historical `handle_key` pre-check ladder
-/// used: finder > capture > overlay-dismiss > quick-select > harpoon >
-/// image-gallery. In
+/// used, with the full-screen image overlay ahead of it: image-view > finder >
+/// capture > overlay-dismiss > quick-select > harpoon > image-gallery. In
 /// practice at most one is ever live at once (a single pager slot + the modal
 /// open/close discipline), but pinning the order keeps the decision total and
 /// the routing deterministic if two were ever set.
 pub(super) const fn active_modal(snap: ModalSnapshot) -> Option<Modal> {
-    if snap.has_find_picker {
+    if snap.has_image_view {
+        Some(Modal::ImageView)
+    } else if snap.has_find_picker {
         Some(Modal::FindPicker)
     } else if snap.has_capture {
         Some(Modal::Capture)
@@ -75,6 +81,7 @@ mod tests {
     /// Snapshot with no modal active.
     const fn none() -> ModalSnapshot {
         ModalSnapshot {
+            has_image_view: false,
             has_find_picker: false,
             has_capture: false,
             overlay_awaiting_dismiss: false,
@@ -133,6 +140,7 @@ mod tests {
     #[test]
     fn precedence_order() {
         let all = ModalSnapshot {
+            has_image_view: true,
             has_image_gallery: true,
             has_find_picker: true,
             has_capture: true,
@@ -140,10 +148,17 @@ mod tests {
             has_quick_select: true,
             has_harpoon: true,
         };
-        assert_eq!(active_modal(all), Some(Modal::FindPicker));
+        // The full-screen image overlay is the last surface drawn, so it takes
+        // the key ahead of everything beneath it.
+        assert_eq!(active_modal(all), Some(Modal::ImageView));
+        let zero = ModalSnapshot {
+            has_image_view: false,
+            ..all
+        };
+        assert_eq!(active_modal(zero), Some(Modal::FindPicker));
         let a = ModalSnapshot {
             has_find_picker: false,
-            ..all
+            ..zero
         };
         assert_eq!(active_modal(a), Some(Modal::Capture));
         let b = ModalSnapshot {

--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -255,6 +255,7 @@ impl super::App {
                 has_quick_select: self.view.quick_select.is_some(),
                 has_harpoon: self.view.harpoon_menu.is_some(),
                 has_image_gallery: self.view.image_gallery.is_some(),
+                has_image_view: self.view.image_view.is_some(),
             }),
             region,
             pager_mount: self.focused_top_pager_mount(),

--- a/src/app/pager_handler/image.rs
+++ b/src/app/pager_handler/image.rs
@@ -22,7 +22,7 @@ impl App {
     /// swallowed so nothing scrolls underneath): `s` save, `y` copy the image,
     /// `Y` copy the source/path, `c` toggle light/dark, `b` flip to a base64
     /// text buffer, `o` open externally, q/Esc/i dismiss.
-    pub(super) fn handle_image_view_key(&mut self, key: KeyEvent) -> Vec<Effect> {
+    pub(crate) fn handle_image_view_key(&mut self, key: KeyEvent) -> Vec<Effect> {
         match key.code {
             KeyCode::Esc | KeyCode::Char('q' | 'i') => {
                 self.view.image_view = None;

--- a/src/app/pager_handler/mod.rs
+++ b/src/app/pager_handler/mod.rs
@@ -95,11 +95,11 @@ impl App {
     }
 
     fn dispatch_pager_key(&mut self, key: KeyEvent) -> Vec<Effect> {
-        // The full-screen image overlay sits on top of the pager and is modal:
-        // intercept before any pager handler and route to its own verbs.
-        if self.view.image_view.is_some() {
-            return self.handle_image_view_key(key);
-        }
+        // No image-overlay check here: `Modal::ImageView` takes the key before
+        // routing ever reaches a pager sink. This used to intercept, which only
+        // worked while the overlay was reachable *from a pager* — once it could
+        // open from the file list or the gallery, a pane-focused key went to the
+        // child instead and the overlay was undismissable.
         let Some(view) = active_pager_mut!(self) else {
             return Vec::new();
         };

--- a/src/app/route.rs
+++ b/src/app/route.rs
@@ -63,6 +63,8 @@ pub(super) enum InputSink {
     Harpoon,
     /// Agent image gallery popup is open.
     ImageGallery,
+    /// Full-screen image overlay is up.
+    ImageView,
     // ── content sinks: the focused region owns the input ──
     /// In-app prompt is active (`Mode::Prompting`); the key feeds
     /// the prompt's line editor.
@@ -151,6 +153,7 @@ pub(super) const fn route_input(snap: RouteSnapshot, kind: InputKind) -> InputSi
     // Modal layer — a single typed value (precedence decided by `active_modal`)
     // maps straight to its sink. Eats every input kind before the content layer.
     match snap.modal {
+        Some(Modal::ImageView) => return InputSink::ImageView,
         Some(Modal::FindPicker) => return InputSink::FindPicker,
         Some(Modal::Capture) => return InputSink::Capture,
         Some(Modal::OverlayDismiss) => return InputSink::OverlayDismiss,
@@ -259,6 +262,7 @@ impl App {
                 has_quick_select: self.view.quick_select.is_some(),
                 has_harpoon: self.view.harpoon_menu.is_some(),
                 has_image_gallery: self.view.image_gallery.is_some(),
+                has_image_view: self.view.image_view.is_some(),
             }),
             is_prompting: matches!(self.state.mode, Mode::Prompting(_)),
             // The authoritative focus, recomputed at the loop top before this
@@ -745,6 +749,42 @@ mod tests {
         assert_eq!(route_key(snap, key('1')), InputSink::Harpoon);
         assert_eq!(route_key(snap, ctrl('a')), InputSink::Harpoon);
         assert_eq!(route_input(snap, InputKind::Paste), InputSink::Harpoon);
+    }
+
+    // ── regression: the full-screen image overlay was undismissable ──
+    //
+    // The reported symptom: previewing a pasted image left the overlay stuck —
+    // `q`/`Esc` did nothing. The overlay is the LAST surface drawn, but it was
+    // only consulted inside `handle_pager_key`, so it received keys solely when
+    // a pager happened to be open. With the pane focused (the normal case when
+    // opening it from `^a g`) routing sent every key to the child instead, and
+    // nothing could dismiss it. These pin the modal layer as the authority.
+
+    #[test]
+    fn the_image_overlay_owns_input_with_the_pane_focused() {
+        let snap = RouteSnapshot {
+            modal: Some(Modal::ImageView),
+            has_pane_tabs: true,
+            focus: Focus::Pane,
+            ..idle()
+        };
+        // The exact stuck keys, plus a meta chord and a paste.
+        assert_eq!(route_key(snap, key('q')), InputSink::ImageView);
+        assert_eq!(route_key(snap, ctrl('a')), InputSink::ImageView);
+        assert_eq!(route_input(snap, InputKind::Paste), InputSink::ImageView);
+    }
+
+    /// Opened from the file list (`Enter` on a PNG) — no pager, list focus.
+    #[test]
+    fn the_image_overlay_owns_input_with_the_list_focused() {
+        let snap = RouteSnapshot {
+            modal: Some(Modal::ImageView),
+            has_pane_tabs: true,
+            focus: Focus::FileList,
+            ..idle()
+        };
+        assert_eq!(route_key(snap, key('q')), InputSink::ImageView);
+        assert_eq!(route_key(snap, key('j')), InputSink::ImageView);
     }
 
     // ── regression: paste into a pager's `/` search (#16) ─────────────


### PR DESCRIPTION
Dogfood bug: previewing a pasted image left the overlay **stuck** — `q`/`Esc` did nothing, no way back to the frame.

## Root cause

The image overlay is the **last surface drawn** — nothing is visible beneath it to aim a key at — but it appeared nowhere in the routing ladder. It was consulted only inside `handle_pager_key`, so it received keys solely when a pager happened to be open.

That assumption held while the only way to raise it was a ` ```mermaid ` block *inside a pager*. #300 made it openable from the file list and #302/#304 from the gallery, and it broke:

| focus when the overlay opens | what `q` / `Esc` did |
| --- | --- |
| **Pane** (normal case via `^a g`) | forwarded to the child agent — **undismissable** |
| File list (`Enter` on a PNG) | hit the resolver, where `q` is a reserved no-op — ignored |

I introduced this in #300 by widening how the overlay could be reached without moving it onto the input authority.

## Fix

`Modal::ImageView` at the head of the precedence ladder, matching draw order, with `InputSink::ImageView` carrying every input kind to the overlay's verbs.

The old pager-side interception is **removed rather than kept as a backstop** — two places deciding who owns a keystroke is what produced this, and the modal axis is the authority the input-authority campaign established for exactly this class of surface.

## Testing

`make check-ci` green (2197 tests). Two regression tests pin the broken focus cases (pane-focused and list-focused, covering `q`, `Esc`, a meta chord and a paste).

`modal::precedence_order` **failed on this change and was extended, not relaxed** — it caught the reordering, which is its job. It now asserts `ImageView` first, then peels it off and re-asserts the original ladder underneath unchanged.

Build at `target/release/spyc`.
