### PR TITLE
fix(archive): refill staging from the archive when a member goes missing

### DIFF
--- a/src/archive/read/mod.rs
+++ b/src/archive/read/mod.rs
@@ -181,6 +181,58 @@ pub fn stream_mount(
     Ok(Indexed { index, facts })
 }
 
+/// Re-extract only the members whose staged copies have gone missing.
+///
+/// Staging is a cache in a user-writable directory, and things outside spyc remove
+/// files from it — a backup or indexing daemon reaping macOS AppleDouble (`._*`)
+/// entries is one observed case. For a streamed archive those staged bytes are the
+/// only copy *outside* the container, so losing one used to make the archive
+/// unwritable for good. The container still has them, so refill instead.
+///
+/// An existing file is never overwritten: a staged copy the user has *edited* is
+/// the whole point of the pending change, and refilling must not undo it. Returns
+/// how many members were restored.
+pub fn restage_missing(
+    archive: &Path,
+    format: ArchiveFormat,
+    staging_root: &Path,
+    cap: usize,
+) -> Result<usize> {
+    let file = File::open(archive).with_context(|| format!("opening {}", archive.display()))?;
+    let reader: Box<dyn Read> = match format {
+        ArchiveFormat::TarGz => Box::new(flate2::read::GzDecoder::new(BufReader::new(file))),
+        ArchiveFormat::TarZst => Box::new(zstd::stream::read::Decoder::new(BufReader::new(file))?),
+        _ => bail!("{} is not a streamed format", format.label()),
+    };
+    let mut facts = super::scan::IndexFacts::default();
+    let mut restored = 0;
+    let mut seen = 0;
+    let mut tar = tar::Archive::new(reader);
+    for entry in tar
+        .entries()
+        .with_context(|| format!("reading {}", archive.display()))?
+    {
+        let mut entry = entry.with_context(|| format!("reading {}", archive.display()))?;
+        seen += 1;
+        if seen > cap {
+            break;
+        }
+        let (name, draft) = tar_draft(&entry, Locator::Staged, &mut facts);
+        let Some(draft) = draft else { continue };
+        let Ok(clean) = normalize(&name) else {
+            continue;
+        };
+        // `staging_rel` is what a reader looks under, so a case-colliding member is
+        // restored where its own reader expects it.
+        if staging_root.join(&clean.inner).exists() {
+            continue;
+        }
+        write_member(&mut entry, &draft, &clean.inner, staging_root, &mut facts)?;
+        restored += 1;
+    }
+    Ok(restored)
+}
+
 /// Put one streamed member on disk under `staging_root`.
 fn write_member<R: Read>(
     entry: &mut tar::Entry<'_, R>,

--- a/src/archive/write.rs
+++ b/src/archive/write.rs
@@ -70,6 +70,30 @@ pub fn repack(
         );
     }
 
+    // A streamed archive's untouched members are carried across *from staging*,
+    // which is a cache: something outside spyc can remove a file from it, and then
+    // the archive could never be written again. The container still holds those
+    // bytes, so refill what's gone before writing — never overwriting a staged copy
+    // that's there, since an edited one is the change being written.
+    if !index.format.is_seekable() {
+        let missing = steps.iter().any(|step| match &step.source {
+            StepSource::Archived { inner } => index.get(inner).is_some_and(|entry| {
+                matches!(entry.locator, Locator::Staged)
+                    && !staging_root.join(entry.staging_rel()).exists()
+            }),
+            StepSource::Staging { .. } => false,
+        });
+        if missing {
+            read::restage_missing(
+                archive,
+                index.format,
+                staging_root,
+                index.entries.len().saturating_add(1024),
+            )
+            .context("refilling the staging tree from the archive")?;
+        }
+    }
+
     // The temp file lives in the archive's own directory so the final rename
     // stays on one filesystem, where it is atomic.
     let tmp = tempfile::NamedTempFile::new_in(parent)
@@ -755,6 +779,113 @@ mod tests {
                 "{format:?}: and still a directory"
             );
         }
