### PR TITLE
fix(transcript): bound the image index's line reader

### DIFF
--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -193,6 +193,69 @@ pub fn read_tail_lossy(path: &std::path::Path, max_bytes: u64) -> std::io::Resul
     })
 }
 
+/// Cap on a SINGLE line of a transcript being streamed whole (the `^a g` image
+/// index, which needs every record rather than a tail).
+///
+/// A JSONL line is one record, and an image record is the big one: ~0.5 MB of
+/// base64 per image, a handful per message. 32 MB is far above anything a real
+/// conversation produces and far below what a file with no newlines at all
+/// would cost — `BufRead::lines` on such a file allocates the whole thing.
+pub const MAX_TRANSCRIPT_LINE_BYTES: usize = 32 * 1024 * 1024;
+
+/// Read one `\n`-terminated line, bounded.
+///
+/// Returns `Ok(Some(true))` for a line that fit (in `buf`, newline trimmed),
+/// `Ok(Some(false))` for one that exceeded `cap` — `buf` is cleared and the
+/// reader is advanced past the offending line, so the caller stays in sync and
+/// can simply skip it — and `Ok(None)` at EOF.
+///
+/// Exists because `BufRead::lines()` / `read_until` grow without limit: a
+/// corrupt or hostile file with no newline in it is read entirely into memory.
+pub fn read_line_capped<R: std::io::BufRead>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+    cap: usize,
+) -> std::io::Result<Option<bool>> {
+    use std::io::{BufRead, Read};
+    buf.clear();
+    // `cap + 1`: reading that many bytes without a newline proves the line is
+    // over the cap, rather than merely reaching it exactly.
+    let read = reader
+        .by_ref()
+        .take(cap as u64 + 1)
+        .read_until(b'\n', buf)?;
+    if read == 0 {
+        return Ok(None);
+    }
+    if buf.last() == Some(&b'\n') {
+        buf.pop();
+        if buf.last() == Some(&b'\r') {
+            buf.pop();
+        }
+        return Ok(Some(true));
+    }
+    // No newline. Either EOF (a final unterminated line, which is fine and
+    // fits) or the cap stopped us mid-line.
+    if read <= cap {
+        return Ok(Some(true));
+    }
+    // Over the cap: drop it and step to the next newline in bounded chunks, so
+    // skipping a huge line costs no more memory than reading a normal one.
+    buf.clear();
+    const SKIP_CHUNK: u64 = 64 * 1024;
+    let mut scratch = Vec::with_capacity(SKIP_CHUNK as usize);
+    loop {
+        scratch.clear();
+        let n = reader
+            .by_ref()
+            .take(SKIP_CHUNK)
+            .read_until(b'\n', &mut scratch)?;
+        if n == 0 || scratch.last() == Some(&b'\n') {
+            return Ok(Some(false));
+        }
+    }
+}
+
 /// Append an agent prose block to a transcript view, rendered through
 /// the Markdown viewer so headings / lists / code / emphasis show as
 /// formatting instead of raw `#` / `**` source. Inserts a single blank
@@ -541,5 +604,91 @@ mod tests {
             assert!(open_state_file_append("link.log").is_none());
             assert_eq!(std::fs::read_to_string(&target).unwrap(), "private");
         });
