### PR TITLE
feat(archive): come back to a place inside an archive, mounting it on the way

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -506,10 +506,15 @@ they land in a session-scoped staging dir that is cleaned up on exit.
   pressing `Enter` again re-enters it without re-reading it, so pending changes
   survive the round trip. Deleting or moving the archive drops its mount with it —
   unless it carries unwritten changes, which would then have nowhere to go.
+- **Coming back to a place inside one** — a mark (`ma`), a harpoon slot (`Ha`)
+  and the session you quit from can all point inside an archive. Jumping to one
+  mounts the archive again on the way, so it doesn't matter that nothing has it
+  open — `spyc -r` puts you back where you left off, several directories deep in
+  a tarball.
 - **Not yet supported inside an archive** — creating an empty directory or a new
-  file, moving across the archive boundary in one step, `:grep`, `F`, marks,
-  harpoon and shell commands are refused with a message rather than
-  half-working. The suffix shows `ro` when the archive can't be written back.
+  file, moving across the archive boundary in one step, `:grep`, `F` and shell
+  commands are refused with a message rather than half-working. The suffix shows
+  `ro` when the archive can't be written back.
 - **An agent can read a member too** — MCP `get_file_content` resolves a path
   inside a mount, reading the container in memory (or your not-yet-written edit,
   if there is one), so asking the agent in the pane about the file you're looking

--- a/src/app/actions.rs
+++ b/src/app/actions.rs
@@ -491,7 +491,7 @@ impl App {
                         .flash_info("graveyard: p restore here · P original · dd/x purge · ? help");
                 }
             }
-            Action::HarpoonJump(n) => self.harpoon_jump(*n),
+            Action::HarpoonJump(n) => return Ok(self.harpoon_jump(*n)),
             Action::HarpoonAppend => self.harpoon_append(),
             Action::HarpoonRemove => self.harpoon_remove(),
             Action::HarpoonOpenMenu => self.harpoon_open_menu(),

--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -18,11 +18,26 @@ impl App {
     /// Kick a mount for `path`. `confirmed` is set on the second pass, after the
     /// user answered a size prompt.
     pub(super) fn request_mount(&mut self, path: &Path, confirmed: bool) -> Vec<Effect> {
+        self.request_mount_then(path, confirmed, None)
+    }
+
+    /// Mount `path`, then run `then` — the held-back effect that wanted a place
+    /// inside it. See [`Self::mount_and_retry`].
+    pub(super) fn request_mount_then(
+        &mut self,
+        path: &Path,
+        confirmed: bool,
+        then: Option<Box<Effect>>,
+    ) -> Vec<Effect> {
         // Already mounted: step back in rather than reading it again. A re-mount
         // installs a fresh journal, so it would silently discard changes the user
         // hasn't written back — and for a compressed tar it would re-stream the
         // whole archive to learn what it already knows.
         if self.state.mounts.contains(path) {
+            // Already mounted, so whatever was waiting on it can just run.
+            if let Some(effect) = then {
+                return vec![*effect];
+            }
             self.enter_mount(path);
             return Vec::new();
         }
@@ -44,6 +59,7 @@ impl App {
             max_entries: self.state.config.archive.max_entries,
             confirmed,
             cancel: std::sync::Arc::clone(&self.runtime.archive_cancel),
+            then,
         })]
     }
 
