### PR TITLE
feat(archive): enter an archive inside an archive

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -224,9 +224,14 @@ enable = true              # false → Enter pages the archive as bytes
 extract_budget_mb = 512    # hard ceiling for a .tar.gz / .tar.zst mount
 warn_over_mb = 128         # confirm before extracting more than this
 max_entries = 200000       # cap on indexed members
+max_depth = 2              # how deep archives may nest (0 = no nesting)
 write_back = "ask"         # "ask" | "never" — offer to write pending changes
 snapshot_max_mb = 64       # graveyard-snapshot the original below this size
 ```
+
+`max_depth` is about disk, not correctness: a container inside a container has to
+be copied out whole before anything can read it, so every level costs its own
+size in staging. Set it to 0 to refuse nested archives entirely.
 
 A write-back never puts the original at risk: the new archive is written to a
 temp file beside it, verified by reading it back, and only then renamed into

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -506,6 +506,13 @@ they land in a session-scoped staging dir that is cleaned up on exit.
   pressing `Enter` again re-enters it without re-reading it, so pending changes
   survive the round trip. Deleting or moving the archive drops its mount with it —
   unless it carries unwritten changes, which would then have nowhere to go.
+- **An archive inside an archive** — `Enter` on a member that is itself a
+  container walks into it, browsed at its own member path (`outer.zip/bundle.zip`)
+  while its bytes are read from the copy spyc extracted. Each level costs a full
+  copy of that container in staging, since bytes have to be a real file before
+  anything can read them, so `[archive] max_depth` (default 2) bounds it. Writing
+  the inner one leaves the outer with a pending change of its own — it says so,
+  and `:archive write` there puts it back.
 - **Coming back to a place inside one** — a mark (`ma`), a harpoon slot (`Ha`)
   and the session you quit from can all point inside an archive. Jumping to one
   mounts the archive again on the way, so it doesn't matter that nothing has it

--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -33,7 +33,11 @@ impl App {
         // installs a fresh journal, so it would silently discard changes the user
         // hasn't written back — and for a compressed tar it would re-stream the
         // whole archive to learn what it already knows.
-        if self.state.mounts.contains(path) {
+        //
+        // `get`, not `contains`: a nested archive's path is *inside* the mount
+        // above it, so "is this path in a mount" is true before it is mounted at
+        // all — and answering it would land the column on a file member's path.
+        if self.state.mounts.get(path).is_some() {
             // Already mounted, so whatever was waiting on it can just run.
             if let Some(effect) = then {
                 return vec![*effect];
@@ -60,6 +64,65 @@ impl App {
             confirmed,
             cancel: std::sync::Arc::clone(&self.runtime.archive_cancel),
             then,
+            address: None,
+            depth: 0,
+        })]
+    }
+
+    /// Mount an archive that lives *inside* another one: `at` is its member path
+    /// (where the column browses it), `source` the extracted copy the bytes come
+    /// from.
+    ///
+    /// Each level costs a full copy of that container in the level above's
+    /// staging — the bytes have to be a real file before anything can read them —
+    /// so `[archive] max_depth` bounds how far this can go.
+    pub(super) fn request_nested_mount(
+        &mut self,
+        at: &Path,
+        source: &Path,
+        then: Option<Box<Effect>>,
+    ) -> Vec<Effect> {
+        if self.state.mounts.get(at).is_some() {
+            if let Some(effect) = then {
+                return vec![*effect];
+            }
+            self.enter_mount(at);
+            return Vec::new();
+        }
+        let depth = self
+            .state
+            .mounts
+            .resolve(at)
+            .map_or(0, |(parent, _)| parent.depth + 1);
+        let max = self.state.config.archive.max_depth;
+        if depth > max {
+            self.state.flash_error(format!(
+                "archive: {} is {depth} archives deep — [archive] max_depth is {max}",
+                display_name(at)
+            ));
+            return Vec::new();
+        }
+        // Staging is keyed on the address, so re-entering a nested archive finds
+        // the same tree rather than a second copy of it.
+        let Some(staging_root) = staging_root_for(at) else {
+            self.state
+                .flash_error("archive: no state directory to stage into");
+            return Vec::new();
+        };
+        self.runtime.archive_cancel =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        self.state
+            .flash_info(format!("reading {}…", display_name(at)));
+        vec![Effect::Archive(ArchiveOp::Mount {
+            path: source.to_path_buf(),
+            staging_root,
+            limits: self.state.config.archive.limits(),
+            max_entries: self.state.config.archive.max_entries,
+            confirmed: false,
+            cancel: std::sync::Arc::clone(&self.runtime.archive_cancel),
+            then,
+            address: Some(at.to_path_buf()),
+            depth,
         })]
     }
 
@@ -97,7 +160,9 @@ impl App {
             return Vec::new();
         }
         vec![Effect::Archive(ArchiveOp::Materialize {
-            archive: mount.archive().to_path_buf(),
+            // Where the bytes are, not where the mount is addressed — a nested
+            // archive is read out of its staged copy.
+            archive: mount.source().to_path_buf(),
             entry: Box::new(entry),
             staging_root: mount.staging_root.clone(),
             then,
@@ -127,6 +192,7 @@ impl App {
                 warnings,
                 staging_root,
                 then,
+                depth,
             } => {
                 let archive = index.archive.clone();
                 let notes = mount_notes(&capability, &warnings);
@@ -140,6 +206,7 @@ impl App {
                         warnings,
                         staging_root,
                         last_used: 0,
+                        depth,
                     },
                     &protected,
                 );
@@ -235,9 +302,41 @@ impl App {
                     report.members,
                     crate::fs::ops::format_size(report.bytes),
                 ));
-                // Re-mount so the index describes what is now on disk rather than
-                // what used to be.
-                self.request_mount(&archive, true)
+                // Re-read it: a repack renumbers a zip's entries and moves a tar's
+                // offsets, so every locator in the old index now points at the
+                // wrong bytes. The mount has to be *dropped* for that to happen —
+                // a live one is re-entered rather than re-indexed, which is right
+                // everywhere except here.
+                let nested = self
+                    .state
+                    .mounts
+                    .get(&archive)
+                    .and_then(|m| (m.depth > 0).then(|| m.source().to_path_buf()));
+                let mut effects = match self.state.mounts.remove(&archive) {
+                    Some(staging) => clean_effects(vec![staging]),
+                    None => Vec::new(),
+                };
+                effects.extend(match &nested {
+                    // A nested archive is read from its staged copy, which the
+                    // write just replaced in place.
+                    Some(source) => self.request_nested_mount(&archive, source, None),
+                    None => self.request_mount(&archive, true),
+                });
+                // Writing an archive that lives inside another one changes a file
+                // in that one's staging, so the outer now has a pending change of
+                // its own. Say so rather than leaving it to the quit warning.
+                let outer = self
+                    .state
+                    .mounts
+                    .member_of(&archive)
+                    .map(|(outer, _)| display_name(outer.archive()));
+                if let Some(outer) = outer {
+                    self.state.flash_info(format!(
+                        "wrote {} into {outer} — :archive write there too",
+                        display_name(&archive)
+                    ));
+                }
+                effects
             }
             ArchiveOutcome::WriteFailed { archive, error } => {
                 self.state.flash_error(format!(
@@ -257,6 +356,9 @@ impl App {
                 self.open_staged_in_pager(real, dest);
                 Vec::new()
             }
+            // A container inside a container: the bytes are on disk now, so mount
+            // them — addressed where the user sees them, read from where they are.
+            MaterializeThen::Mount { at, then } => self.request_nested_mount(&at, real, then),
             MaterializeThen::Edit { in_pane } => {
                 let argv = crate::shell::resolve_editor();
                 if argv.is_empty() {
@@ -387,6 +489,15 @@ impl App {
                 .filter(|m| m.is_dirty())
                 .map(|m| m.archive().to_path_buf()),
         );
+        // A nested mount reads from a staged copy inside the mount above it, so
+        // evicting the parent would take the child's bytes with it.
+        for child in self.state.mounts.iter() {
+            if child.depth > 0
+                && let Some((parent, _)) = self.state.mounts.resolve(child.archive())
+            {
+                out.push(parent.archive().to_path_buf());
+            }
+        }
         out
     }
 
@@ -400,6 +511,27 @@ impl App {
                 .is_some_and(|(m, _)| m.archive() == archive)
         }) {
             self.state.flash_error("archive: climb out of it first (h)");
+            return Vec::new();
+        }
+        // Dropping this one would delete the staged copy another mount is reading
+        // from, leaving that one pointing at nothing.
+        let staging = self
+            .state
+            .mounts
+            .get(archive)
+            .map(|m| m.staging_root.clone());
+        let child = staging.and_then(|staging| {
+            self.state
+                .mounts
+                .iter()
+                .find(|m| m.depth > 0 && m.archive() != archive && m.source().starts_with(&staging))
+                .map(|m| m.archive().to_path_buf())
+        });
+        if let Some(child) = child {
+            self.state.flash_error(format!(
+                "archive: unmount {} first — it lives inside this one",
+                display_name(&child)
+            ));
             return Vec::new();
         }
         if let Some(staging) = self.state.mounts.remove(archive) {
@@ -693,7 +825,7 @@ impl App {
     /// that wanted them.
     fn extraction_effect(&mut self, members: &[PathBuf], then: MaterializeThen) -> Option<Effect> {
         let (mount, _) = members.first().and_then(|p| self.state.mounts.resolve(p))?;
-        let archive = mount.archive().to_path_buf();
+        let archive = mount.source().to_path_buf();
         let staging_root = mount.staging_root.clone();
         let entries: Vec<(PathBuf, crate::archive::IndexEntry)> = members
             .iter()

--- a/src/app/archive_ops.rs
+++ b/src/app/archive_ops.rs
@@ -31,6 +31,15 @@ pub enum MaterializeThen {
     /// up by the next write-back, which compares each staged file against what
     /// spyc wrote when it extracted it.
     Edit { in_pane: bool },
+    /// Mount the extracted copy as an archive in its own right — a container
+    /// inside a container. `at` is where it's addressed (its member path), which
+    /// is what the column browses; the extracted copy is only where the bytes are.
+    /// `then` carries an effect that was waiting for that mount, so a path several
+    /// containers deep resolves one level at a time.
+    Mount {
+        at: PathBuf,
+        then: Option<Box<super::Effect>>,
+    },
 }
 
 #[derive(Debug)]
@@ -52,6 +61,11 @@ pub enum ArchiveOp {
         /// didn't exist yet. Re-issued once it does, so the original keeps its
         /// cursor target and its message. `None` for an ordinary `Enter`.
         then: Option<Box<super::Effect>>,
+        /// Where to address the mount, when that isn't `path`: a nested archive
+        /// is read from its staged copy (`path`) but browsed at its member path.
+        address: Option<PathBuf>,
+        /// Nesting depth to record on the mount — 0 for a file on disk.
+        depth: usize,
     },
     /// Extract one member so something can read it.
     Materialize {
@@ -98,6 +112,7 @@ pub enum ArchiveOutcome {
         /// The held-back effect from [`ArchiveOp::Mount`], to run now that the
         /// mount exists.
         then: Option<Box<super::Effect>>,
+        depth: usize,
     },
     /// Big enough to ask about first. Answering `y` re-issues the op.
     NeedsConfirm {
@@ -153,14 +168,21 @@ pub fn run_archive_op(op: ArchiveOp) -> ArchiveOutcome {
             confirmed,
             cancel,
             then,
+            address,
+            depth,
         } => carry_then(
-            mount(
+            readdress(
+                mount(
+                    &path,
+                    &staging_root,
+                    &limits,
+                    max_entries,
+                    confirmed,
+                    &cancel,
+                ),
                 &path,
-                &staging_root,
-                &limits,
-                max_entries,
-                confirmed,
-                &cancel,
+                address,
+                depth,
             ),
             then,
         ),
@@ -232,6 +254,44 @@ pub fn run_archive_op(op: ArchiveOp) -> ArchiveOutcome {
 /// that lead somewhere carry it: a mount that failed, or turned out not to be an
 /// archive, has nowhere for a `ChangeDir` to land — and re-issuing it would find
 /// no mount, hold it back again, and mount in a circle.
+/// Point a freshly-built index at the address the mount will be browsed under.
+///
+/// [`mount`] indexes a *file*, so the index it hands back is addressed at that
+/// file. A nested archive was read from a staged copy, and browsing it there would
+/// put the user in the cache; it belongs at its member path. Splitting address
+/// from source is the whole of what makes nesting work — everything else already
+/// keys on one or the other.
+fn readdress(
+    outcome: ArchiveOutcome,
+    read_from: &Path,
+    address: Option<PathBuf>,
+    depth: usize,
+) -> ArchiveOutcome {
+    let ArchiveOutcome::Mounted {
+        mut index,
+        capability,
+        warnings,
+        staging_root,
+        then,
+        ..
+    } = outcome
+    else {
+        return outcome;
+    };
+    if let Some(address) = address {
+        index.archive = address;
+        index.source = Some(read_from.to_path_buf());
+    }
+    ArchiveOutcome::Mounted {
+        index,
+        capability,
+        warnings,
+        staging_root,
+        then,
+        depth,
+    }
+}
+
 fn carry_then(outcome: ArchiveOutcome, then: Option<Box<super::Effect>>) -> ArchiveOutcome {
     match outcome {
         ArchiveOutcome::Mounted {
@@ -239,6 +299,7 @@ fn carry_then(outcome: ArchiveOutcome, then: Option<Box<super::Effect>>) -> Arch
             capability,
             warnings,
             staging_root,
+            depth,
             ..
         } => ArchiveOutcome::Mounted {
             index,
@@ -246,6 +307,9 @@ fn carry_then(outcome: ArchiveOutcome, then: Option<Box<super::Effect>>) -> Arch
             warnings,
             staging_root,
             then,
+            // Carried, not reset: `readdress` ran first and it is what knows how
+            // deep this mount is.
+            depth,
         },
         ArchiveOutcome::NeedsConfirm { path, question, .. } => ArchiveOutcome::NeedsConfirm {
             path,
@@ -311,6 +375,8 @@ fn mount(
     let capability = assess(&indexed.facts, format);
     let warnings = warnings(&indexed.facts, &indexed.index);
     ArchiveOutcome::Mounted {
+        // `readdress` sets the real depth at the op boundary.
+        depth: 0,
         index: Box::new(indexed.index),
         capability,
         warnings,
@@ -435,6 +501,8 @@ mod tests {
             confirmed,
             cancel: Arc::new(AtomicBool::new(false)),
             then: None,
+            address: None,
+            depth: 0,
         })
     }
 

--- a/src/app/archive_route.rs
+++ b/src/app/archive_route.rs
@@ -570,6 +570,7 @@ mod tests {
                 warnings: Vec::new(),
                 staging_root: PathBuf::from("/staging"),
                 last_used: 0,
+                depth: 0,
             },
             &[],
         );

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -38,6 +38,8 @@ fn mount_inline(app: &mut App, archive: &Path, staging: &Path) -> Vec<Effect> {
         confirmed: false,
         cancel: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
         then: None,
+        address: None,
+        depth: 0,
     });
     assert!(
         matches!(outcome, ArchiveOutcome::Mounted { .. }),
@@ -513,6 +515,7 @@ fn eviction_hands_back_the_staging_tree_to_clean() {
                     warnings: Vec::new(),
                     staging_root: staging,
                     last_used: 0,
+                    depth: 0,
                 },
                 &[],
             ));
@@ -1672,5 +1675,272 @@ fn a_harpoon_slot_inside_an_archive_comes_back_to_it() {
             "{:?}",
             app.state.flash.as_ref().map(|f| f.text.clone())
         );
+    });
+}
+
+// ── an archive inside an archive ──────────────────────────────────────────
+
+/// A zip holding a text file and a second zip.
+fn build_nested_zip(path: &Path) {
+    let inner_bytes = {
+        let mut buf = std::io::Cursor::new(Vec::new());
+        let mut w = zip::ZipWriter::new(&mut buf);
+        let opts = zip::write::SimpleFileOptions::default().unix_permissions(0o644);
+        w.start_file("deep/note.txt", opts).unwrap();
+        w.write_all(b"from the inner archive\n").unwrap();
+        w.start_file("inner.txt", opts).unwrap();
+        w.write_all(b"second member\n").unwrap();
+        w.finish().unwrap();
+        buf.into_inner()
+    };
+    let file = std::fs::File::create(path).unwrap();
+    let mut w = zip::ZipWriter::new(file);
+    let opts = zip::write::SimpleFileOptions::default().unix_permissions(0o644);
+    w.start_file("README.md", opts).unwrap();
+    w.write_all(b"# outer\n").unwrap();
+    // Stored, not deflated: a nested archive compresses badly anyway, and this
+    // keeps the fixture's own bytes recognisable.
+    w.start_file(
+        "bundle.zip",
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored),
+    )
+    .unwrap();
+    w.write_all(&inner_bytes).unwrap();
+    w.finish().unwrap();
+}
+
+/// `Enter` on a member that is itself an archive walks into it. The mount is
+/// **addressed** at the member path — what the user sees — while its bytes are
+/// read from the staged copy, which is the whole trick.
+#[test]
+fn entering_an_archive_inside_an_archive_browses_it_at_its_member_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("outer.zip");
+        build_nested_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Cursor onto `bundle.zip` and enter it.
+        let idx = app
+            .state
+            .cur()
+            .rows
+            .iter()
+            .position(|r| r.display.starts_with("bundle.zip"))
+            .expect("the nested archive is listed");
+        app.state.cur_mut().cursor.index = idx;
+        let fx = app.apply(&Action::EnterOrDisplay).unwrap();
+        settle(&mut app, fx);
+
+        let inner = archive.join("bundle.zip");
+        assert_eq!(
+            app.state.cur().listing.dir,
+            inner,
+            "browsing the inner archive at its member path: {:?}",
+            app.state.flash.as_ref().map(|f| f.text.clone())
+        );
+        assert_eq!(row_names(&app), ["deep/", "inner.txt"]);
+
+        let mount = app.state.mounts.get(&inner).expect("mounted");
+        assert_eq!(mount.depth, 1, "recorded as one level deep");
+        assert_ne!(
+            mount.source(),
+            inner,
+            "and read from the staged copy, not its address"
+        );
+        assert!(mount.source().is_file(), "which is a real file");
+    });
+}
+
+/// Reading a member of the inner archive gets the inner archive's bytes — the
+/// read follows `source`, not the address.
+#[test]
+fn a_member_of_a_nested_archive_reads_its_own_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("outer.zip");
+        build_nested_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let idx = app
+            .state
+            .cur()
+            .rows
+            .iter()
+            .position(|r| r.display.starts_with("bundle.zip"))
+            .unwrap();
+        app.state.cur_mut().cursor.index = idx;
+        let fx = app.apply(&Action::EnterOrDisplay).unwrap();
+        settle(&mut app, fx);
+
+        // Yank `inner.txt` out of the inner archive.
+        let idx = app
+            .state
+            .cur()
+            .rows
+            .iter()
+            .position(|r| r.display.starts_with("inner.txt"))
+            .expect("listed");
+        app.state.cur_mut().cursor.index = idx;
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+
+        let item = app
+            .state
+            .inventory
+            .items()
+            .find(|i| i.filename == "inner.txt")
+            .unwrap_or_else(|| {
+                panic!(
+                    "the inner member should be in the inventory; flash: {:?}",
+                    app.state.flash.as_ref().map(|f| f.text.clone())
+                )
+            });
+        assert_eq!(
+            app.state.inventory.read_content(&item.id).as_deref(),
+            Some(b"second member\n".as_slice())
+        );
+    });
+}
+
+/// The cap is what stops each level from costing another full copy in staging.
+#[test]
+fn nesting_past_max_depth_is_refused_and_names_the_knob() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("outer.zip");
+        build_nested_zip(&archive);
+        let mut app = App::test_app(dir);
+        app.state.config.archive.max_depth = 0;
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let idx = app
+            .state
+            .cur()
+            .rows
+            .iter()
+            .position(|r| r.display.starts_with("bundle.zip"))
+            .unwrap();
+        app.state.cur_mut().cursor.index = idx;
+        let fx = app.apply(&Action::EnterOrDisplay).unwrap();
+        settle(&mut app, fx);
+
+        // `get`, not `contains`: the inner archive's path is inside the outer
+        // mount either way, so only "is there a mount rooted here" answers this.
+        assert!(
+            app.state.mounts.get(&archive.join("bundle.zip")).is_none(),
+            "not mounted"
+        );
+        let flash = app.state.flash.as_ref().map(|f| f.text.clone());
+        assert!(
+            flash.as_deref().is_some_and(|t| t.contains("max_depth")),
+            "the refusal names the knob: {flash:?}"
+        );
+    });
+}
+
+/// Unmounting the outer archive would delete the staged copy the inner one is
+/// reading from, so it says which to unmount first.
+#[test]
+fn unmounting_the_outer_archive_is_refused_while_the_inner_is_mounted() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("outer.zip");
+        build_nested_zip(&archive);
+        let mut app = App::test_app(dir.clone());
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let idx = app
+            .state
+            .cur()
+            .rows
+            .iter()
+            .position(|r| r.display.starts_with("bundle.zip"))
+            .unwrap();
+        app.state.cur_mut().cursor.index = idx;
+        let fx = app.apply(&Action::EnterOrDisplay).unwrap();
+        settle(&mut app, fx);
+
+        // Step right out of both, then try to drop the outer.
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+        assert_eq!(app.state.cur().listing.dir, dir, "outside both");
+
+        let fx = app.unmount_archive(&archive);
+        settle(&mut app, fx);
+
+        assert!(app.state.mounts.contains(&archive), "still mounted");
+        let flash = app.state.flash.as_ref().map(|f| f.text.clone());
+        assert!(
+            flash.as_deref().is_some_and(|t| t.contains("bundle.zip")),
+            "and it says which one is in the way: {flash:?}"
+        );
+    });
+}
+
+/// A repack renumbers a zip's entries, so the index built before it describes a
+/// file that no longer exists. The mount has to be re-read, not re-entered —
+/// otherwise a later read follows a stale locator to the wrong member's bytes.
+#[test]
+fn a_write_re_reads_the_archive_rather_than_trusting_the_old_index() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Delete the FIRST stored member, which shifts every later member's
+        // position in the central directory.
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::RemovePrompt(None)).unwrap();
+        let fx = if fx.is_empty() {
+            app.handle_remove_confirm_key(crossterm::event::KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::empty(),
+            ))
+        } else {
+            fx
+        };
+        settle(&mut app, fx);
+        let fx = app.cmd_archive("write");
+        settle(&mut app, fx);
+
+        // Read every surviving member through the index the mount now holds. A
+        // repack writes members in index order, which is not the order they were
+        // stored in, so a stale locator points at a *different* member's bytes —
+        // checking them all is what makes that impossible to pass by luck.
+        let mount = app.state.mounts.get(&archive).expect("re-mounted");
+        for (inner, want) in [
+            ("src/main.rs", "fn main() {}\n"),
+            ("src/deep/mod.rs", "pub fn helper() {}\n"),
+        ] {
+            let entry = mount
+                .index
+                .get(inner)
+                .unwrap_or_else(|| panic!("{inner} is still in the archive"))
+                .clone();
+            let bytes = crate::archive::read::member_bytes(mount.source(), &entry)
+                .unwrap_or_else(|e| panic!("reading {inner} after the write: {e:#}"));
+            assert_eq!(
+                String::from_utf8_lossy(&bytes),
+                want,
+                "{inner}: the index has to describe the archive as it is now"
+            );
+        }
     });
 }

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -241,6 +241,7 @@ impl App {
                 .map(|m| crate::context::ArchiveMountRef {
                     root: m.archive().to_path_buf(),
                     staging: m.staging_root.clone(),
+                    source: (m.source() != m.archive()).then(|| m.source().to_path_buf()),
                 })
                 .collect(),
         }

--- a/src/app/navigate.rs
+++ b/src/app/navigate.rs
@@ -239,6 +239,23 @@ impl App {
         // A *mounted archive* is not a member of itself — it falls through to the
         // container branch below, so leaving one and coming back re-enters it.
         if self.state.mounts.holds_member(&path) {
+            // A member that is itself a container: walk into it, the same as
+            // `Enter` on an archive out on disk. Its bytes have to become a real
+            // file first, so the mount rides the extraction.
+            if matches!(intent, ActivateIntent::Display)
+                && self.state.config.archive.enable
+                && path
+                    .file_name()
+                    .is_some_and(|n| crate::archive::looks_mountable(&n.to_string_lossy()))
+            {
+                return self.open_member(
+                    &path,
+                    crate::app::archive_ops::MaterializeThen::Mount {
+                        at: path.clone(),
+                        then: None,
+                    },
+                );
+            }
             return match intent {
                 ActivateIntent::Display => self.open_member(
                     &path,

--- a/src/archive/index.rs
+++ b/src/archive/index.rs
@@ -279,6 +279,8 @@ impl IndexBuilder {
         (
             ArchiveIndex {
                 archive,
+                // Set by the mount when the bytes came from somewhere else.
+                source: None,
                 format,
                 entries: self.entries,
                 truncated: self.truncated,
@@ -341,7 +343,14 @@ impl IndexBuilder {
 /// The immutable entry table for one mounted archive.
 #[derive(Debug, Clone)]
 pub struct ArchiveIndex {
+    /// Where this archive is **addressed**: the mount root, under which every
+    /// member is a path. Usually the archive file itself — but a *nested* archive
+    /// is addressed at its member path (`outer.zip/inner.zip`), which is not a
+    /// file on disk. Reading bytes goes through [`Self::source`], never this.
     pub archive: PathBuf,
+    /// Where the bytes are, when that isn't [`Self::archive`] — the staged copy of
+    /// a nested archive. `None` for an archive that is its own file.
+    pub source: Option<PathBuf>,
     pub format: ArchiveFormat,
     /// Sorted by [`IndexEntry::inner`], which the prefix lookups depend on.
     pub entries: Vec<IndexEntry>,
@@ -358,6 +367,7 @@ impl ArchiveIndex {
     pub const fn empty(archive: PathBuf, format: ArchiveFormat) -> Self {
         Self {
             archive,
+            source: None,
             format,
             entries: Vec::new(),
             truncated: false,
@@ -434,6 +444,15 @@ impl ArchiveIndex {
         } else {
             self.archive.join(inner)
         }
+    }
+
+    /// The file to read this archive's bytes out of.
+    ///
+    /// Every read and the repack's rename target go through here. For a nested
+    /// archive that's the staged copy: its address names a member of the archive
+    /// above it, which no `File::open` can resolve.
+    pub fn source(&self) -> &Path {
+        self.source.as_deref().unwrap_or(&self.archive)
     }
 
     /// Inverse of [`Self::mount_path`]: the inner path for an absolute path

--- a/src/archive/mount.rs
+++ b/src/archive/mount.rs
@@ -37,11 +37,23 @@ pub struct ArchiveMount {
     /// Monotonic stamp of the last time a column entered this mount, so the
     /// least-recently-used one is the one evicted.
     pub last_used: u64,
+    /// How many archives deep this one is: 0 when it's a file on disk, 1 for one
+    /// inside that, and so on. Carried rather than derived so a third level can't
+    /// read as a second.
+    pub depth: usize,
 }
 
 impl ArchiveMount {
+    /// Where this mount is addressed — its root, and the registry key. Every
+    /// member path sits under it.
     pub fn archive(&self) -> &Path {
         &self.index.archive
+    }
+
+    /// The file its bytes come out of. Differs from [`Self::archive`] only for a
+    /// nested archive, which is read from the staged copy.
+    pub fn source(&self) -> &Path {
+        self.index.source()
     }
 
     pub const fn format(&self) -> ArchiveFormat {
@@ -248,6 +260,7 @@ mod tests {
             warnings: Vec::new(),
             staging_root: PathBuf::from(format!("/staging/{}", archive.replace('/', "_"))),
             last_used: 0,
+            depth: 0,
         }
     }
 

--- a/src/archive/write.rs
+++ b/src/archive/write.rs
@@ -41,7 +41,7 @@ pub struct RepackReport {
     pub snapshot: Option<String>,
 }
 
-/// Write `steps` over `index.archive`.
+/// Write `steps` over the archive's [`ArchiveIndex::source`] file.
 ///
 /// The order of operations is the safety property: precheck, write a temp,
 /// verify the temp, snapshot the original, rename. The snapshot comes *after*
@@ -53,7 +53,9 @@ pub fn repack(
     staging_root: &Path,
     opts: &RepackOptions,
 ) -> Result<RepackReport> {
-    let archive = &index.archive;
+    // The file the bytes live in — the staged copy for a nested archive, whose
+    // address names a member of the archive above it.
+    let archive = index.source();
     let parent = archive
         .parent()
         .filter(|p| !p.as_os_str().is_empty())
@@ -109,8 +111,8 @@ fn write_zip(
     dest: &Path,
 ) -> Result<()> {
     let mut src = zip::ZipArchive::new(BufReader::new(
-        File::open(&index.archive)
-            .with_context(|| format!("opening {}", index.archive.display()))?,
+        File::open(index.source())
+            .with_context(|| format!("opening {}", index.source().display()))?,
     ))?;
     let out_file = File::create(dest).with_context(|| format!("writing {}", dest.display()))?;
     let mut out = zip::ZipWriter::new(BufWriter::new(out_file));
@@ -202,7 +204,7 @@ fn write_tar(
                 let bytes = match entry.locator {
                     // A plain tar is seekable, so untouched bytes come straight
                     // from it.
-                    Locator::TarData { offset } => read_at(&index.archive, offset, entry.size)?,
+                    Locator::TarData { offset } => read_at(index.source(), offset, entry.size)?,
                     // A streamed mount extracted everything, so its "archived"
                     // bytes are the staged copy.
                     Locator::Staged => std::fs::read(staging_root.join(entry.staging_rel()))

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -179,6 +179,10 @@
 #   warn_over_mb       (default 128)    confirm before extracting more.
 #   max_entries        (default 200000) cap on indexed members; past it
 #                        the listing shows itself as truncated.
+#   max_depth          (default 2)      how deep archives may nest. A
+#                        container inside a container has to be copied
+#                        out whole before it can be read, so each level
+#                        costs its own size in staging. 0 refuses one.
 #   write_back         (default "ask")  "ask" offers to write pending
 #                        changes back when you unmount a changed
 #                        archive; "never" leaves them pending.
@@ -193,6 +197,7 @@
 # extract_budget_mb = 512
 # warn_over_mb = 128
 # max_entries = 200000
+# max_depth = 2
 # write_back = "ask"
 # snapshot_max_mb = 64
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -456,6 +456,10 @@ pub struct ArchiveConfig {
     pub warn_over_mb: u64,
     /// Cap on indexed members; past it the listing marks itself truncated.
     pub max_entries: usize,
+    /// How deep archives may nest. 0 refuses a container inside a container; each
+    /// level costs a full copy of that container in the level above's staging,
+    /// which is why it's bounded rather than unlimited.
+    pub max_depth: usize,
     /// Whether leaving a container with unwritten changes offers to write them.
     pub write_back: WriteBack,
     /// Copy the original into the graveyard before replacing it, for archives up
@@ -483,6 +487,7 @@ impl Default for ArchiveConfig {
             extract_budget_mb: 512,
             warn_over_mb: 128,
             max_entries: 200_000,
+            max_depth: 2,
             write_back: WriteBack::Ask,
             snapshot_max_mb: 64,
         }
@@ -509,6 +514,7 @@ struct FileArchive {
     extract_budget_mb: Option<u64>,
     warn_over_mb: Option<u64>,
     max_entries: Option<usize>,
+    max_depth: Option<usize>,
     write_back: Option<WriteBack>,
     snapshot_max_mb: Option<u64>,
 }
@@ -917,6 +923,9 @@ impl Config {
         }
         if let Some(v) = file.archive.max_entries {
             self.archive.max_entries = v;
+        }
+        if let Some(v) = file.archive.max_depth {
+            self.archive.max_depth = v;
         }
         if let Some(v) = file.archive.write_back {
             self.archive.write_back = v;

--- a/src/context.rs
+++ b/src/context.rs
@@ -58,6 +58,10 @@ pub struct ArchiveMountRef {
     pub root: PathBuf,
     /// Directory holding whatever has been extracted so far.
     pub staging: PathBuf,
+    /// The file the bytes are read out of, when that isn't `root` — a nested
+    /// archive is addressed at its member path but read from a staged copy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<PathBuf>,
 }
 
 /// Environment variable that tells `spyc --mcp` where to find the

--- a/src/mcp/readers.rs
+++ b/src/mcp/readers.rs
@@ -135,7 +135,7 @@ pub(super) fn search_root(ctx_path: &Path) -> PathBuf {
 ///
 /// Empty unless the user is browsing an archive, which is why every reader that
 /// doesn't care can ignore mounts entirely.
-pub(super) fn archive_mounts(ctx_path: &Path) -> Vec<(PathBuf, PathBuf)> {
+pub(super) fn archive_mounts(ctx_path: &Path) -> Vec<ArchiveMountView> {
     let Ok(text) = std::fs::read_to_string(ctx_path) else {
         return Vec::new();
     };
@@ -147,11 +147,28 @@ pub(super) fn archive_mounts(ctx_path: &Path) -> Vec<(PathBuf, PathBuf)> {
     };
     list.iter()
         .filter_map(|m| {
-            let root = m["root"].as_str()?;
-            let staging = m["staging"].as_str()?;
-            Some((PathBuf::from(root), PathBuf::from(staging)))
+            let root = PathBuf::from(m["root"].as_str()?);
+            let staging = PathBuf::from(m["staging"].as_str()?);
+            // A nested archive is read from a staged copy; its own address is a
+            // member of the archive above it and opens nothing.
+            let source = m["source"]
+                .as_str()
+                .map_or_else(|| root.clone(), PathBuf::from);
+            Some(ArchiveMountView {
+                root,
+                staging,
+                source,
+            })
         })
         .collect()
+}
+
+/// A mounted archive as a reader sees it: where it's addressed, where its
+/// extracted bytes go, and which file to actually open.
+pub(super) struct ArchiveMountView {
+    pub root: PathBuf,
+    pub staging: PathBuf,
+    pub source: PathBuf,
 }
 
 /// Split `path` into the mount holding it and the member within, longest mount
@@ -159,21 +176,21 @@ pub(super) fn archive_mounts(ctx_path: &Path) -> Vec<(PathBuf, PathBuf)> {
 ///
 /// `None` for the mount root itself: the archive file is an ordinary file, and
 /// reading it means reading the container's bytes.
-fn member_in_mount(
-    path: &Path,
-    mounts: &[(PathBuf, PathBuf)],
-) -> Option<(PathBuf, PathBuf, String)> {
+fn member_in_mount(path: &Path, mounts: &[ArchiveMountView]) -> Option<(PathBuf, PathBuf, String)> {
     mounts
         .iter()
-        .filter_map(|(root, staging)| {
-            let rel = path.strip_prefix(root).ok()?;
+        .filter_map(|m| {
+            let rel = path.strip_prefix(&m.root).ok()?;
             // A member name that survives normalization is relative and has no
             // `..`, so neither the staging join below nor the index lookup can be
             // walked out of the mount by a crafted argument.
             let inner = crate::archive::index::normalize(&rel.to_string_lossy()).ok()?;
-            Some((root.clone(), staging.clone(), inner.inner))
+            Some((m, inner.inner))
         })
-        .max_by_key(|(root, _, _)| root.as_os_str().len())
+        // Longest root wins, so a nested archive answers for its own members
+        // rather than for the one it sits inside.
+        .max_by_key(|(m, _)| m.root.as_os_str().len())
+        .map(|(m, inner)| (m.source.clone(), m.staging.clone(), inner))
 }
 
 /// Whether `path` is at or inside a mounted archive — the guard for a tool that
@@ -181,7 +198,7 @@ fn member_in_mount(
 pub(super) fn is_in_mount(path: &Path, ctx_path: &Path) -> bool {
     archive_mounts(ctx_path)
         .iter()
-        .any(|(root, _)| path == root || path.starts_with(root))
+        .any(|m| path == m.root || path.starts_with(&m.root))
 }
 
 /// Content for a path inside a mounted archive, or `None` when it isn't one (the

--- a/src/mcp/tests/mod.rs
+++ b/src/mcp/tests/mod.rs
@@ -1283,6 +1283,7 @@ fn mounted_zip(dir: &std::path::Path, staging: &std::path::Path) -> (PathBuf, Pa
         archive_mounts: vec![context::ArchiveMountRef {
             root: archive.clone(),
             staging: staging.to_path_buf(),
+            source: None,
         }],
     };
     let ctx_path = context::context_path(dir);


### PR DESCRIPTION
Last of the three that were PR 5, and the last item on #149's charter. `Enter` on a member that is itself a container walks into it — a jar in a war, a tarball in a zip.

## One field meant two things

`ArchiveIndex.archive` was both **where a mount is addressed** (the root every member path hangs off) and **the file its bytes are read from**. Identical for an archive on disk; different for one inside another, which is addressed at its member path — a path no `File::open` can resolve — while its bytes are the copy spyc extracted.

Splitting it into `archive` (address) and `source` (bytes) is the whole of what makes nesting work. Nothing else needed restructuring, because every other site already keys on one or the other: resolution, labels and the registry key take the address; `materialize`, `member_bytes` and the repack take the source.

The readdressing happens at the op boundary — `mount` indexes a *file* and so hands back an index addressed at that file, and `readdress` moves it to where the column will browse it. Depth is carried rather than derived, so a third level can't read as a second.

## The bound

`[archive] max_depth` (default 2). Each level costs a **full copy of that container** in the level above's staging, because bytes have to be a real file before anything can read them. That's inherent to the format, not incidental, so it's bounded rather than unlimited; 0 refuses nesting entirely.

Since a nested mount's bytes live inside its parent's staging tree, the parent is protected from LRU eviction, and unmounting it while the child is live is refused and names the child.

## The write cascade needs no plumbing

Writing the inner archive replaces a file inside the parent's staging tree — which the parent's own change detection (staged `(size, mtime)` vs what spyc recorded) already notices. So the cascade falls out for free; all that was needed was a flash saying the outer now has a pending change of its own, rather than leaving it to the quit warning.

## Two bugs this turned up

- **`contains` was standing in for "is this archive mounted"** in both mount requests. Those diverge the moment archives nest: a nested archive's own path is *inside* its parent, so the request short-circuited to "already mounted" and left the column on a file member's path, listing nothing. Now `get`. My first test for the depth cap asserted with `contains` too and passed for the same wrong reason.
- **A repack renumbers a zip's entries** — it writes members in index order, which is not the order they were stored in. The post-write re-mount was meant to re-read the archive, but since #312 made a live mount *re-enter* rather than re-index, it silently kept the old locators. A read after a write then followed a stale index to a **different member's bytes**. The mount is now dropped first so the re-mount really re-reads.

  Worth noting how narrowly that one was caught: my first version of the test checked one surviving member and **passed against the broken code**, because that member's position happened not to move. Checking every surviving member fails deterministically. That bug predates this PR and would have bitten any read after any `:archive write`.

## Verification

- `make check-ci` → `=== GATE: PASS ===`; 240 archive tests.
- New: entering a nested archive (asserting it's addressed at its member path, `depth == 1`, and read from a real file that is *not* its address), reading a member of the inner archive and getting the inner archive's bytes, the depth cap naming the knob, unmounting the outer being refused while the inner is live, and the stale-index test above — each checked to fail against the code before it.
- The fixture is a zip holding a zip, built in a tempdir; no binary blobs committed.
- Not driven by hand. `demo.zip`-in-a-zip is easy to make if you want a target — say so and I'll build one alongside a fresh binary.

## #149

This closes out the charter: mount, read out, write back, MCP reads, persistence, nesting. The only thing still deliberately deferred is `:grep` / `F` inside a mount, which needs the whole mount extracted *and* result paths mapped back to members or `gf` can't resolve them.

Generated with [Claude Code](https://claude.com/claude-code)
