### PR TITLE
feat(archive): a yanked member is remembered by its path in the archive

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -480,7 +480,10 @@ they land in a session-scoped staging dir that is cleaned up on exit.
   capped index are all reported when the mount opens, in full under
   `:archive info`.
 - **Taking things out** — `y` yanks a member into the inventory (contents and
-  all, so `p` outside the archive writes a real file), `c` copies members out,
+  all, so `p` outside the archive writes a real file), remembered by its path
+  *inside* the archive — `pkg.zip/src/main.rs` — so the row reads as taken, a
+  re-yank refreshes that entry, and the inventory never holds a cache path that
+  outlives the session. It puts as its basename, like any other yank, `c` copies members out,
   `^a p` pipes one to the pane, and `f` / `L` report on them. Each extracts what
   it needs first, so nothing is unpacked speculatively.
 - **Deleting a member** — `R` marks it for removal; the archive on disk is

--- a/src/app/archive_route.rs
+++ b/src/app/archive_route.rs
@@ -17,7 +17,7 @@ use crate::archive::Mounts;
 
 use super::Effect;
 use super::file_ops::FileOp;
-use super::inventory_ops::InventoryOp;
+use super::inventory_ops::{InventoryOp, YankSource as InventoryYankSource};
 
 /// What to do with an outgoing effect. Takes ownership so a held-back effect can
 /// be handed straight back later without the enum needing to be cloneable.