@@ -110,6 +126,7 @@ impl App {
                 capability,
                 warnings,
                 staging_root,
+                then,
             } => {
                 let archive = index.archive.clone();
                 let notes = mount_notes(&capability, &warnings);
@@ -127,8 +144,17 @@ impl App {
                     &protected,
                 );
                 // Enter it, then say what was odd about it — the flash outlives
-                // the chdir, so the note is what the user is left reading.
-                self.enter_mount(&archive);
+                // the chdir, so the note is what the user is left reading. A
+                // held-back effect names where to land instead, and re-running it
+                // is what gets the cursor and the message it came with.
+                let mut effects = clean_effects(evicted);
+                match then {
+                    Some(effect) => {
+                        self.state.mounts.touch(&archive);
+                        effects.push(*effect);
+                    }
+                    None => self.enter_mount(&archive),
+                }
                 if let Some(note) = notes.first() {
                     let extra = notes.len().saturating_sub(1);
                     self.state.flash_info(if extra > 0 {
@@ -138,9 +164,17 @@ impl App {
                     });
                 }
                 self.view.needs_full_repaint = true;
-                clean_effects(evicted)
+                effects
             }
-            ArchiveOutcome::NeedsConfirm { path, question } => {
+            ArchiveOutcome::NeedsConfirm {
+                path,
+                question,
+                then,
+            } => {
+                // The prompt is a round trip through the keyboard, and a
+                // `PromptKind` is plain data — so what was waiting on the mount
+                // waits here until the answer comes back.
+                self.runtime.archive_mount_then = then.map(|effect| (path.clone(), effect));
                 self.state.mode = Mode::Prompting(Prompt::simple(
                     PromptKind::ArchiveMountConfirm { path },
                     format!("{question} [Y/n] "),
@@ -554,7 +588,39 @@ impl App {
     ///
     /// `Some` means execute it; `None` means it was held back for extraction (or
     /// refused), and the drain will bring it round again once the bytes exist.
+    /// Two questions, in order: does this effect want an archive mounted before it
+    /// can run at all, and does it name something inside one that already is?
     pub(super) fn screen_archive_effect(&mut self, effect: Effect) -> Option<Effect> {
+        self.mount_and_retry(effect)
+    }
+
+    /// Hold back a `ChangeDir` that names a place inside an archive nobody has
+    /// mounted, and mount it first.
+    ///
+    /// Every way of landing on a path goes through this effect — a mark, a harpoon
+    /// slot, a restored session, `navigate_to`, `J` — so doing it here means none
+    /// of them has to know that a path can name a place inside a file. The mount
+    /// carries the original effect and re-issues it, which is how the cursor
+    /// target and the message survive the round trip.
+    fn mount_and_retry(&mut self, effect: Effect) -> Option<Effect> {
+        let Effect::ChangeDir { path, .. } = &effect else {
+            return self.screen_mount_paths(effect);
+        };
+        // An already-mounted path is served from the index by `chdir_into_mount`,
+        // and a real directory is a real directory.
+        if !self.state.config.archive.enable || self.state.mounts.contains(path) || path.is_dir() {
+            return self.screen_mount_paths(effect);
+        }
+        let Some((archive, _inner)) = archive_ancestor_of(path) else {
+            return self.screen_mount_paths(effect);
+        };
+        self.request_mount_then(&archive, false, Some(Box::new(effect)))
+            .into_iter()
+            .next()
+    }
+
+    /// The member/container screen proper: [`route_archive_effect`]'s verdict.
+    fn screen_mount_paths(&mut self, effect: Effect) -> Option<Effect> {
         use super::archive_route::{ArchiveSink, route_archive_effect};
         let staged_check = |p: &Path| {
             self.state
@@ -817,6 +883,19 @@ pub fn sweep_orphan_staging() {
             let _ = std::fs::remove_dir_all(entry.path());
         }
     }
+}
+
+/// [`super::archive_route::archive_ancestor`] against the real filesystem.
+///
+/// The name test runs before the `is_file` stat and costs no syscall, so an
+/// ordinary path pays nothing here — only one with an archive-shaped component in
+/// it goes on to ask the disk.
+pub(super) fn archive_ancestor_of(path: &Path) -> Option<(PathBuf, String)> {
+    super::archive_route::archive_ancestor(path, &|p: &Path| {
+        p.file_name()
+            .is_some_and(|n| crate::archive::looks_mountable(&n.to_string_lossy()))
+            && p.is_file()
+    })
 }
 
 fn clean_effects(roots: Vec<PathBuf>) -> Vec<Effect> {

--- a/src/app/archive_ops.rs
+++ b/src/app/archive_ops.rs
@@ -47,6 +47,11 @@ pub enum ArchiveOp {
         max_entries: usize,
         confirmed: bool,
         cancel: Arc<AtomicBool>,
+        /// An effect that was waiting for this archive to be mounted — a
+        /// `ChangeDir` naming a path inside it, held back because the mount
+        /// didn't exist yet. Re-issued once it does, so the original keeps its
+        /// cursor target and its message. `None` for an ordinary `Enter`.
+        then: Option<Box<super::Effect>>,
     },
     /// Extract one member so something can read it.
     Materialize {
@@ -90,11 +95,15 @@ pub enum ArchiveOutcome {
         capability: Capability,
         warnings: Vec<String>,
         staging_root: PathBuf,
+        /// The held-back effect from [`ArchiveOp::Mount`], to run now that the
+        /// mount exists.
+        then: Option<Box<super::Effect>>,
     },
     /// Big enough to ask about first. Answering `y` re-issues the op.
     NeedsConfirm {
         path: PathBuf,
         question: String,
+        then: Option<Box<super::Effect>>,
     },
     /// The magic bytes say this isn't a container after all — the name filter
     /// admitted it, so fall back to opening it as a file.
@@ -143,13 +152,17 @@ pub fn run_archive_op(op: ArchiveOp) -> ArchiveOutcome {
             max_entries,
             confirmed,
             cancel,
-        } => mount(
-            &path,
-            &staging_root,
-            &limits,
-            max_entries,
-            confirmed,
-            &cancel,
+            then,
+        } => carry_then(
+            mount(
+                &path,
+                &staging_root,
+                &limits,
+                max_entries,
+                confirmed,
+                &cancel,
+            ),
+            then,
         ),
         ArchiveOp::Materialize {
             archive,
@@ -212,6 +225,37 @@ pub fn run_archive_op(op: ArchiveOp) -> ArchiveOutcome {
     }
 }
 
+/// Attach the held-back effect to a mount outcome.
+///
+/// Done here rather than inside [`mount`] so the decision to carry something
+/// lives at the op boundary and `mount` keeps its one job. Only the two outcomes
+/// that lead somewhere carry it: a mount that failed, or turned out not to be an
+/// archive, has nowhere for a `ChangeDir` to land — and re-issuing it would find
+/// no mount, hold it back again, and mount in a circle.
+fn carry_then(outcome: ArchiveOutcome, then: Option<Box<super::Effect>>) -> ArchiveOutcome {
+    match outcome {
+        ArchiveOutcome::Mounted {
+            index,
+            capability,
+            warnings,
+            staging_root,
+            ..
+        } => ArchiveOutcome::Mounted {
+            index,
+            capability,
+            warnings,
+            staging_root,
+            then,
+        },
+        ArchiveOutcome::NeedsConfirm { path, question, .. } => ArchiveOutcome::NeedsConfirm {
+            path,
+            question,
+            then,
+        },
+        other => other,
+    }
+}
+
 fn mount(
     path: &Path,
     staging_root: &Path,
@@ -271,6 +315,8 @@ fn mount(
         capability,
         warnings,
         staging_root: staging_root.to_path_buf(),
+        // `carry_then` attaches the held-back effect at the op boundary.
+        then: None,
     }
 }
 
@@ -299,6 +345,7 @@ fn gate(
         }),
         MountDecision::Confirm(question) if ask && !confirmed => {
             Some(ArchiveOutcome::NeedsConfirm {
+                then: None,
                 path: path.to_path_buf(),
                 question,
             })
@@ -328,6 +375,7 @@ fn preflight_streamed(
             error: why,
         }),
         MountDecision::Confirm(question) if !confirmed => Some(ArchiveOutcome::NeedsConfirm {
+            then: None,
             path: path.to_path_buf(),
             question,
         }),
@@ -386,6 +434,7 @@ mod tests {
             max_entries: 1000,
             confirmed,
             cancel: Arc::new(AtomicBool::new(false)),
+            then: None,
         })
     }
 

--- a/src/app/archive_route.rs
+++ b/src/app/archive_route.rs
@@ -366,6 +366,38 @@ fn rename_within(paths: &[PathBuf], dest: &Path, mounts: &Mounts) -> Verdict {
     Verdict::Record(changes)
 }
 
+/// The archive an *unmounted* path is inside, if any.
+///
+/// A mount is addressed under the archive's own path, so `…/pkg.zip/src` names a
+/// place inside `pkg.zip` whether or not it happens to be mounted right now. That
+/// is what turns a path saved earlier — a mark, a harpoon slot, a restored session
+/// cwd — back into "mount this, then go there", and it's the same walk that will
+/// find a nested container.
+///
+/// `is_container` is injected because deciding it means asking the filesystem
+/// whether an ancestor is a file; this half stays pure and testable.
+pub fn archive_ancestor(
+    path: &Path,
+    is_container: &dyn Fn(&Path) -> bool,
+) -> Option<(PathBuf, String)> {
+    // Deepest first: with a nested container the inner one owns the path.
+    for ancestor in path.ancestors() {
+        if !is_container(ancestor) {
+            continue;
+        }
+        let rel = path.strip_prefix(ancestor).ok()?;
+        if rel.as_os_str().is_empty() {
+            // The archive itself — mount it and land at its root.
+            return Some((ancestor.to_path_buf(), String::new()));
+        }
+        // Normalized for the same reason a member name is: a `..` between here
+        // and the archive would name somewhere outside it.
+        let inner = crate::archive::index::normalize(&rel.to_string_lossy()).ok()?;
+        return Some((ancestor.to_path_buf(), inner.inner));
+    }
+    None
+}
+
 /// The mounted archive *files* among `paths`, when the op would move or remove
 /// them — a container going away has to take its mount with it.
 ///
@@ -986,5 +1018,67 @@ mod tests {
             &no_names,
         );
         assert!(matches!(sink, ArchiveSink::Refuse(_)), "got {sink:?}");
+    }
+
+    // ── reaching a place inside an unmounted archive ──────────────────────
+
+    /// The predicate the App supplies from the filesystem; here it's a set.
+    fn containers(names: &[&str]) -> impl Fn(&Path) -> bool + use<> {
+        let set: Vec<PathBuf> = names.iter().map(PathBuf::from).collect();
+        move |p: &Path| set.iter().any(|c| c == p)
+    }
+
+    #[test]
+    fn a_path_inside_an_unmounted_archive_names_the_archive_and_the_way_in() {
+        let is_container = containers(&["/src/pkg.zip"]);
+        assert_eq!(
+            archive_ancestor(Path::new("/src/pkg.zip/a/b.txt"), &is_container),
+            Some((PathBuf::from("/src/pkg.zip"), "a/b.txt".to_string()))
+        );
+        // The archive itself: mount it and land at its root.
+        assert_eq!(
+            archive_ancestor(Path::new("/src/pkg.zip"), &is_container),
+            Some((PathBuf::from("/src/pkg.zip"), String::new()))
+        );
+    }
+
+    #[test]
+    fn an_ordinary_path_names_no_archive() {
+        let is_container = containers(&["/src/pkg.zip"]);
+        assert_eq!(
+            archive_ancestor(Path::new("/src/main.rs"), &is_container),
+            None
+        );
+        assert_eq!(archive_ancestor(Path::new("/src"), &is_container), None);
+        // Named like one but not a file on disk — the predicate is what decides.
+        assert_eq!(
+            archive_ancestor(Path::new("/src/other.zip/a"), &is_container),
+            None
+        );
+    }
+
+    /// With one archive inside another, the deepest owns the path — the same rule
+    /// `Mounts::resolve` applies to a live mount.
+    #[test]
+    fn the_innermost_container_wins() {
+        let is_container = containers(&["/src/outer.zip", "/src/outer.zip/inner.zip"]);
+        assert_eq!(
+            archive_ancestor(Path::new("/src/outer.zip/inner.zip/a.txt"), &is_container),
+            Some((
+                PathBuf::from("/src/outer.zip/inner.zip"),
+                "a.txt".to_string()
+            ))
+        );
+    }
+
+    /// A `..` between the archive and the target names somewhere outside it, so
+    /// there is nothing here to mount into.
+    #[test]
+    fn a_traversing_path_reaches_no_archive() {
+        let is_container = containers(&["/src/pkg.zip"]);
+        assert_eq!(
+            archive_ancestor(Path::new("/src/pkg.zip/../escape"), &is_container),
+            None
+        );
     }
 }

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -319,6 +319,7 @@ impl App {
                 image_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 archive_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 archive_cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                archive_mount_then: None,
                 file_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 listing_refresh_inflight: false,
                 listing_refresh_dirty: false,

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -37,6 +37,7 @@ fn mount_inline(app: &mut App, archive: &Path, staging: &Path) -> Vec<Effect> {
         max_entries: 1000,
         confirmed: false,
         cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        then: None,
     });
     assert!(
         matches!(outcome, ArchiveOutcome::Mounted { .. }),
@@ -556,6 +557,15 @@ fn settle(app: &mut App, effects: Vec<Effect>) {
                     let outcome = crate::app::graveyard_ops::run_graveyard_op(op);
                     app.runtime.graveyard_results.lock().unwrap().push(outcome);
                 }
+                // A mount re-issues the `ChangeDir` that was waiting for it.
+                Effect::ChangeDir {
+                    path,
+                    focus,
+                    on_ok,
+                    err_prefix,
+                } => app
+                    .state
+                    .change_dir(&path, focus.as_deref(), on_ok.as_deref(), err_prefix),
                 _ => {}
             }
         }
@@ -1503,6 +1513,164 @@ fn a_mixed_selection_rewrites_the_staged_member_too() {
         assert!(
             paths.contains(&main),
             "and the unextracted one still waits for the worker: {paths:?}"
+        );
+    });
+}
+
+// ── coming back to a place inside an archive ──────────────────────────────
+
+/// The smallest session that names a cwd — nothing else about it is under test.
+fn session_at(cwd: PathBuf) -> crate::state::sessions::Session {
+    crate::state::sessions::Session {
+        id: 1,
+        saved_at: String::new(),
+        epoch_secs: 0,
+        cwd,
+        tabs: Vec::new(),
+        active_tab: 0,
+        pane_height_pct: 30,
+        pane_focused: false,
+        name: String::new(),
+        project_home: None,
+        vsplit: None,
+        scope_claims: Vec::new(),
+    }
+}
+
+/// A mark inside an archive used to be refused, because the mount it pointed into
+/// was gone by the time you came back. Now the jump mounts it again.
+#[test]
+fn a_mark_inside_an_archive_mounts_it_again_on_the_way_back() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir.clone());
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Into `src/`, mark it, then leave the archive entirely.
+        app.apply(&Action::EnterOrDisplay).unwrap();
+        assert_eq!(app.state.cur().listing.dir, archive.join("src"));
+        app.apply(&Action::SetMark('a')).unwrap();
+
+        // `:archive unmount` steps the column out itself, then drops the mount.
+        let fx = app.cmd_archive("unmount");
+        settle(&mut app, fx);
+        assert!(!app.state.mounts.contains(&archive), "unmounted");
+        assert_eq!(app.state.cur().listing.dir, dir, "and out of it");
+
+        // The jump names a path inside a file. Nothing is mounted, so the effect
+        // screen has to mount it before the chdir can mean anything.
+        let fx = app.apply(&Action::JumpMark('a')).unwrap();
+        settle(&mut app, fx);
+
+        assert!(app.state.mounts.contains(&archive), "re-mounted");
+        assert_eq!(
+            app.state.cur().listing.dir,
+            archive.join("src"),
+            "and landed where the mark pointed: {:?}",
+            app.state.flash.as_ref().map(|f| f.text.clone())
+        );
+        assert_eq!(row_names(&app), ["deep/", "main.rs"]);
+    });
+}
+
+/// Quitting while browsing an archive and restoring the session puts you back
+/// inside it. The saved cwd is not a directory and never was, so the restore path
+/// can't `chdir` to it — it hands the effect screen a `ChangeDir` instead.
+#[test]
+fn restoring_a_session_that_ended_inside_an_archive_mounts_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+
+        let session = session_at(archive.join("src"));
+        let fx = app.restore_session(&session);
+        settle(&mut app, fx);
+
+        assert!(
+            app.state.mounts.contains(&archive),
+            "the archive is mounted"
+        );
+        assert_eq!(
+            app.state.cur().listing.dir,
+            archive.join("src"),
+            "back where the session ended: {:?}",
+            app.state.flash.as_ref().map(|f| f.text.clone())
+        );
+    });
+}
+
+/// A session whose cwd is simply gone still reports that, rather than being
+/// mistaken for an archive.
+#[test]
+fn restoring_a_session_whose_directory_is_gone_still_says_so() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let mut app = App::test_app(dir.clone());
+
+        let session = session_at(dir.join("no-such-dir"));
+        let fx = app.restore_session(&session);
+
+        assert!(fx.is_empty(), "nothing to mount");
+        let flash = app.state.flash.as_ref().map(|f| f.text.clone());
+        assert!(
+            flash.as_deref().is_some_and(|t| t.contains("gone")),
+            "{flash:?}"
+        );
+    });
+}
+
+/// Harpoon, the other bookmark: appending inside a mount is allowed now, and the
+/// slot jump comes back the same way a mark does.
+#[test]
+fn a_harpoon_slot_inside_an_archive_comes_back_to_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir.clone());
+        // Harpoon is keyed on the column's repo root or PROJECT_HOME; inside a
+        // mount there is no repo, so the archive's own project is the key.
+        app.state.project_home = Some(dir);
+        app.reconcile_harpoon();
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        app.apply(&Action::EnterOrDisplay).unwrap();
+        assert_eq!(app.state.cur().listing.dir, archive.join("src"));
+        app.apply(&Action::HarpoonAppend).unwrap();
+        assert!(
+            app.state
+                .cur()
+                .harpoon
+                .as_ref()
+                .is_some_and(|h| h.get(1).is_some()),
+            "the slot took: {:?}",
+            app.state.flash.as_ref().map(|f| f.text.clone())
+        );
+
+        let fx = app.cmd_archive("unmount");
+        settle(&mut app, fx);
+        assert!(!app.state.mounts.contains(&archive), "unmounted");
+
+        let fx = app.apply(&Action::HarpoonJump(1)).unwrap();
+        settle(&mut app, fx);
+        assert!(app.state.mounts.contains(&archive), "re-mounted");
+        assert_eq!(
+            app.state.cur().listing.dir,
+            archive.join("src"),
+            "{:?}",
+            app.state.flash.as_ref().map(|f| f.text.clone())
         );
     });
 }

