### PR TITLE
feat(archive): write or discard an archive without being inside it

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -537,8 +537,12 @@ they land in a session-scoped staging dir that is cleaned up on exit.
   if there is one), so asking the agent in the pane about the file you're looking
   at works in here as well. `search_content` / `search_paths` say why they can't
   instead of reporting "no matches" from walking a single binary file.
-- **`:archive`** — `info` (everything about this mount), `list` (every mounted
-  archive), `unmount` (drop it and its staged bytes), `cancel`.
+- **`:archive`** — `info` (this mount, or what's mounted when you're outside one),
+  `list` (every mounted archive, dirty ones marked), `write` / `discard`,
+  `unmount` (drop it and its staged bytes), `cancel`. `write` and `discard` work
+  from outside a mount too: they take the archive under the cursor — the row
+  showing `~` — else the only one with changes, and name them rather than guess
+  when several do.
 
 ## In-app pager
 

--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -563,6 +563,42 @@ impl App {
         }
     }
 
+    /// Which archive `:archive write` / `discard` means.
+    ///
+    /// Inside a mount it's that one. From outside it used to be nothing at all,
+    /// which left the container's `~` marker as a dead end: you could see an
+    /// archive held unwritten changes and had to climb back in to act on it. So:
+    /// the archive under the cursor if it's a dirty mount — that's the row telling
+    /// you — else the only dirty mount when there's exactly one. More than one is
+    /// named rather than guessed at.
+    fn archive_to_act_on(&self, verb: &str) -> Result<PathBuf, String> {
+        if let Some((mount, _)) = self.state.mounts.resolve(&self.state.cur().listing.dir) {
+            return Ok(mount.archive().to_path_buf());
+        }
+        let cursor = self
+            .state
+            .cur()
+            .rows
+            .get(self.state.cur().cursor.index)
+            .map(|r| r.path.clone());
+        if let Some(path) = cursor
+            && self.state.mounts.get(&path).is_some()
+            && self.mount_is_dirty(&path)
+        {
+            return Ok(path);
+        }
+        let dirty = self.dirty_mounts();
+        match dirty.len() {
+            0 => Err(format!("archive: nothing to {verb}")),
+            1 => Ok(dirty[0].clone()),
+            _ => Err(format!(
+                "archive: {} archives have changes — put the cursor on the one to {verb}, \
+                 or go into it",
+                dirty.len()
+            )),
+        }
+    }
+
     /// `:archive [info|list|unmount]`.
     pub(crate) fn cmd_archive(&mut self, arg: &str) -> Vec<Effect> {
         // Anything about to be reported — or written — should account for edits
@@ -577,18 +613,15 @@ impl App {
                 self.archive_list();
                 Vec::new()
             }
-            "write" => {
-                if let Some((mount, _)) = self.state.mounts.resolve(&self.state.cur().listing.dir) {
-                    let archive = mount.archive().to_path_buf();
-                    self.write_effect(&archive).into_iter().collect()
-                } else {
-                    self.state.flash_error("archive: not inside an archive");
+            "write" => match self.archive_to_act_on("write") {
+                Ok(archive) => self.write_effect(&archive).into_iter().collect(),
+                Err(why) => {
+                    self.state.flash_error(why);
                     Vec::new()
                 }
-            }
-            "discard" => {
-                if let Some((mount, _)) = self.state.mounts.resolve(&self.state.cur().listing.dir) {
-                    let archive = mount.archive().to_path_buf();
+            },
+            "discard" => match self.archive_to_act_on("discard") {
+                Ok(archive) => {
                     if let Some(m) = self.state.mounts.get_mut(&archive) {
                         m.journal.clear();
                     }
@@ -596,11 +629,12 @@ impl App {
                     // the journal, so "discard" means all of it.
                     self.state.flash_info("archive: pending changes discarded");
                     self.request_mount(&archive, true)
-                } else {
-                    self.state.flash_error("archive: not inside an archive");
+                }
+                Err(why) => {
+                    self.state.flash_error(why);
                     Vec::new()
                 }
-            }
+            },
             "cancel" => {
                 self.cancel_archive_mount();
                 self.state.flash_info("archive: cancel requested");

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -2488,3 +2488,145 @@ fn re_yanking_a_member_refreshes_one_entry() {
         assert_eq!(held.len(), 1, "one entry, refreshed: {held:?}");
     });
 }
+
+// ── writing without being inside the archive ──────────────────────────────
+
+/// Delete a member, then climb out, leaving the cursor on the archive.
+fn dirty_then_climb_out(app: &mut App, dir: &Path) {
+    app.apply(&Action::Down(1)).unwrap();
+    let fx = app.apply(&Action::RemovePrompt(None)).unwrap();
+    let fx = if fx.is_empty() {
+        app.handle_remove_confirm_key(crossterm::event::KeyEvent::new(
+            KeyCode::Char('y'),
+            KeyModifiers::empty(),
+        ))
+    } else {
+        fx
+    };
+    settle(app, fx);
+    let fx = app.apply(&Action::Climb).unwrap();
+    apply_effects(app, fx);
+    assert_eq!(app.state.cur().listing.dir, dir, "outside the archive");
+}
+
+/// The dead end the container marker created: you can see `demo.zip` holds
+/// unwritten changes from the directory it lives in, and `:archive write` there
+/// did nothing because it resolved the archive from the cwd. The cursor is on the
+/// row that told you, so that's what it means.
+#[test]
+fn writing_from_outside_uses_the_archive_under_the_cursor() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir.clone());
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+        dirty_then_climb_out(&mut app, &dir);
+
+        // Climbing out leaves the cursor on the archive it came from.
+        let cursor = app
+            .state
+            .cur()
+            .rows
+            .get(app.state.cur().cursor.index)
+            .map(|r| r.path.clone());
+        assert_eq!(
+            cursor.as_deref(),
+            Some(archive.as_path()),
+            "cursor is on it"
+        );
+
+        let fx = app.cmd_archive("write");
+        settle(&mut app, fx);
+
+        assert_eq!(
+            member_names(&archive),
+            ["src/deep/mod.rs", "src/main.rs"],
+            "the delete was applied to the archive on disk"
+        );
+        assert!(!app.mount_is_dirty(&archive), "and nothing is pending");
+    });
+}
+
+/// Cursor elsewhere: one archive has changes, so there's nothing to guess at.
+#[test]
+fn writing_from_outside_falls_back_to_the_only_dirty_archive() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        std::fs::write(dir.join("aaa.txt"), b"not an archive\n").unwrap();
+        let mut app = App::test_app(dir.clone());
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+        dirty_then_climb_out(&mut app, &dir);
+
+        // Move the cursor off the archive entirely.
+        app.state.cur_mut().cursor.index = 0;
+        let cursor = app
+            .state
+            .cur()
+            .rows
+            .first()
+            .map(|r| r.path.clone())
+            .unwrap();
+        assert_ne!(cursor, archive, "cursor is not on the archive");
+
+        let fx = app.cmd_archive("write");
+        settle(&mut app, fx);
+        assert!(!app.mount_is_dirty(&archive), "written anyway");
+    });
+}
+
+/// Two dirty archives and no cursor to disambiguate: say so rather than pick.
+#[test]
+fn writing_from_outside_refuses_to_guess_between_two() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let mut app = App::test_app(dir.clone());
+        for (name, staging) in [("one.zip", "s1"), ("two.zip", "s2")] {
+            let archive = dir.join(name);
+            build_zip(&archive);
+            mount_inline(&mut app, &archive, &tmp.path().join(staging));
+            dirty_then_climb_out(&mut app, &dir);
+        }
+        assert_eq!(app.dirty_mounts().len(), 2, "both are dirty");
+
+        // Cursor on neither.
+        std::fs::write(dir.join("aaa.txt"), b"x\n").unwrap();
+        app.state.refresh_listing();
+        app.state.cur_mut().cursor.index = 0;
+
+        let fx = app.cmd_archive("write");
+        settle(&mut app, fx);
+
+        let flash = app.state.flash.as_ref().map(|f| f.text.clone());
+        assert!(
+            flash
+                .as_deref()
+                .is_some_and(|t| t.contains('2') && t.contains("write")),
+            "names the count and the verb: {flash:?}"
+        );
+        assert_eq!(app.dirty_mounts().len(), 2, "and wrote neither");
+    });
+}
+
+#[test]
+fn writing_with_nothing_pending_says_so() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let _cwd = CwdGuard;
+        let dir = std::fs::canonicalize(tmp.path()).unwrap();
+        let mut app = App::test_app(dir);
+
+        let fx = app.cmd_archive("write");
+        settle(&mut app, fx);
+        let flash = app.state.flash.as_ref().map(|f| f.text.clone());
+        assert_eq!(flash.as_deref(), Some("archive: nothing to write"));
+    });
+}


### PR DESCRIPTION
Closes the dead end #329 created.

## The problem

`:archive write` resolved which archive it meant from the cwd, so **from outside a mount it did nothing**. Once a dirty container was marked in its own directory, that became actively misleading: the row says `demo.zip` has unwritten changes, and the command that would apply them refuses because you aren't standing inside it.

I found this writing a test for #329 — my first version wrote from outside, and the marker never cleared because no write had happened.

## The targeting

| where you are | what it means |
|---|---|
| inside a mount | that archive (unchanged) |
| outside, cursor on an archive with changes | that one — it's the row that told you |
| outside, cursor elsewhere, exactly one archive has changes | that one |
| outside, several have changes | names the count instead of guessing |

`:archive discard` gets the same targeting, and both refusals name the verb they're refusing (`nothing to write` / `nothing to discard`).

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- Four tests, one per row of that table. The three behavioural ones were verified to fail against the old code. The cursor case asserts the *archive on disk* actually changed (`member_names` after the write), not just that the mount reads clean.

Generated with [Claude Code](https://claude.com/claude-code)
