### PR TITLE
fix(status): the status bar describes the focused column, not always column a

### DIFF
--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -406,7 +406,7 @@ impl App {
     }
 
     /// Start watching a staged copy for a change spyc won't make itself.
-    fn watch_for_edits(&mut self, real: &Path) {
+    pub(super) fn watch_for_edits(&mut self, real: &Path) {
         let Some((archive, inner)) = self.staged_owner(real) else {
             return;
         };
@@ -999,13 +999,24 @@ impl App {
 
     /// Whether a mount has anything a write would change — the journal, or a
     /// staged file that no longer matches what spyc wrote.
-    /// Record edits to members the user opened in an editor.
+    /// Notice a staged member that changed, and record it as a pending change.
     ///
-    /// Runs on every loop wake, which is affordable because it only stats what
-    /// [`ArchiveMount::editing`] names — usually one member. An edit is otherwise
-    /// invisible until something asks the disk, and the *draw* pass can't: a staged
-    /// copy that supersedes its archived bytes has to be in the Model for the
-    /// badge, `:archive info` and the repack to agree about it.
+    /// Runs on every loop wake. An edit is otherwise invisible until something
+    /// asks the disk, and the *draw* pass can't: a staged copy that supersedes its
+    /// archived bytes has to be in the Model for the badge, `:archive info` and
+    /// the repack to agree about it.
+    ///
+    /// Deliberately **not** limited to members spyc handed to an editor. There are
+    /// several routes to the same staged file — the pager's `v` edits its own
+    /// `source_path`, an agent in the pane can write it, so can `!vim` — and a fix
+    /// that only watched the ones spyc knew about left the badge blank for all of
+    /// them. What bounds the cost instead is the size of the staged set: it holds
+    /// only members that have actually been extracted, which for a zip is whatever
+    /// the user has read. Past [`AUTO_SCAN_MAX`] — a streamed tarball, where
+    /// mounting extracts everything — statting it on every keypress would be
+    /// visible jank, so those fall back to [`Self::scan_archive_edits`] at the
+    /// moments something reports or writes, plus the `editing` set, which stays
+    /// cheap however large the archive is.
     pub(super) fn settle_archive_edits(&mut self) -> bool {
         if self.state.mounts.is_empty() {
             return false;
@@ -1014,8 +1025,17 @@ impl App {
             .state
             .mounts
             .iter()
-            .filter(|m| !m.editing.is_empty())
-            .map(|m| (m.archive().to_path_buf(), changed_among(m, &m.editing)))
+            .map(|m| {
+                let mut candidates: Vec<String> = m.editing.clone();
+                if m.staged.len() <= AUTO_SCAN_MAX {
+                    for inner in m.staged.keys() {
+                        if !candidates.contains(inner) {
+                            candidates.push(inner.clone());
+                        }
+                    }
+                }
+                (m.archive().to_path_buf(), changed_among(m, &candidates))
+            })
             .filter(|(_, changed)| !changed.is_empty())
             .collect();
         self.record_replacements(found)
@@ -1198,6 +1218,12 @@ fn current_staged_stats(mount: &ArchiveMount) -> crate::archive::journal::Staged
     }
     now
 }
+
+/// How many staged members spyc will stat on every loop wake to notice an edit.
+///
+/// A handful of reads costs nothing; a streamed tarball's whole member list would
+/// cost tens of milliseconds per keypress.
+const AUTO_SCAN_MAX: usize = 256;
 
 /// Which of `candidates` has a staged copy that no longer matches what spyc
 /// recorded — skipping any already recorded as replaced.

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -1387,6 +1387,26 @@ fn build_tar_gz(path: &Path) {
     b.into_inner().unwrap().finish().unwrap();
 }
 
+/// A `.tar.gz` with `count` small members, for the staged-set bound.
+fn build_tar_gz_with(path: &Path, count: usize) {
+    let enc = flate2::write::GzEncoder::new(
+        std::fs::File::create(path).unwrap(),
+        flate2::Compression::default(),
+    );
+    let mut b = tar::Builder::new(enc);
+    for i in 0..count {
+        let body = format!("member {i}\n");
+        let mut h = tar::Header::new_gnu();
+        h.set_size(body.len() as u64);
+        h.set_mode(0o644);
+        h.set_mtime(1_000_000);
+        h.set_entry_type(tar::EntryType::Regular);
+        b.append_data(&mut h, format!("file-{i}.txt"), body.as_bytes())
+            .unwrap();
+    }
+    b.into_inner().unwrap().finish().unwrap();
+}
+
 /// The reported bug: `y` inside a `.tar.gz` failed with
 /// `demo.tar.gz/src/main.rs: Not a directory`.
 ///
@@ -2018,10 +2038,13 @@ fn an_edit_becomes_a_pending_change_the_badge_can_show() {
     });
 }
 
-/// An agent in the pane editing a member the user never opened is caught too —
-/// on the next thing that reports, rather than by statting every member forever.
+/// The route that actually bit: the pager's `v` edits its own `source_path`,
+/// which for a member *is* the staged copy — so spyc never handed the member to
+/// an editor through `open_member`. An agent in the pane writing the same file
+/// looks identical. Neither can be caught by watching only what spyc knows it
+/// handed over, which is why the scan covers everything staged.
 #[test]
-fn an_edit_to_a_member_nobody_opened_is_caught_when_something_reports() {
+fn an_edit_spyc_did_not_make_shows_up_without_being_asked() {
     let tmp = tempfile::tempdir().unwrap();
     crate::state::with_state_root(tmp.path(), || {
         let dir = tmp.path().to_path_buf();
@@ -2030,20 +2053,60 @@ fn an_edit_to_a_member_nobody_opened_is_caught_when_something_reports() {
         let mut app = App::test_app(dir);
         mount_inline(&mut app, &archive, &tmp.path().join("staging"));
 
-        // Extract a member the way a read does (no editor, so nothing is watched).
+        // Extract a member the way a *read* does — nothing is handed to an editor.
         app.apply(&Action::Down(1)).unwrap();
         let fx = app.apply(&Action::Take).unwrap();
         settle(&mut app, fx);
         let mount = app.state.mounts.get(&archive).expect("mounted");
-        assert!(mount.editing.is_empty(), "nothing is being watched");
+        assert!(mount.editing.is_empty(), "spyc handed nothing to an editor");
         let staged = mount.staging_path(mount.index.get("README.md").unwrap());
 
         std::fs::write(&staged, b"# changed by something else\n").unwrap();
+
+        assert!(
+            app.settle_archive_edits(),
+            "and it is still noticed, with no command run"
+        );
+        assert_eq!(
+            app.state
+                .mounts
+                .get(&archive)
+                .unwrap()
+                .journal
+                .counts()
+                .badge(),
+            "~1"
+        );
+    });
+}
+
+/// The bound that keeps that scan affordable. A streamed mount extracts every
+/// member, so its staged set is the whole archive — statting it on every keypress
+/// would be visible jank, and those fall back to the scan at reporting time.
+#[test]
+fn a_huge_staged_set_falls_back_to_the_reporting_scan() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("many.tar.gz");
+        build_tar_gz_with(&archive, 300);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let mount = app.state.mounts.get(&archive).expect("mounted");
+        assert!(
+            mount.staged.len() > 256,
+            "the fixture is past the bound: {}",
+            mount.staged.len()
+        );
+        let staged = mount.staging_path(mount.index.get("file-7.txt").unwrap());
+        std::fs::write(&staged, b"edited\n").unwrap();
+
         assert!(
             !app.settle_archive_edits(),
-            "the cheap check only looks where it was told to"
+            "too many to stat on every wake"
         );
-        assert!(app.scan_archive_edits(), "the full scan finds it");
+        assert!(app.scan_archive_edits(), "but reporting still catches it");
         assert_eq!(
             app.state
                 .mounts

--- a/src/app/pager_handler/motion.rs
+++ b/src/app/pager_handler/motion.rs
@@ -302,6 +302,10 @@ impl App {
                 if matches!(mount, crate::ui::pager::Mount::TopPane)
                     && let Some(src) = view.source_path.clone()
                 {
+                    // The pager's source *is* the staged copy when it was opened on
+                    // an archive member, so this hands a member to an editor
+                    // without going through `open_member`.
+                    self.watch_for_edits(&src);
                     let cmd = format!(
                         "{editor_cmd} {}",
                         shell::shell_quote(&src.display().to_string())
@@ -315,7 +319,8 @@ impl App {
                 }
 
                 // Determine the file to edit and the return state.
-                let (edit_path, pager_return) = if let Some(ref src) = view.source_path {
+                let source = view.source_path.clone();
+                let (edit_path, pager_return) = if let Some(ref src) = source {
                     (
                         src.clone(),
                         PagerReturn::SourceFile {
@@ -344,6 +349,13 @@ impl App {
                         }
                     }
                 };
+                // A pager opened on an archive member holds the staged copy as its
+                // source, so this hands a member to an editor without going through
+                // `open_member`. (After the `view` borrow, which the editor path
+                // above still needs.)
+                if source.is_some() {
+                    self.watch_for_edits(&edit_path);
+                }
                 self.view.pending_pager_return = Some(pager_return);
                 // A scrollback `v` lives in `view.scroll_pager`, which
                 // `clear_pager` (top slot only) wouldn't touch — clear ITS slot

--- a/src/app/render/chrome.rs
+++ b/src/app/render/chrome.rs
@@ -393,90 +393,93 @@ impl App {
     /// Status-bar header: the left (path / view name) and right
     /// (status tags) halves of the top line, per current view.
     pub(super) fn header_parts(&self) -> (String, String) {
-        match self.state.left.view {
-            View::Dir => (crate::paths::display_tilde(&self.state.left.listing.dir), {
-                let filter_tag = match &self.state.left.temp_filter {
-                    Some(f) if f == "!" => " limit:picks".to_string(),
-                    Some(f) => format!(" limit:{f}"),
-                    None => String::new(),
-                };
+        match self.state.cur().view {
+            View::Dir => (
+                crate::paths::display_tilde(&self.state.cur().listing.dir),
                 {
-                    let total = self.state.left.listing.entries.len();
-                    let shown = self.state.left.rows.len();
-                    let hidden = total.saturating_sub(shown);
-                    let hidden_tag = format!(" hidden:{hidden}");
-                    // Bg tasks normally render in the divider line above
-                    // the pane (distinct color, right-aligned). When the
-                    // pane is hidden there is no divider, so fall back
-                    // to the status-bar suffix here.
-                    let bg_tag = if self.runtime.pane_tabs.is_some() {
-                        String::new()
-                    } else {
-                        let running = self.runtime.background_tasks.running_count();
-                        let done = self.runtime.background_tasks.done_count();
-                        if running == 0 && done == 0 {
-                            String::new()
-                        } else if done == 0 {
-                            format!(" bg:{running}\u{25cf}")
-                        } else {
-                            format!(" bg:{running}\u{25cf}{done}\u{2713}")
-                        }
+                    let filter_tag = match &self.state.cur().temp_filter {
+                        Some(f) if f == "!" => " limit:picks".to_string(),
+                        Some(f) => format!(" limit:{f}"),
+                        None => String::new(),
                     };
-                    // Inside a mounted archive, say so — the path alone reads
-                    // like an ordinary directory under a file, which is exactly
-                    // what it is, but not obviously deliberate.
-                    let archive_tag = self
-                        .state
-                        .mounts
-                        .resolve(&self.state.left.listing.dir)
-                        .map_or_else(String::new, |(mount, _)| {
-                            let ro = if mount.capability.is_writable() {
-                                ""
-                            } else {
-                                " ro"
-                            };
-                            let pending = if mount.is_dirty() {
-                                format!(" {}", mount.journal.counts().badge())
-                            } else {
-                                String::new()
-                            };
-                            format!(" {}{ro}{pending}", mount.format().label())
-                        });
-                    let sort_tag = format!(
-                        " sort:{}{}",
-                        self.state.left.sort_order,
-                        if self.state.left.sort_reversed {
-                            "\u{2191}"
+                    {
+                        let total = self.state.cur().listing.entries.len();
+                        let shown = self.state.cur().rows.len();
+                        let hidden = total.saturating_sub(shown);
+                        let hidden_tag = format!(" hidden:{hidden}");
+                        // Bg tasks normally render in the divider line above
+                        // the pane (distinct color, right-aligned). When the
+                        // pane is hidden there is no divider, so fall back
+                        // to the status-bar suffix here.
+                        let bg_tag = if self.runtime.pane_tabs.is_some() {
+                            String::new()
                         } else {
-                            ""
-                        },
-                    );
-                    let suffix = format!(
-                        "[picks:{} inv:{} m1:{} m2:{}{}{}{}{}{}]",
-                        self.state.left.picks.len(),
-                        self.state.inventory.len(),
-                        on_off(self.state.left.masks.mask1.enabled),
-                        on_off(self.state.left.masks.mask2.enabled),
-                        filter_tag,
-                        hidden_tag,
-                        sort_tag,
-                        archive_tag,
-                        bg_tag,
-                    );
-                    // `TopList` zoom collapses the pane (no divider), so its
-                    // zoom cue can't ride the pane divider like `BottomPane`'s
-                    // does — surface it here, the same fallback the bg-task
-                    // tag uses when there's no divider.
-                    if matches!(
-                        self.state.pane.zoom,
-                        state::ZoomTarget::TopList | state::ZoomTarget::RightColumn
-                    ) {
-                        format!("{suffix} [ZOOM]")
-                    } else {
-                        suffix
+                            let running = self.runtime.background_tasks.running_count();
+                            let done = self.runtime.background_tasks.done_count();
+                            if running == 0 && done == 0 {
+                                String::new()
+                            } else if done == 0 {
+                                format!(" bg:{running}\u{25cf}")
+                            } else {
+                                format!(" bg:{running}\u{25cf}{done}\u{2713}")
+                            }
+                        };
+                        // Inside a mounted archive, say so — the path alone reads
+                        // like an ordinary directory under a file, which is exactly
+                        // what it is, but not obviously deliberate.
+                        let archive_tag = self
+                            .state
+                            .mounts
+                            .resolve(&self.state.cur().listing.dir)
+                            .map_or_else(String::new, |(mount, _)| {
+                                let ro = if mount.capability.is_writable() {
+                                    ""
+                                } else {
+                                    " ro"
+                                };
+                                let pending = if mount.is_dirty() {
+                                    format!(" {}", mount.journal.counts().badge())
+                                } else {
+                                    String::new()
+                                };
+                                format!(" {}{ro}{pending}", mount.format().label())
+                            });
+                        let sort_tag = format!(
+                            " sort:{}{}",
+                            self.state.cur().sort_order,
+                            if self.state.cur().sort_reversed {
+                                "\u{2191}"
+                            } else {
+                                ""
+                            },
+                        );
+                        let suffix = format!(
+                            "[picks:{} inv:{} m1:{} m2:{}{}{}{}{}{}]",
+                            self.state.cur().picks.len(),
+                            self.state.inventory.len(),
+                            on_off(self.state.cur().masks.mask1.enabled),
+                            on_off(self.state.cur().masks.mask2.enabled),
+                            filter_tag,
+                            hidden_tag,
+                            sort_tag,
+                            archive_tag,
+                            bg_tag,
+                        );
+                        // `TopList` zoom collapses the pane (no divider), so its
+                        // zoom cue can't ride the pane divider like `BottomPane`'s
+                        // does — surface it here, the same fallback the bg-task
+                        // tag uses when there's no divider.
+                        if matches!(
+                            self.state.pane.zoom,
+                            state::ZoomTarget::TopList | state::ZoomTarget::RightColumn
+                        ) {
+                            format!("{suffix} [ZOOM]")
+                        } else {
+                            suffix
+                        }
                     }
-                }
-            }),
+                },
+            ),
             View::Inventory => (
                 "<INVENTORY>".to_string(),
                 format!(

--- a/src/app/render/mod.rs
+++ b/src/app/render/mod.rs
@@ -996,6 +996,9 @@ mod render_tests {
     /// rows-cache forced to rebuild the way `demo_app` does for the left.
     #[test]
     fn snapshot_frame_second_commander() {
+        // The status bar describes `b` here, because `b` is what's focused — see
+        // `the_status_bar_describes_the_focused_column`.
+
         let tmp = tempfile::tempdir().unwrap();
         crate::state::with_state_root(tmp.path(), || {
             // Real files so `b`'s listing has deterministic basenames; the
@@ -1008,6 +1011,34 @@ mod render_tests {
             app.open_second_commander_at(tmp.path()); // b reads the 3 files, focused
             app.state.right.as_mut().unwrap().listing.dir = PathBuf::from("/projects/other");
             insta::assert_snapshot!(render_to_string(&mut app, 80, 24));
+        });
+    }
+
+    /// The status bar follows focus, so it can't describe one column's path beside
+    /// the other's branch — `render_status_bar` takes the git half from `cur()`,
+    /// and taking the rest from `left` is how an archive badge for a mount browsed
+    /// in `b` never appeared at all.
+    #[test]
+    fn the_status_bar_describes_the_focused_column() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let mut app = demo_app(&files()); // a = /projects/demo
+            app.open_second_commander_at(tmp.path());
+            app.state.right.as_mut().unwrap().listing.dir = PathBuf::from("/projects/other");
+
+            let flip = |app: &mut App, side| {
+                if let Some(v) = app.state.vsplit.as_mut() {
+                    v.focus = side;
+                }
+            };
+
+            flip(&mut app, crate::app::state::Side::Right);
+            let (path, _) = app.header_parts();
+            assert!(path.contains("other"), "b focused: {path}");
+
+            flip(&mut app, crate::app::state::Side::Left);
+            let (path, _) = app.header_parts();
+            assert!(path.contains("demo"), "a focused: {path}");
         });
     }
 

--- a/src/app/render/snapshots/spyc__app__render__render_tests__snapshot_frame_second_commander.snap
+++ b/src/app/render/snapshots/spyc__app__render__render_tests__snapshot_frame_second_commander.snap
@@ -1,8 +1,9 @@
 ---
 source: src/app/render/mod.rs
+assertion_line: 1010
 expression: "render_to_string(&mut app, 80, 24)"
 ---
- 🌶️   /projects/demo  [picks:0 inv:0 m1:on m2:on hidden:0 sort:name]           
+ 🌶️   /projects/other  [picks:0 inv:0 m1:on m2:on hidden:0 sort:name]          
   README.md                            │  lib.rs                                
   Cargo.toml                           │  main.rs                               
   src                                  │  mod.rs                                


### PR DESCRIPTION
The left-column gap, and it's wider than the archive badge.

## What was wrong

`render_status_bar` takes the **git half** from `cur()` — the focused column — while `header_parts` read `left` for everything else. So with a second commander focused, the bar showed column **a's** path, picks, filter, sort and hidden count beside column **b's** branch.

The archive badge is how it surfaced: a mount browsed in `b` never showed its format, `ro` or pending-change badge at all, because the tag was resolved against column a's directory — which usually isn't in an archive. Fixing only the badge would have left the inconsistency, so `header_parts` now reads `cur()` throughout, which is what the git half already assumed.

## The snapshot moved, and it should have

`snapshot_frame_second_commander` sets up `b` focused (its own comment says so) and its status line changed from `/projects/demo` to `/projects/other`. That's the assertion, not a regression — the bar now names the column the user is working in. Accepted, with a comment on the test pointing at the invariant.

I also added `the_status_bar_describes_the_focused_column`, which flips vsplit focus and checks the path both ways, so the intent is pinned by a direct assertion rather than living only inside a full-frame glyph snapshot.

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- The one snapshot change is reviewed above; 104 render tests otherwise unchanged.
- Not driven by hand. The check: open a split, browse an archive in `b`, and the badge should be there.

Note: the commit list shows #321's pre-squash commit because this branched off it before that merged. The diff against main is only the three files here, and force-pushing the tidied history was blocked, so I left it — the squash takes this PR's title either way.

Generated with [Claude Code](https://claude.com/claude-code)