--- a/src/app/harpoon.rs
+++ b/src/app/harpoon.rs
@@ -201,17 +201,22 @@ impl App {
     /// the directory if the slot is a directory). The user picks
     /// the verb (Enter, V, ^a s) afterwards. Missing-on-disk → flash
     /// and bail; we don't auto-prune (the user might be mid-rebase).
-    pub fn harpoon_jump(&mut self, slot: u8) {
+    pub fn harpoon_jump(&mut self, slot: u8) -> Vec<Effect> {
         let Some(h) = self.state.cur().harpoon.as_ref() else {
             self.state
                 .flash_error("harpoon: open a repo or set PROJECT_HOME (gP)");
-            return;
+            return Vec::new();
         };
         let Some(target) = h.get(slot).map(Path::to_path_buf) else {
             self.state.flash_info(format!("harpoon: slot {slot} empty"));
-            return;
+            return Vec::new();
         };
-        if !target.exists() {
+        // A slot inside an archive can't pass `exists` — its bytes are an index
+        // entry, and the archive may not even be mounted right now. The chdir
+        // itself mounts what it needs, so let it try.
+        let in_archive = self.state.mounts.contains(&target)
+            || super::archive::archive_ancestor_of(&target).is_some();
+        if !target.exists() && !in_archive {
             self.state.flash_error(format!(
                 "harpoon: gone — {}",
                 target.file_name().map_or_else(
@@ -219,25 +224,48 @@ impl App {
                     |n| n.to_string_lossy().into_owned(),
                 )
             ));
-            return;
+            return Vec::new();
         }
-        let (chdir_to, focus) = if target.is_dir() {
+        let is_dir = if in_archive {
+            // A member's kind lives in the index, and only while it's mounted.
+            // Unmounted, land next to it rather than guess — one keystroke from
+            // either answer, and never wrong.
+            self.state
+                .mounts
+                .resolve(&target)
+                .and_then(|(mount, inner)| mount.index.is_dir(&inner).then_some(()))
+                .is_some()
+        } else {
+            target.is_dir()
+        };
+        let (chdir_to, focus) = if is_dir {
             (target, None)
         } else if let Some(parent) = target.parent() {
             (parent.to_path_buf(), Some(target.clone()))
         } else {
             self.state.flash_error("harpoon: slot has no parent dir");
-            return;
+            return Vec::new();
         };
+        if in_archive {
+            // Through the effect screen, which mounts the archive first when
+            // nothing has it open — the inline chdir below can't.
+            return vec![Effect::ChangeDir {
+                path: chdir_to,
+                focus,
+                on_ok: Some(format!("harpoon[{slot}]")),
+                err_prefix: "harpoon chdir",
+            }];
+        }
         if let Err(e) = self.state.chdir(&chdir_to) {
             self.state.flash_error(format!("harpoon chdir: {e:#}"));
-            return;
+            return Vec::new();
         }
         if let Some(p) = focus {
             self.state.focus_on_path(&p);
         }
         self.state.rebuild_rows();
         self.state.flash_info(format!("harpoon[{slot}]"));
+        Vec::new()
     }
 
     /// `Hh` / `gh` — open the harpoon menu overlay. The menu

--- a/src/app/key_dispatch/confirms.rs
+++ b/src/app/key_dispatch/confirms.rs
@@ -178,8 +178,15 @@ impl App {
         else {
             return Vec::new();
         };
+        // Whatever was waiting on this mount was parked when the prompt went up.
+        let then = self
+            .runtime
+            .archive_mount_then
+            .take()
+            .filter(|(archive, _)| *archive == path)
+            .map(|(_, effect)| effect);
         if confirmed {
-            self.request_mount(&path, true)
+            self.request_mount_then(&path, true, then)
         } else {
             self.state.flash_info("archive: not mounted");
             Vec::new()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -618,6 +618,12 @@ struct Runtime {
     /// be abandoned with `:archive cancel`. Replaced per mount, so cancelling one
     /// can never cancel the next.
     archive_cancel: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    /// An effect parked across the mount-size prompt, with the archive it's
+    /// waiting for: a `ChangeDir` into a not-yet-mounted archive whose size asked
+    /// a question first. A `PromptKind` is plain data and an `Effect` is not, so
+    /// the in-flight half waits here — beside `archive_cancel`, the other piece of
+    /// in-flight mount state.
+    archive_mount_then: Option<(std::path::PathBuf, Box<Effect>)>,
     /// Landing slot for off-thread file operations.
     file_results: std::sync::Arc<std::sync::Mutex<Vec<file_ops::FileOutcome>>>,
     /// The watcher-driven listing refresh (`FileOp::RefreshListing`) reads the

--- a/src/app/pager_handler/pickers.rs
+++ b/src/app/pager_handler/pickers.rs
@@ -391,8 +391,8 @@ impl App {
                         let session = session.clone();
                         self.clear_pager();
                         self.view.needs_full_repaint = true;
-                        self.restore_session(&session);
-                        return Some(Vec::new());
+                        let fx = self.restore_session(&session);
+                        return Some(fx);
                     }
                     self.state.pending_sessions = Some(sessions);
                 }
@@ -415,8 +415,8 @@ impl App {
                         let session = session.clone();
                         self.clear_pager();
                         self.view.needs_full_repaint = true;
-                        self.restore_session(&session);
-                        return Some(Vec::new());
+                        let fx = self.restore_session(&session);
+                        return Some(fx);
                     }
                     self.state.pending_sessions = Some(sessions);
                 }

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -12,6 +12,7 @@
 //! Worktree helpers moved to `git_state.rs` and pane-sizing helpers to
 //! `pane_tabs.rs`.
 
+use crate::app::Effect;
 use crate::pane::PaneTabs;
 use crate::state::sessions::AgentKind;
 use crate::ui::line_edit::LineEditor;
@@ -416,19 +417,31 @@ impl App {
         self.set_pager(view);
     }
 
-    pub fn restore_session(&mut self, session: &crate::state::sessions::Session) {
+    pub fn restore_session(&mut self, session: &crate::state::sessions::Session) -> Vec<Effect> {
         // Restore working directory and update start_dir so backtick (`)
         // jumps to the session's home, not where spyc was launched from.
+        let mut effects = Vec::new();
         if session.cwd.is_dir() {
             if let Err(e) = self.state.chdir(&session.cwd) {
                 self.state.flash_error(format!("session chdir: {e:#}"));
-                return;
+                return effects;
             }
             self.state.start_dir.clone_from(&session.cwd);
+        } else if super::archive::archive_ancestor_of(&session.cwd).is_some() {
+            // The user quit while browsing an archive. It isn't a directory and
+            // never was — the effect screen mounts it and lands the column back
+            // where they left off. The rest of the restore carries on meanwhile.
+            self.state.start_dir.clone_from(&session.cwd);
+            effects.push(Effect::ChangeDir {
+                path: session.cwd.clone(),
+                focus: None,
+                on_ok: None,
+                err_prefix: "session chdir failed",
+            });
         } else {
             self.state
                 .flash_error(format!("session dir gone: {}", session.cwd.display()));
-            return;
+            return effects;
         }
         // Keep the startup-generated name when an older session file
         // has no name field; otherwise take the saved one.
@@ -527,6 +540,7 @@ impl App {
         // informative and releasable rather than silently lost.
         self.state.scope_registry.clone_from(&session.scope_claims);
         self.state.flash_info("session restored");
+        effects
     }
 
     /// Restore a saved vertical split: reopen the second commander at its saved

--- a/src/app/state/archive.rs
+++ b/src/app/state/archive.rs
@@ -31,11 +31,6 @@ pub const fn refusal(action: &Action) -> Option<&'static str> {
             "archive: shell commands run outside the archive"
         }
 
-        // Bookmarks that would persist a path with nothing behind it once the
-        // mount is dropped. Jumping *out* by a mark or harpoon slot is fine.
-        A::SetMark(_) => "archive: marks can't point inside an archive",
-        A::HarpoonAppend | A::HarpoonRemove => "archive: harpoon can't point inside an archive",
-
         // A member has no history, and there is no worktree in here.
         A::GitDiff
         | A::GitDiffCached
@@ -132,12 +127,20 @@ mod tests {
         assert!(why.contains("outside"), "{why}");
     }
 
+    /// A bookmark inside an archive is allowed because coming back to one works:
+    /// a `ChangeDir` naming a place inside an unmounted archive mounts it first.
+    /// Before that it could only dangle, so it was refused.
     #[test]
-    fn bookmarks_that_would_dangle_are_refused_but_jumps_out_are_not() {
-        assert!(refusal(&Action::SetMark('a')).is_some());
-        assert!(refusal(&Action::HarpoonAppend).is_some());
-        assert_eq!(refusal(&Action::JumpMark('a')), None);
-        assert_eq!(refusal(&Action::HarpoonJump(2)), None);
+    fn bookmarks_inside_an_archive_are_allowed_now_that_they_can_be_returned_to() {
+        for action in [
+            Action::SetMark('a'),
+            Action::JumpMark('a'),
+            Action::HarpoonAppend,
+            Action::HarpoonRemove,
+            Action::HarpoonJump(2),
+        ] {
+            assert_eq!(refusal(&action), None, "{action:?}");
+        }
     }
 
     #[test]
@@ -159,7 +162,7 @@ mod tests {
     fn every_refusal_message_is_user_facing() {
         for action in [
             Action::MakeDirPrompt,
-            Action::SetMark('a'),
+            Action::ChmodAdd('x'),
             Action::GitDiff,
             Action::FindFile,
             Action::StartShell,

--- a/src/app/test_harness.rs
+++ b/src/app/test_harness.rs
@@ -68,6 +68,7 @@ impl App {
                 image_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 archive_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 archive_cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                archive_mount_then: None,
                 worktree_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 preview_results: std::sync::Arc::new(std::sync::Mutex::new(None)),
                 file_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),


### PR DESCRIPTION
Second of the three that were PR 5. Stacked on nothing — #314 is already in.

## What was broken

A mark, a harpoon slot and a saved session cwd are all just paths, and a path under an archive names a place inside it whether or not anything has it mounted right now.

- **Marks and harpoon were refused inside a mount**, because what they recorded could only dangle once the mount was dropped.
- **Restoring a session that ended inside an archive** reported `session dir gone` — the mount root is a *file*, so `is_dir` was never going to be true.

## One seam, not four call sites

Every way of landing on a path goes out as `Effect::ChangeDir`, and the effect screen already sees every effect. So it holds one back when it names a place inside an unmounted archive, mounts the archive, and **re-issues the original effect**.

Carrying the whole effect rather than just the destination is what keeps the cursor target and the flash message it came with — and it's the same shape a held-back *read* already uses (`MaterializeThen::Retry`). Nothing else had to learn that a path can name a place inside a file: `J`, MCP `navigate_to` and `` ` `` get it for free.

`archive_ancestor` is the pure half: the ancestor walk that finds the container, with "is this a file on disk" injected so it stays testable. **The name test runs before the stat**, so an ordinary chdir pays no syscall for this — only a path with an archive-shaped component asks the disk. A `..` between the archive and the target names somewhere outside it and is rejected, the same normalization a member name gets.

## Two things that had to follow

- **The size prompt.** The mount op carries the held-back effect, but a mount big enough to ask about first goes back through the keyboard — and a `PromptKind` is plain data while an `Effect` is not. It parks in `Runtime` beside the cancel flag (the other piece of in-flight mount state) until the answer comes back, rather than being silently dropped and landing you at the archive root instead of where you asked for.
- **`harpoon_jump` chdir'd inline**, which can't mount anything. An in-archive slot now goes out as an effect. Its `exists()` precheck couldn't pass for a member either — it reported `harpoon: gone` for a slot that was fine, which I only found because a test drove it. Unmounted, a member's *kind* is unknowable (that lives in the index), so the jump lands next to it rather than guessing: one keystroke from either answer, never wrong.

`restore_session` now returns effects instead of nothing, so the archive case has somewhere to send its chdir; the rest of the restore carries on regardless.

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- Harness tests for the round trip: mark a directory two levels into a zip, unmount, jump back; the same for a harpoon slot; a session whose cwd was inside an archive; and a session whose directory is simply gone, which must still say so rather than being mistaken for an archive.
- Pure tests for `archive_ancestor`: a member path, the archive itself, an ordinary path, a name that *looks* like an archive but isn't a file, the innermost of two nested containers (which is what PR 5c will need), and a traversing path.
- Not driven by hand. Worth trying: `ma` inside a zip, `:archive unmount`, then `'a`; and quitting from inside an archive then `spyc -r`.

## Next

PR 5c, nested archives — `ArchiveMount` has to separate its address (`outer.zip/inner.zip`) from its source bytes (the staging copy), plus a depth cap and the write-back cascade. The ancestor walk above already resolves the innermost container, which is half of the addressing.

Generated with [Claude Code](https://claude.com/claude-code)