+    }
+
+    /// Staging is a cache: something outside spyc can remove a member spyc
+    /// extracted. Observed on a real archive — a daemon reaped ~100 macOS
+    /// AppleDouble (`._*`) files out of `~/.local/state`, and the write then
+    /// refused with `No such file or directory`, permanently.
+    #[test]
+    fn a_repack_refills_staging_that_lost_a_member() {
+        let tmp = tempfile::tempdir().unwrap();
+        let archive = tmp.path().join("pkg.tar.gz");
+        let staging = tmp.path().join("staging");
+        tar_at(
+            &archive,
+            &[
+                ("keep.txt", b"kept", 0o644),
+                ("gone.txt", b"recovered", 0o644),
+                ("drop.txt", b"dropped", 0o644),
+            ],
+            ArchiveFormat::TarGz,
+        );
+        let indexed = read::stream_mount(
+            &archive,
+            ArchiveFormat::TarGz,
+            &staging,
+            u64::MAX,
+            1000,
+            &std::sync::atomic::AtomicBool::new(false),
+        )
+        .unwrap();
+
+        // Something else removes a staged member spyc isn't changing.
+        std::fs::remove_file(staging.join("gone.txt")).unwrap();
+
+        let mut journal = Journal::default();
+        journal.delete("drop.txt");
+        let steps = plan_repack(
+            &indexed.index,
+            &journal,
+            &StagedStats::new(),
+            &StagedStats::new(),
+        );
+        repack(&indexed.index, &steps, &staging, &opts()).expect("writes rather than refusing");
+
+        let after = contents(&archive);
+        assert!(
+            after.contains(&("gone.txt".to_string(), b"recovered".to_vec())),
+            "the lost member came back out of the archive: {after:?}"
+        );
+        assert!(
+            after.contains(&("keep.txt".to_string(), b"kept".to_vec())),
+            "{after:?}"
+        );
+        assert!(
+            !after.iter().any(|(n, _)| n == "drop.txt"),
+            "and the delete still applied"
+        );
+    }
+
+    /// The refill must not undo the change being written: an edited staged copy is
+    /// the pending change, so a member that IS there is left alone.
+    #[test]
+    fn refilling_staging_never_overwrites_an_edited_member() {
+        let tmp = tempfile::tempdir().unwrap();
+        let archive = tmp.path().join("pkg.tar.gz");
+        let staging = tmp.path().join("staging");
+        tar_at(
+            &archive,
+            &[
+                ("edited.txt", b"from the archive", 0o644),
+                ("gone.txt", b"recovered", 0o644),
+            ],
+            ArchiveFormat::TarGz,
+        );
+        let indexed = read::stream_mount(
+            &archive,
+            ArchiveFormat::TarGz,
+            &staging,
+            u64::MAX,
+            1000,
+            &std::sync::atomic::AtomicBool::new(false),
+        )
+        .unwrap();
+
+        // One member edited in staging, another lost from it — so the refill runs
+        // in the same repack that carries the edit.
+        std::fs::write(staging.join("edited.txt"), b"edited by hand").unwrap();
+        std::fs::remove_file(staging.join("gone.txt")).unwrap();
+
+        let mut journal = Journal::default();
+        journal.replace("edited.txt");
+        let steps = plan_repack(
+            &indexed.index,
+            &journal,
+            &StagedStats::new(),
+            &StagedStats::new(),
+        );
+        repack(&indexed.index, &steps, &staging, &opts()).unwrap();
+
+        let after = contents(&archive);
+        assert!(
+            after.contains(&("edited.txt".to_string(), b"edited by hand".to_vec())),
+            "the edit survived the refill: {after:?}"
+        );
+        assert!(
+            after.contains(&("gone.txt".to_string(), b"recovered".to_vec())),
+            "and the lost member still came back: {after:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Second failure from the same real tarball, one member further along than #330.

```
NOT written: reading staged fika-reporting/._.env.example:
  No such file or directory (os error 2) — changes are still pending
```

## What the evidence said

I ran spyc's own indexer on the actual archive rather than reasoning about it:

| | |
|---|---|
| fresh mount of that tarball | 458 index entries, **440 files on disk, none missing** |
| the live session's staging tree | **341 files** |
| the other live session's tree | **336 files** |
| what's absent | 99 files, **all macOS AppleDouble (`._*`)**, scattered rather than a truncated tail |

So the extraction was fine and the cache was reaped afterwards — hours later, by something outside spyc. I checked that writes don't absorb AppleDoubles (`._probe.txt` + `probe.txt` both survive, in `/var/folders` and in `~/.local/state`), which rules out spyc's own writes. My fresh tree lives in `/var/folders`, which is excluded from indexing and backup; the staging tree is in the home directory, which isn't.

## The defect

Whatever reaped them, spyc's behaviour was wrong: a streamed archive's untouched members are carried across **from staging**, and staging is a cache in a user-writable directory. Losing one entry made the archive **unwritable for good** — every future `:archive write` would hit the same missing file.

The container still holds those bytes. So the repack now refills what's gone before writing, from the archive itself.

**It restores only what's missing.** A staged copy that *is* there is the pending change being written — overwriting an edited member with the archive's version would silently undo the user's edit. That's the second test.

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- `a_repack_refills_staging_that_lost_a_member` — delete an untouched member's staged file, repack, assert its bytes are back and an unrelated delete still applied. With the refill block removed it fails with exactly the reported error: `reading staged gone.txt: No such file or directory (os error 2)`.
- `refilling_staging_never_overwrites_an_edited_member` — edit one staged member, lose another, repack in one go: the edit survives *and* the lost member returns.
- Not yet driven by hand on the reporting tarball; that's the next thing worth doing, since it's the archive that found both this and #330.

Generated with [Claude Code](https://claude.com/claude-code)
