### PR TITLE
fix(archive): notice an edited member however it was edited

### DIFF
--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -406,7 +406,7 @@ impl App {
     }
 
     /// Start watching a staged copy for a change spyc won't make itself.
-    fn watch_for_edits(&mut self, real: &Path) {
+    pub(super) fn watch_for_edits(&mut self, real: &Path) {
         let Some((archive, inner)) = self.staged_owner(real) else {
             return;
         };
@@ -999,13 +999,24 @@ impl App {
 
     /// Whether a mount has anything a write would change — the journal, or a
     /// staged file that no longer matches what spyc wrote.
-    /// Record edits to members the user opened in an editor.
+    /// Notice a staged member that changed, and record it as a pending change.
     ///
-    /// Runs on every loop wake, which is affordable because it only stats what
-    /// [`ArchiveMount::editing`] names — usually one member. An edit is otherwise
-    /// invisible until something asks the disk, and the *draw* pass can't: a staged
-    /// copy that supersedes its archived bytes has to be in the Model for the
-    /// badge, `:archive info` and the repack to agree about it.
+    /// Runs on every loop wake. An edit is otherwise invisible until something
+    /// asks the disk, and the *draw* pass can't: a staged copy that supersedes its
+    /// archived bytes has to be in the Model for the badge, `:archive info` and
+    /// the repack to agree about it.
+    ///
+    /// Deliberately **not** limited to members spyc handed to an editor. There are
+    /// several routes to the same staged file — the pager's `v` edits its own
+    /// `source_path`, an agent in the pane can write it, so can `!vim` — and a fix
+    /// that only watched the ones spyc knew about left the badge blank for all of
+    /// them. What bounds the cost instead is the size of the staged set: it holds
+    /// only members that have actually been extracted, which for a zip is whatever
+    /// the user has read. Past [`AUTO_SCAN_MAX`] — a streamed tarball, where
+    /// mounting extracts everything — statting it on every keypress would be
+    /// visible jank, so those fall back to [`Self::scan_archive_edits`] at the
+    /// moments something reports or writes, plus the `editing` set, which stays
+    /// cheap however large the archive is.
     pub(super) fn settle_archive_edits(&mut self) -> bool {
         if self.state.mounts.is_empty() {
             return false;
@@ -1014,8 +1025,17 @@ impl App {
             .state
             .mounts
             .iter()
-            .filter(|m| !m.editing.is_empty())
-            .map(|m| (m.archive().to_path_buf(), changed_among(m, &m.editing)))
+            .map(|m| {
+                let mut candidates: Vec<String> = m.editing.clone();
+                if m.staged.len() <= AUTO_SCAN_MAX {
+                    for inner in m.staged.keys() {
+                        if !candidates.contains(inner) {
+                            candidates.push(inner.clone());
+                        }
+                    }
+                }
+                (m.archive().to_path_buf(), changed_among(m, &candidates))
+            })
             .filter(|(_, changed)| !changed.is_empty())
             .collect();
         self.record_replacements(found)
@@ -1198,6 +1218,12 @@ fn current_staged_stats(mount: &ArchiveMount) -> crate::archive::journal::Staged
     }
     now
 }
+
+/// How many staged members spyc will stat on every loop wake to notice an edit.
+///
+/// A handful of reads costs nothing; a streamed tarball's whole member list would
+/// cost tens of milliseconds per keypress.
+const AUTO_SCAN_MAX: usize = 256;
 
 /// Which of `candidates` has a staged copy that no longer matches what spyc
 /// recorded — skipping any already recorded as replaced.

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -1387,6 +1387,26 @@ fn build_tar_gz(path: &Path) {
     b.into_inner().unwrap().finish().unwrap();
 }
 
+/// A `.tar.gz` with `count` small members, for the staged-set bound.
+fn build_tar_gz_with(path: &Path, count: usize) {
+    let enc = flate2::write::GzEncoder::new(
+        std::fs::File::create(path).unwrap(),
+        flate2::Compression::default(),
+    );
+    let mut b = tar::Builder::new(enc);
+    for i in 0..count {
+        let body = format!("member {i}\n");
+        let mut h = tar::Header::new_gnu();
+        h.set_size(body.len() as u64);
+        h.set_mode(0o644);
+        h.set_mtime(1_000_000);
+        h.set_entry_type(tar::EntryType::Regular);
+        b.append_data(&mut h, format!("file-{i}.txt"), body.as_bytes())
+            .unwrap();
+    }
+    b.into_inner().unwrap().finish().unwrap();
+}
+
 /// The reported bug: `y` inside a `.tar.gz` failed with
 /// `demo.tar.gz/src/main.rs: Not a directory`.
 ///
@@ -2018,10 +2038,13 @@ fn an_edit_becomes_a_pending_change_the_badge_can_show() {
     });
 }
 
-/// An agent in the pane editing a member the user never opened is caught too —
-/// on the next thing that reports, rather than by statting every member forever.
+/// The route that actually bit: the pager's `v` edits its own `source_path`,
+/// which for a member *is* the staged copy — so spyc never handed the member to
+/// an editor through `open_member`. An agent in the pane writing the same file
+/// looks identical. Neither can be caught by watching only what spyc knows it
+/// handed over, which is why the scan covers everything staged.
 #[test]
-fn an_edit_to_a_member_nobody_opened_is_caught_when_something_reports() {
+fn an_edit_spyc_did_not_make_shows_up_without_being_asked() {
     let tmp = tempfile::tempdir().unwrap();
     crate::state::with_state_root(tmp.path(), || {
         let dir = tmp.path().to_path_buf();
@@ -2030,20 +2053,60 @@ fn an_edit_to_a_member_nobody_opened_is_caught_when_something_reports() {
         let mut app = App::test_app(dir);
         mount_inline(&mut app, &archive, &tmp.path().join("staging"));
 
-        // Extract a member the way a read does (no editor, so nothing is watched).
+        // Extract a member the way a *read* does — nothing is handed to an editor.
         app.apply(&Action::Down(1)).unwrap();
         let fx = app.apply(&Action::Take).unwrap();
         settle(&mut app, fx);
         let mount = app.state.mounts.get(&archive).expect("mounted");
-        assert!(mount.editing.is_empty(), "nothing is being watched");
+        assert!(mount.editing.is_empty(), "spyc handed nothing to an editor");
         let staged = mount.staging_path(mount.index.get("README.md").unwrap());
 
         std::fs::write(&staged, b"# changed by something else\n").unwrap();
+
+        assert!(
+            app.settle_archive_edits(),
+            "and it is still noticed, with no command run"
+        );
+        assert_eq!(
+            app.state
+                .mounts
+                .get(&archive)
+                .unwrap()
+                .journal
+                .counts()
+                .badge(),
+            "~1"
+        );
+    });
+}
+
+/// The bound that keeps that scan affordable. A streamed mount extracts every
+/// member, so its staged set is the whole archive — statting it on every keypress
+/// would be visible jank, and those fall back to the scan at reporting time.
+#[test]
+fn a_huge_staged_set_falls_back_to_the_reporting_scan() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("many.tar.gz");
+        build_tar_gz_with(&archive, 300);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let mount = app.state.mounts.get(&archive).expect("mounted");
+        assert!(
+            mount.staged.len() > 256,
+            "the fixture is past the bound: {}",
+            mount.staged.len()
+        );
+        let staged = mount.staging_path(mount.index.get("file-7.txt").unwrap());
+        std::fs::write(&staged, b"edited\n").unwrap();
+
         assert!(
             !app.settle_archive_edits(),
-            "the cheap check only looks where it was told to"
+            "too many to stat on every wake"
         );
-        assert!(app.scan_archive_edits(), "the full scan finds it");
+        assert!(app.scan_archive_edits(), "but reporting still catches it");
         assert_eq!(
             app.state
                 .mounts

--- a/src/app/pager_handler/motion.rs
+++ b/src/app/pager_handler/motion.rs
@@ -302,6 +302,10 @@ impl App {
                 if matches!(mount, crate::ui::pager::Mount::TopPane)
                     && let Some(src) = view.source_path.clone()
                 {
+                    // The pager's source *is* the staged copy when it was opened on
+                    // an archive member, so this hands a member to an editor
+                    // without going through `open_member`.
+                    self.watch_for_edits(&src);
                     let cmd = format!(
                         "{editor_cmd} {}",
                         shell::shell_quote(&src.display().to_string())
@@ -315,7 +319,8 @@ impl App {
                 }
 
                 // Determine the file to edit and the return state.
-                let (edit_path, pager_return) = if let Some(ref src) = view.source_path {
+                let source = view.source_path.clone();
+                let (edit_path, pager_return) = if let Some(ref src) = source {
                     (
                         src.clone(),
                         PagerReturn::SourceFile {
@@ -344,6 +349,13 @@ impl App {
                         }
                     }
                 };
+                // A pager opened on an archive member holds the staged copy as its
+                // source, so this hands a member to an editor without going through
+                // `open_member`. (After the `view` borrow, which the editor path
+                // above still needs.)
+                if source.is_some() {
+                    self.watch_for_edits(&edit_path);
+                }
                 self.view.pending_pager_return = Some(pager_return);
                 // A scrollback `v` lives in `view.scroll_pager`, which
                 // `clear_pager` (top slot only) wouldn't touch — clear ITS slot


### PR DESCRIPTION
Follow-up to #320, from driving it: **the badge still didn't light up.**

## Why

#320 made an edit a pending change, but only for members spyc knew it had handed to an editor (`ArchiveMount::editing`, set in `open_member`'s `Edit` arm). The route actually taken doesn't go through that:

`pager_handler/motion.rs` — the pager's `v` edits `view.source_path`, and for a member **that is the staged copy**. `open_member` never sees it. An agent in the pane writing the same file, or `!vim` on it, are indistinguishable. So for every one of those the badge stayed blank until something ran the full scan — exactly the state #320 was meant to end.

My fix was too narrow, and the test I wrote for it *asserted* the narrowness (`"the cheap check only looks where it was told to"`), which is why the suite was green while the feature wasn't.

## The fix

The always-on check no longer depends on knowing. It stats every member in the mount's **staged set** — which holds only what has actually been extracted, so for a zip it's whatever has been read.

What bounds the cost is that set's size, not spyc's knowledge: past `AUTO_SCAN_MAX` (256) — a streamed tarball, where mounting extracts everything — statting it on each keypress would be visible jank, so those keep the reporting-time scan plus the `editing` set, which stays cheap however large the archive is. The pager's two editor routes now register the member as well, so the fast path covers them even there.

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- `an_edit_spyc_did_not_make_shows_up_without_being_asked` — extract a member via a *read* (nothing handed to an editor), write to the staged copy, and the settle catches it with no command run. Verified to fail with the narrow candidate set.
- `a_huge_staged_set_falls_back_to_the_reporting_scan` — a 300-member `.tar.gz` fixture, so the bound is tested behaviour rather than a comment: the settle skips it, the scan catches it.
- The test that asserted the old narrowness is gone.

Generated with [Claude Code](https://claude.com/claude-code)