+    }
+}
+
+#[cfg(test)]
+mod capped_line_tests {
+    use super::{MAX_TRANSCRIPT_LINE_BYTES, read_line_capped};
+    use std::io::BufReader;
+
+    /// Read every line through the capped reader, marking the skipped ones.
+    fn read_all(data: &[u8], cap: usize) -> Vec<Option<String>> {
+        let mut r = BufReader::new(data);
+        let mut buf = Vec::new();
+        let mut out = Vec::new();
+        while let Ok(Some(fit)) = read_line_capped(&mut r, &mut buf, cap) {
+            out.push(fit.then(|| String::from_utf8_lossy(&buf).into_owned()));
+        }
+        out
+    }
+
+    #[test]
+    fn ordinary_lines_round_trip() {
+        assert_eq!(
+            read_all(b"one\ntwo\nthree\n", 1024),
+            vec![Some("one".into()), Some("two".into()), Some("three".into())]
+        );
+    }
+
+    /// A final line with no trailing newline is still a line, not a truncation.
+    #[test]
+    fn a_missing_final_newline_still_yields_the_line() {
+        assert_eq!(
+            read_all(b"a\nb", 1024),
+            vec![Some("a".into()), Some("b".into())]
+        );
+    }
+
+    #[test]
+    fn crlf_is_trimmed() {
+        assert_eq!(
+            read_all(b"a\r\nb\r\n", 1024),
+            vec![Some("a".into()), Some("b".into())]
+        );
+    }
+
+    /// The whole point: an over-cap line is skipped AND the reader resyncs, so
+    /// the lines after it are still read correctly. Getting this wrong would
+    /// silently mis-split the rest of the file.
+    #[test]
+    fn an_oversized_line_is_skipped_and_the_reader_resyncs() {
+        let mut data = Vec::new();
+        data.extend_from_slice(b"before\n");
+        data.extend(std::iter::repeat_n(b'x', 5000));
+        data.push(b'\n');
+        data.extend_from_slice(b"after\n");
+        assert_eq!(
+            read_all(&data, 100),
+            vec![Some("before".into()), None, Some("after".into())],
+            "the huge line is dropped, not mis-split"
+        );
+    }
+
+    /// A file with NO newline at all is the case `BufRead::lines()` reads
+    /// whole. Bounded here: it yields one skip, not one enormous allocation.
+    #[test]
+    fn a_file_with_no_newline_is_bounded() {
+        let data: Vec<u8> = std::iter::repeat_n(b'x', 100_000).collect();
+        assert_eq!(read_all(&data, 1024), vec![None]);
+    }
+
+    /// Exact-boundary behaviour: a line of exactly `cap` bytes fits; `cap + 1`
+    /// does not. Off-by-one here would reject legitimate records.
+    #[test]
+    fn the_cap_boundary_is_inclusive() {
+        let at_cap = format!("{}\n", "x".repeat(64));
+        assert_eq!(read_all(at_cap.as_bytes(), 64), vec![Some("x".repeat(64))]);
+        let over = format!("{}\n", "x".repeat(65));
+        assert_eq!(read_all(over.as_bytes(), 64), vec![None]);
+    }
+
+    /// The shipped cap must clear a realistic image record by a wide margin —
+    /// too tight and the gallery silently loses real screenshots.
+    #[test]
+    fn the_shipped_cap_clears_a_realistic_image_record() {
+        // ~0.7 MB of base64 per image was the largest seen in a real
+        // transcript; even ten in one record must fit.
+        const { assert!(MAX_TRANSCRIPT_LINE_BYTES > 10 * 700_000) };
     }
 }

--- a/src/state/transcript_images.rs
+++ b/src/state/transcript_images.rs
@@ -26,7 +26,7 @@
 //!   neither "skip attachments" nor "dedupe by label" is correct; dedupe is on
 //!   content identity.
 
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::path::Path;
 
 /// How much of a base64 payload to read from each end when fingerprinting it
@@ -72,18 +72,46 @@ pub fn index(path: &Path) -> Vec<TranscriptImage> {
     };
     let mut seen: Vec<u64> = Vec::new();
     let mut out: Vec<TranscriptImage> = Vec::new();