@@ -135,8 +135,13 @@ fn classify(
 ) -> Verdict {
     match effect {
         // --- reads: extract, then run ---
-        Effect::Inventory(InventoryOp::Yank { paths })
-        | Effect::FileOp(
+        // A yank names each file twice — where to read it, and what to remember it
+        // as — and only the former can be a member path needing extraction.
+        Effect::Inventory(InventoryOp::Yank { sources }) => {
+            let reads: Vec<PathBuf> = sources.iter().map(|s| s.read.clone()).collect();
+            need(&reads, mounts, is_staged)
+        }
+        Effect::FileOp(
             FileOp::PipeContent { paths, .. }
             | FileOp::LongList { paths, .. }
             | FileOp::FileType { paths },
@@ -503,8 +508,16 @@ pub fn rewrite_paths(effect: Effect, staged: &HashMap<PathBuf, PathBuf>) -> Effe
     let map = |p: &PathBuf| staged.get(p).cloned().unwrap_or_else(|| p.clone());
     let map_all = |paths: &[PathBuf]| paths.iter().map(map).collect::<Vec<_>>();
     match effect {
-        Effect::Inventory(InventoryOp::Yank { paths }) => Effect::Inventory(InventoryOp::Yank {
-            paths: map_all(&paths),
+        // Only `read` moves to the staging tree; `record_as` stays the member path,
+        // which is the whole point of carrying both.
+        Effect::Inventory(InventoryOp::Yank { sources }) => Effect::Inventory(InventoryOp::Yank {
+            sources: sources
+                .iter()
+                .map(|s| InventoryYankSource {
+                    read: map(&s.read),
+                    record_as: s.record_as.clone(),
+                })
+                .collect(),
         }),
         Effect::FileOp(FileOp::Copy { paths, dest }) => Effect::FileOp(FileOp::Copy {
             paths: map_all(&paths),
@@ -598,7 +611,10 @@ mod tests {
     #[test]
     fn with_nothing_mounted_every_effect_passes_through() {
         let effect = Effect::Inventory(InventoryOp::Yank {
-            paths: vec![PathBuf::from("/real/file.txt")],
+            sources: vec![PathBuf::from("/real/file.txt")]
+                .into_iter()
+                .map(crate::app::inventory_ops::YankSource::plain)
+                .collect(),
         });
         assert!(matches!(
             route_archive_effect(effect, &Mounts::default(), &nothing_staged, &no_names),
@@ -610,7 +626,10 @@ mod tests {
     fn an_effect_over_real_files_passes_through_even_with_a_mount_open() {
         let mounts = mounts_with(&["a.txt"]);
         let effect = Effect::Inventory(InventoryOp::Yank {
-            paths: vec![PathBuf::from("/real/file.txt")],
+            sources: vec![PathBuf::from("/real/file.txt")]
+                .into_iter()
+                .map(crate::app::inventory_ops::YankSource::plain)
+                .collect(),
         });
         assert!(matches!(
             route_archive_effect(effect, &mounts, &nothing_staged, &no_names),
@@ -623,7 +642,10 @@ mod tests {
     fn yanking_a_member_is_held_back_for_extraction() {
         let mounts = mounts_with(&["a.txt", "d/b.txt"]);
         let effect = Effect::Inventory(InventoryOp::Yank {
-            paths: vec![member("a.txt"), member("d/b.txt")],
+            sources: vec![member("a.txt"), member("d/b.txt")]
+                .into_iter()
+                .map(crate::app::inventory_ops::YankSource::plain)
+                .collect(),
         });
         let ArchiveSink::Materialize { members, then } =
             route_archive_effect(effect, &mounts, &nothing_staged, &no_names)
@@ -640,7 +662,10 @@ mod tests {
     fn staged_members_pass_straight_through() {
         let mounts = mounts_with(&["a.txt"]);
         let effect = Effect::Inventory(InventoryOp::Yank {
-            paths: vec![member("a.txt")],
+            sources: vec![member("a.txt")]
+                .into_iter()
+                .map(crate::app::inventory_ops::YankSource::plain)
+                .collect(),
         });
         assert!(matches!(
             route_archive_effect(effect, &mounts, &all_staged, &no_names),
@@ -654,11 +679,14 @@ mod tests {
         let mounts = mounts_with(&["a.txt", "b.txt"]);
         let staged = |p: &Path| p == member("b.txt");
         let effect = Effect::Inventory(InventoryOp::Yank {
-            paths: vec![
+            sources: vec![
                 PathBuf::from("/real/x.txt"),
                 member("a.txt"),
                 member("b.txt"),
-            ],
+            ]
+            .into_iter()
+            .map(crate::app::inventory_ops::YankSource::plain)
+            .collect(),
         });
         let ArchiveSink::Materialize { members, .. } =
             route_archive_effect(effect, &mounts, &staged, &no_names)
@@ -867,20 +895,31 @@ mod tests {
 
         let rewritten = rewrite_paths(
             Effect::Inventory(InventoryOp::Yank {
-                paths: vec![member("a.txt"), PathBuf::from("/real/x.txt")],
+                sources: vec![member("a.txt"), PathBuf::from("/real/x.txt")]
+                    .into_iter()
+                    .map(crate::app::inventory_ops::YankSource::plain)
+                    .collect(),
             }),
             &staged,
         );
-        let Effect::Inventory(InventoryOp::Yank { paths }) = rewritten else {
+        let Effect::Inventory(InventoryOp::Yank { sources }) = rewritten else {
             panic!("shape preserved");
         };
         assert_eq!(
-            paths,
+            sources.iter().map(|s| s.read.clone()).collect::<Vec<_>>(),
             [
                 PathBuf::from("/staging/a.txt"),
                 PathBuf::from("/real/x.txt")
             ],
-            "members are redirected, real paths left alone"
+            "members are redirected to read from staging, real paths left alone"
+        );
+        assert_eq!(
+            sources
+                .iter()
+                .map(|s| s.record_as.clone())
+                .collect::<Vec<_>>(),
+            [member("a.txt"), PathBuf::from("/real/x.txt")],
+            "and each is still remembered by the path the user sees"
         );
     }
 
@@ -959,7 +998,10 @@ mod tests {
         let container = PathBuf::from("/src/pkg.zip");
         for effect in [
             Effect::Inventory(InventoryOp::Yank {
-                paths: vec![container.clone()],
+                sources: vec![container.clone()]
+                    .into_iter()
+                    .map(crate::app::inventory_ops::YankSource::plain)
+                    .collect(),
             }),
             Effect::FileOp(FileOp::FileType {
                 paths: vec![container.clone()],

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -743,7 +743,10 @@ fn an_already_extracted_member_passes_straight_through_the_screen() {
 
         let held = app.screen_archive_effect(Effect::Inventory(
             crate::app::inventory_ops::InventoryOp::Yank {
-                paths: vec![archive.join("README.md")],
+                sources: vec![archive.join("README.md")]
+                    .into_iter()
+                    .map(crate::app::inventory_ops::YankSource::plain)
+                    .collect(),
             },
         ));
         assert!(held.is_some(), "no round trip for bytes already on disk");
@@ -765,7 +768,10 @@ fn the_screen_leaves_unrelated_effects_alone() {
 
         let held = app.screen_archive_effect(Effect::Inventory(
             crate::app::inventory_ops::InventoryOp::Yank {
-                paths: vec![dir.join("real.txt")],
+                sources: vec![dir.join("real.txt")]
+                    .into_iter()
+                    .map(crate::app::inventory_ops::YankSource::plain)
+                    .collect(),
             },
         ));
         assert!(held.is_some(), "a real file's yank runs as normal");
@@ -997,7 +1003,10 @@ fn putting_an_inventory_item_into_an_archive_adds_it() {
             &mut app,
             vec![Effect::Inventory(
                 crate::app::inventory_ops::InventoryOp::Yank {
-                    paths: vec![source],
+                    sources: vec![source]
+                        .into_iter()
+                        .map(crate::app::inventory_ops::YankSource::plain)
+                        .collect(),
                 },
             )],
         );
@@ -1517,7 +1526,10 @@ fn a_mixed_selection_rewrites_the_staged_member_too() {
         let main = archive.join("src/main.rs");
         let fx = app.screen_archive_effect(Effect::Inventory(
             crate::app::inventory_ops::InventoryOp::Yank {
-                paths: vec![readme.clone(), main.clone()],
+                sources: vec![readme.clone(), main.clone()]
+                    .into_iter()
+                    .map(crate::app::inventory_ops::YankSource::plain)
+                    .collect(),
             },
         ));
         let Some(Effect::Archive(ArchiveOp::MaterializeMany { then, .. })) = fx else {
@@ -1526,17 +1538,22 @@ fn a_mixed_selection_rewrites_the_staged_member_too() {
         let crate::app::archive_ops::MaterializeThen::Retry(effect) = then else {
             panic!("a held-back read retries the original effect");
         };
-        let Effect::Inventory(crate::app::inventory_ops::InventoryOp::Yank { paths }) = *effect
+        let Effect::Inventory(crate::app::inventory_ops::InventoryOp::Yank { sources }) = *effect
         else {
             panic!("shape preserved");
         };
+        let reads: Vec<PathBuf> = sources.iter().map(|s| s.read.clone()).collect();
         assert!(
-            !paths.contains(&readme),
-            "the staged member is already pointed at staging: {paths:?}"
+            !reads.contains(&readme),
+            "the staged member is already pointed at staging: {reads:?}"
         );
         assert!(
-            paths.contains(&main),
-            "and the unextracted one still waits for the worker: {paths:?}"
+            reads.contains(&main),
+            "and the unextracted one still waits for the worker: {reads:?}"
+        );
+        assert!(
+            sources.iter().all(|s| s.record_as.starts_with(&archive)),
+            "both are still remembered by their member paths"
         );
     });
 }
@@ -2387,5 +2404,87 @@ fn a_dirty_archive_is_marked_in_the_directory_it_lives_in() {
         apply_effects(&mut app, fx);
         let row = archive_row(&mut app);
         assert!(!row.contains('~'), "clean again after the write: {row:?}");
+    });
+}
+
+// ── what a yanked member is remembered as ─────────────────────────────────
+
+/// A yanked member is remembered by its path *into the archive*, not by the
+/// staged copy the bytes came from.
+///
+/// The staging path is a per-process cache location: recording it meant the row
+/// never showed as taken (its path is the member's), a re-yank in a later session
+/// made a second entry instead of refreshing the first, and the inventory kept a
+/// path that stopped existing when the session did.
+#[test]
+fn a_yanked_member_is_remembered_by_its_path_in_the_archive() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // `y` on `README.md`.
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+
+        let member = archive.join("README.md");
+        let item = app
+            .state
+            .inventory
+            .items()
+            .find(|i| i.filename == "README.md")
+            .expect("in the inventory");
+        assert_eq!(
+            item.orig_path, member,
+            "remembered as the member path, not the staging copy"
+        );
+        assert_eq!(
+            app.state.inventory.read_content(&item.id).as_deref(),
+            Some(b"# pkg\n".as_slice()),
+            "with the member's real bytes, which came from staging"
+        );
+        // Which is what makes the row's take-check work: it compares the row's own
+        // path against the inventory.
+        assert!(
+            app.state.inventory.contains(&member),
+            "so the member row reads as taken"
+        );
+    });
+}
+
+/// Re-yanking the same member refreshes its entry rather than adding a second
+/// one. Keyed on the staging path it couldn't: that path carries the pid.
+#[test]
+fn re_yanking_a_member_refreshes_one_entry() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+        app.apply(&Action::Down(1)).unwrap();
+
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+        // Re-mount into a *different* staging tree, as a later session would, and
+        // yank the same member again.
+        app.state.mounts.remove(&archive);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging-2"));
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+
+        let held: Vec<_> = app
+            .state
+            .inventory
+            .items()
+            .filter(|i| i.filename == "README.md")
+            .collect();
+        assert_eq!(held.len(), 1, "one entry, refreshed: {held:?}");
     });
 }

--- a/src/app/inventory_ops.rs
+++ b/src/app/inventory_ops.rs
@@ -8,9 +8,33 @@ use crate::state::inventory::Inventory;
 /// serialization. This means rapid concurrent operations (like double-yanking)
 /// can race during the read-modify-write cache update. This is an accepted
 /// race condition for now, as inventory ops are usually human-driven and sparse.
+/// One file to yank: where its bytes are, and the path the inventory should
+/// remember it by.
+///
+/// The two differ only for an archive member. Its bytes are a staged copy in a
+/// per-process cache directory, but what identifies it is the path *into the
+/// archive* — that's what the user sees, what a re-yank should refresh, and what
+/// survives the mount being dropped. `rewrite_paths` therefore only ever
+/// substitutes `read`.
+#[derive(Debug, Clone)]
+pub struct YankSource {
+    pub read: PathBuf,
+    pub record_as: PathBuf,
+}
+
+impl YankSource {
+    /// A file that is what it appears to be — read and remembered by one path.
+    pub fn plain(path: PathBuf) -> Self {
+        Self {
+            record_as: path.clone(),
+            read: path,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum InventoryOp {
-    Yank { paths: Vec<PathBuf> },
+    Yank { sources: Vec<YankSource> },
     Remove { id: String, show_flash: bool },
     Clear,
     Put { dest_dir: PathBuf, ids: Vec<String> },
@@ -38,9 +62,20 @@ pub enum InventoryOutcome {
 pub fn run_inventory_op(op: InventoryOp) -> InventoryOutcome {
     let mut inv = Inventory::load();
     match op {
-        InventoryOp::Yank { paths } => {
-            let total = paths.len();
-            let (count, first_err) = inv.yank_many(&paths);
+        InventoryOp::Yank { sources } => {
+            let total = sources.len();
+            let mut count = 0;
+            let mut first_err = None;
+            for source in &sources {
+                match inv.yank_as(&source.read, &source.record_as) {
+                    Ok(()) => count += 1,
+                    Err(e) => {
+                        if first_err.is_none() {
+                            first_err = Some(e);
+                        }
+                    }
+                }
+            }
             InventoryOutcome::Yanked {
                 count,
                 skipped: total - count,
@@ -183,7 +218,10 @@ mod tests {
             let subdir = work.path().join("sub");
             std::fs::create_dir(&subdir).unwrap();
             let out = run_inventory_op(InventoryOp::Yank {
-                paths: vec![a, subdir],
+                sources: vec![a, subdir]
+                    .into_iter()
+                    .map(super::YankSource::plain)
+                    .collect(),
             });
             let InventoryOutcome::Yanked {
                 count,

--- a/src/app/state/selection.rs
+++ b/src/app/state/selection.rs
@@ -90,7 +90,12 @@ impl AppState {
             return Vec::new();
         }
         vec![crate::app::Effect::Inventory(
-            crate::app::inventory_ops::InventoryOp::Yank { paths: to_take },
+            crate::app::inventory_ops::InventoryOp::Yank {
+                sources: to_take
+                    .into_iter()
+                    .map(crate::app::inventory_ops::YankSource::plain)
+                    .collect(),
+            },
         )]
     }
 

--- a/src/state/inventory.rs
+++ b/src/state/inventory.rs
@@ -68,16 +68,34 @@ impl Inventory {
 
     /// Yank a file into the inventory cache. Returns an error message
     /// if the file can't be yanked (not a regular file, too large, etc.).
+    /// Read and remember one path. Test-only: production always knows both halves
+    /// (they're simply equal for a file that isn't an archive member), so it goes
+    /// through [`Self::yank_as`].
+    #[cfg(test)]
     pub fn yank(&mut self, path: &Path) -> Result<(), String> {
+        self.yank_as(path, path)
+    }
+
+    /// Cache `read`'s bytes, remembered under `record_as`.
+    ///
+    /// They differ for an archive member: the bytes come from a staged copy in a
+    /// per-process cache, but the item is remembered by its path *into the
+    /// archive*. Recording the staging path instead meant the row never showed as
+    /// taken (its path is the member's), a later re-yank made a second entry
+    /// rather than refreshing the first (the cache dir is keyed on pid), and the
+    /// inventory kept a path that stopped existing when the session did.
+    pub fn yank_as(&mut self, read: &Path, record_as: &Path) -> Result<(), String> {
         let Some(dir) = inventory_dir() else {
             return Err("no state directory".into());
         };
-        let meta =
-            std::fs::metadata(path).map_err(|e| format!("can't read {}: {e}", path.display()))?;
+        let meta = std::fs::metadata(read)
+            .map_err(|e| format!("can't read {}: {e}", record_as.display()))?;
         if !meta.is_file() {
-            return Err(format!("{}: not a regular file", path.display()));
+            return Err(format!("{}: not a regular file", record_as.display()));
         }
-        let filename = path
+        // Filename only, as for any other yank: a member deep inside an archive
+        // puts as its basename.
+        let filename = record_as
             .file_name()
             .unwrap_or_default()
             .to_string_lossy()
@@ -89,14 +107,14 @@ impl Inventory {
         let id = self
             .items
             .values()
-            .find(|item| item.orig_path == path)
+            .find(|item| item.orig_path == record_as)
             .map_or_else(
                 || uuid::Uuid::now_v7().simple().to_string(),
                 |item| item.id.clone(),
             );
         let item = CachedItem {
             id: id.clone(),
-            orig_path: path.to_path_buf(),
+            orig_path: record_as.to_path_buf(),
             filename,
             timestamp: now_secs(),
             size: meta.len(),
@@ -104,30 +122,12 @@ impl Inventory {
         let _ = std::fs::create_dir_all(&dir);
         let dat_path = dir.join(format!("{id}.dat"));
         let json_path = dir.join(format!("{id}.json"));
-        std::fs::copy(path, &dat_path).map_err(|e| format!("copy failed: {e}"))?;
+        std::fs::copy(read, &dat_path).map_err(|e| format!("copy failed: {e}"))?;
         let json = serde_json::to_string_pretty(&item).map_err(|e| format!("json: {e}"))?;
         crate::fs::write_atomic(&json_path, json.as_bytes())
             .map_err(|e| format!("write meta: {e}"))?;
         self.items.insert(id, item);
         Ok(())
-    }
-
-    /// Yank multiple files. Returns count of successfully yanked files
-    /// and the first error (if any).
-    pub fn yank_many(&mut self, paths: &[PathBuf]) -> (usize, Option<String>) {
-        let mut count = 0;
-        let mut first_err = None;
-        for p in paths {
-            match self.yank(p) {
-                Ok(()) => count += 1,
-                Err(e) => {
-                    if first_err.is_none() {
-                        first_err = Some(e);
-                    }
-                }
-            }
-        }
-        (count, first_err)
     }
 
     /// Put a cached item to a destination directory. Copies the cached


### PR DESCRIPTION
Your call, built: the inventory remembers a member by its path **into the archive**, and puts as the basename.

## What was wrong

The inventory recorded where the bytes were *read from*. For a member that's a staged copy under `<pid>-<hash>/` — a per-process cache location, not a place. Three consequences, all of which you'd hit:

1. **The row never showed as taken.** A member row's path is the member's; the inventory held the staging path, so `inventory.contains(row.path)` was always false.
2. **A re-yank duplicated.** Dedup keys on the recorded path, and the staging root carries the pid — so the same member yanked in a later session made a second entry instead of refreshing the first.
3. **It persisted as garbage.** Exactly what your inventory showed: `archives/2455-…/…pcap` from a session that had already exited.

## The change

A yank now names each file twice:

```rust
pub struct YankSource { pub read: PathBuf, pub record_as: PathBuf }
```

They differ only for a member — bytes from staging, remembered as `pkg.zip/src/main.rs`. The load-bearing part is that **`rewrite_paths` only ever substitutes `read`**, so the distinction survives the archive screen redirecting the op; `record_as` is untouched by construction rather than by care.

Filename-only on put, as you said — a member at `src/deep/mod.rs` puts as `mod.rs`, like every other yank.

`Inventory::yank_many` goes with it (nothing called it any more), and the one-path `yank` becomes the test-only convenience it had already become.

## What I did *not* do, and why

Making the inventory lazy — resolving content at put time from the archive instead of copying at yank time. It reads better than it behaves: the archive can change between yank and put (you'd silently put different bytes), the reference can dangle, and today `p` works after the mount is gone. Eager bytes, durable path is the stronger pair.

## Verification

- `make check-ci` → `=== GATE: PASS ===`; 2261 tests.
- `a_yanked_member_is_remembered_by_its_path_in_the_archive` — asserts the recorded path is the member's, the bytes are the member's (so they *did* come from staging), and `inventory.contains(member)` holds, which is what makes the row's take-check work.
- `re_yanking_a_member_refreshes_one_entry` — yanks, re-mounts into a *different* staging tree as a later session would, yanks again, and asserts one entry.
- Both verified to fail against the old recording.
- The router test now asserts both halves: members redirected to staging for reading, still remembered by the path the user sees.

## Still queued from earlier

`:archive write` / `discard` from outside a mount (cursor on a dirty archive → that one; else the single dirty mount; several → named). Written and building, parked while your write bug took priority — next PR.

Generated with [Claude Code](https://claude.com/claude-code)
