### PR TITLE
fix(archive): mark a dirty archive in the directory it lives in

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -499,9 +499,11 @@ they land in a session-scoped staging dir that is cleaned up on exit.
   no bytes move however large it is), and `e` / `V` edit a member by extracting it
   and opening your editor on that copy. Everything stays pending until
   `:archive write`; the suffix carries a `+2 ~1 -3` badge meanwhile, and each
-  changed member is marked in the listing's own status gutter — `~` edited, `+`
-  added, `>` renamed, the same glyphs git changes use, because it's the same
-  question: what about this row isn't written yet. An edit made
+  changed member is marked in the listing's own status gutter — and the archive
+  file itself is marked `~` in the directory it lives in, so a container holding
+  unwritten changes is visible from outside it too. Inside, `~` is an edited
+  member, `+` added, `>` renamed — the same glyphs git changes use, because it's
+  the same question: what about this row isn't written yet. An edit made
   outside spyc — by your editor, or by an agent in the pane — counts as a change
   too, and shows in that badge: spyc compares each extracted file against what it
   wrote. From outside the archive, where the badge isn't visible, `:archive info`

--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -464,26 +464,18 @@ impl App {
         let Ok(md) = std::fs::metadata(real) else {
             return;
         };
-        let Some(archive) = self
-            .state
-            .mounts
-            .iter()
-            .find(|m| real.starts_with(&m.staging_root))
-            .map(|m| m.archive().to_path_buf())
-        else {
+        // Keyed by **journal path**, which is what every reader of this map uses.
+        // The staging-relative path is not the same string: a case-colliding member
+        // stages under a `.spyc-case-N/` prefix, so recording its location gave one
+        // member two names and its edits were never noticed.
+        let Some((archive, inner)) = self.staged_owner(real) else {
             return;
         };
         let Some(mount) = self.state.mounts.get_mut(&archive) else {
             return;
         };
-        let Ok(rel) = real.strip_prefix(&mount.staging_root) else {
-            return;
-        };
-        let key = rel
-            .to_string_lossy()
-            .replace(std::path::MAIN_SEPARATOR, "/");
         mount.staged.insert(
-            key,
+            inner,
             crate::archive::journal::StagedStat {
                 size: md.len(),
                 mtime: md.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH),

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -2318,3 +2318,74 @@ fn an_edited_member_is_marked_in_the_listing() {
         );
     });
 }
+
+/// The place the indicator was missing that mattered most: standing in the
+/// directory the archive lives in, looking at the archive file, with an unwritten
+/// change inside it.
+///
+/// The suffix badge only shows while you're *in* the mount, and the members aren't
+/// listed out here — so without a mark on the container's own row there is nothing
+/// at all to see.
+#[test]
+fn a_dirty_archive_is_marked_in_the_directory_it_lives_in() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir.clone());
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let archive_row = |app: &mut App| -> String {
+            let mut terminal =
+                ratatui::Terminal::new(ratatui::backend::TestBackend::new(60, 12)).unwrap();
+            terminal.draw(|f| app.render(f)).unwrap();
+            let buf = terminal.backend().buffer().clone();
+            (0..buf.area.height)
+                .map(|y| {
+                    (0..buf.area.width)
+                        .map(|x| buf[(x, y)].symbol())
+                        .collect::<String>()
+                })
+                .find(|line| line.contains("pkg.zip"))
+                .unwrap_or_default()
+        };
+
+        // Delete a member, then climb out to where the archive lives.
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::RemovePrompt(None)).unwrap();
+        let fx = if fx.is_empty() {
+            app.handle_remove_confirm_key(crossterm::event::KeyEvent::new(
+                KeyCode::Char('y'),
+                KeyModifiers::empty(),
+            ))
+        } else {
+            fx
+        };
+        settle(&mut app, fx);
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+        assert_eq!(app.state.cur().listing.dir, dir, "outside the archive");
+
+        let row = archive_row(&mut app);
+        assert!(
+            row.contains('~'),
+            "the archive says it holds unwritten changes: {row:?}"
+        );
+
+        // And once written it stops saying so. (The write runs from *inside* the
+        // mount: `:archive write` resolves which archive it means from the cwd.)
+        let fx = app.apply(&Action::EnterOrDisplay).unwrap();
+        settle(&mut app, fx);
+        assert_eq!(app.state.cur().listing.dir, archive, "back inside");
+        let fx = app.cmd_archive("write");
+        settle(&mut app, fx);
+        assert!(!app.mount_is_dirty(&archive), "the write landed");
+
+        let fx = app.apply(&Action::Climb).unwrap();
+        apply_effects(&mut app, fx);
+        let row = archive_row(&mut app);
+        assert!(!row.contains('~'), "clean again after the write: {row:?}");
+    });
+}

--- a/src/app/render/chrome.rs
+++ b/src/app/render/chrome.rs
@@ -20,6 +20,12 @@ fn archive_change(
 ) -> Option<crate::ui::list_view::GitChange> {
     use crate::archive::MemberChange;
     use crate::ui::list_view::GitChange;
+    // The archive *file*, seen from the directory it lives in: an unwritten change
+    // inside it is invisible out here otherwise — the suffix badge only shows while
+    // you're standing in the mount, and the members aren't listed.
+    if let Some(mount) = mounts.get(path) {
+        return mount.journal.is_dirty().then_some(GitChange::Modified);
+    }
     let (mount, _) = mounts.member_of(path)?;
     let entry = mount.entry_at(path)?;
     Some(match mount.journal.state_of(&entry.inner)? {


### PR DESCRIPTION
Diagnosed from your live session rather than by reading code — and it was a **third** place the indicator was missing.

## What your session actually showed

`get_spyc_context` on pid 82594 (`2f845ba`):

- cwd `/Users/derekmarshall/src` — **outside both mounts**
- `demo.zip` mounted, staging holds `README.md` at 8 bytes; the archive's own copy is 7

So the mount is genuinely dirty and unwritten, and you were standing in the directory looking at the archive file. There are three places a pending change could show, and only two were wired:

| where | needs | state |
|---|---|---|
| suffix badge `~1` | standing *in* the mount | worked (#320/#321) |
| member's row gutter | members listed, i.e. in the mount | worked (#328) |
| **the archive file's own row** | nothing | **showed nothing** |

The third is the one you notice a forgotten change from. The container's row now carries `~` while its journal holds changes, from the same helper that marks members.

## Also: what record_staged keys by

`StagedStats` is documented as keyed on the **journal path** — "not the displayed one, and not the staging-relative one" — and `record_staged` was inserting the staging-relative one. Identical for an ordinary member, which is why nothing caught it, but a **case-colliding** member stages under a `.spyc-case-N/` prefix: it got two names, so its edits were never noticed. It now uses the same `staged_owner` lookup as everything else.

## Something this turned up that I have *not* changed

`:archive write` resolves which archive it means from the cwd, so **from outside a mount it does nothing**. My first version of the test wrote from outside and the marker never cleared — because no write happened. That's now a visible dead end: you can see the archive is dirty from its directory but can't act on it there. Worth fixing (write the single dirty mount, or name them), but it's a behaviour change beyond this PR.

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- `a_dirty_archive_is_marked_in_the_directory_it_lives_in` renders a frame, asserts `~` on the container row, then writes (from inside) and asserts it clears. Verified to fail without the fix: `"  pkg.zip"`, no marker.

Generated with [Claude Code](https://claude.com/claude-code)