-    for (line_no, line) in BufReader::new(file).lines().enumerate() {
-        let Ok(line) = line else { continue };
+    let mut reader = BufReader::new(file);
+    let mut buf = Vec::new();
+    let mut oversized = 0usize;
+    // Bounded per line, NOT `lines()`: a file with no newline in it would be
+    // read whole. See `read_line_capped`.
+    for line_no in 0.. {
+        match crate::state::read_line_capped(
+            &mut reader,
+            &mut buf,
+            crate::state::MAX_TRANSCRIPT_LINE_BYTES,
+        ) {
+            Ok(None) | Err(_) => break,
+            Ok(Some(false)) => {
+                oversized += 1;
+                continue;
+            }
+            Ok(Some(true)) => {}
+        }
+        let Ok(line) = std::str::from_utf8(&buf) else {
+            continue;
+        };
         // Cheap reject first: only a handful of lines in a transcript hold an
         // image, and parsing a multi-hundred-KB JSON line to discover otherwise
         // is the whole cost of this pass.
         if !line.contains("\"type\":\"image\"") {
             continue;
         }
-        let Ok(record) = serde_json::from_str::<serde_json::Value>(&line) else {
+        let Ok(record) = serde_json::from_str::<serde_json::Value>(line) else {
             continue;
         };
         index_record(&record, line_no, &mut seen, &mut out);
+    }
+    if oversized > 0 {
+        // Not silent: a skipped record could have held an image, and a gallery
+        // that quietly omits one is worse than one that says it did.
+        crate::debug_log::log(&format!(
+            "transcript_images: skipped {oversized} record(s) over {} bytes in {}",
+            crate::state::MAX_TRANSCRIPT_LINE_BYTES,
+            path.display()
+        ));
     }
     out
 }
@@ -164,13 +192,25 @@ fn index_record(
 pub fn load(path: &Path, entry: &TranscriptImage) -> Result<Vec<u8>, String> {
     use base64::Engine;
     let file = std::fs::File::open(path).map_err(|e| format!("{}: {e}", path.display()))?;
-    let line = BufReader::new(file)
-        .lines()
-        .nth(entry.line)
-        .ok_or_else(|| "transcript changed under us (line is gone)".to_string())?
-        .map_err(|e| format!("read: {e}"))?;
+    let mut reader = BufReader::new(file);
+    let mut buf = Vec::new();
+    // Same bound as the index pass — this walks the same records.
+    for _ in 0..=entry.line {
+        match crate::state::read_line_capped(
+            &mut reader,
+            &mut buf,
+            crate::state::MAX_TRANSCRIPT_LINE_BYTES,
+        ) {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                return Err("transcript changed under us (line is gone)".to_string());
+            }
+            Err(e) => return Err(format!("read: {e}")),
+        }
+    }
+    let line = std::str::from_utf8(&buf).map_err(|e| format!("read: {e}"))?;
     let record: serde_json::Value =
-        serde_json::from_str(&line).map_err(|e| format!("parse: {e}"))?;
+        serde_json::from_str(line).map_err(|e| format!("parse: {e}"))?;
     let blocks = content_blocks(&record).ok_or_else(|| "no content blocks".to_string())?;
     let data = blocks
         .iter()
@@ -379,6 +419,33 @@ mod tests {
             .decode(PNG_B64)
             .expect("fixture decodes");
         assert_eq!(decoded_len(PNG_B64), actual.len());
+    }
+
+    /// A monstrous record must not cost the images after it: the index has to
+    /// skip it and carry on, not stop or mis-split the rest of the file.
+    #[test]
+    fn an_oversized_record_does_not_hide_the_images_after_it() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("session.jsonl");
+        let mut data = user_line("first", &[PNG_B64], "2026-08-04T10:00:00Z");
+        data.push('\n');
+        // A single line far past the cap, with no newline inside it.
+        data.push_str(&"x".repeat(crate::state::MAX_TRANSCRIPT_LINE_BYTES + 1024));
+        data.push('\n');
+        let other = PNG_B64.replace("iVBORw0", "iVBORw1");
+        data.push_str(&user_line("second", &[&other], "2026-08-04T11:00:00Z"));
+        std::fs::write(&path, data).expect("write transcript");
+
+        let images = index(&path);
+        assert_eq!(
+            images.len(),
+            2,
+            "the record after the huge line is still indexed"
+        );
+        assert_eq!(images[1].prompt_excerpt, "second");
+        // And its bytes still load — the line index survived the skip.
+        let bytes = load(&path, &images[1]).expect("load the second image");
+        assert_eq!(&bytes[1..4], b"PNG");
     }
 
     /// A transcript with no images, a missing file, and a corrupt line are all


### PR DESCRIPTION
Last loose end from the security review.

## The gap

`transcript_images` streams the **whole** conversation to find every image — the `^a v` readers are bounded by a 4 MB tail (`read_tail_lossy`), but the gallery needs the entire file, so it had no bound at all.

`BufRead::lines()` grows a line until it finds `\n`. A corrupt or hostile transcript with no newline in it is therefore read wholly into memory: a multi-GB file is a multi-GB allocation. Both `index()` and `load()` had this.

*(Correction to what I said earlier: I claimed "every other transcript reader shares the property". Not true — claude/codex/agy are all bounded. This was mine alone.)*

## Fix

`state::read_line_capped` reads one `\n`-terminated line with a ceiling: a line that fits is returned, a line that doesn't is reported as skipped and the reader advanced past it **in bounded chunks**.

The resync is the part that needed care, and it's where the tests are pointed:

- skipping by reading the rest of the line into a buffer would **reintroduce the exact allocation** being prevented — hence chunked;
- not skipping at all would **mis-split every subsequent line**, silently renumbering the index that `load` later seeks by.

## The cap is chosen against the format, not picked round

32 MB per line. A record's bulk is base64 images at ~0.5 MB each, a handful per message — so this clears **ten large images in one record** while sitting far under what an unbounded read costs. A test asserts that margin, so tightening the constant later can't quietly start dropping real screenshots.

Skipped records are logged rather than silently dropped: one could have held an image, and a gallery that quietly omits one is worse than a gallery that says it did.

## Testing

`make check-ci` green (2227 tests). Eight new: round-trip, missing final newline, CRLF, **skip-and-resync**, a file with no newline at all, the exact cap boundary (inclusive — off-by-one here would reject legitimate records), the shipped-cap margin, and an integration test that a monstrous record doesn't hide the images after it (index *and* load).

Verified against a real 8000-line transcript: **16 images in 115 ms, byte-identical** to the unbounded reader.
