### PR TITLE
fix(archive): discard throws away the staged copies, not just the journal

### DIFF
--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -563,6 +563,54 @@ impl App {
         }
     }
 
+    /// Throw away an archive's pending changes: the journal *and* the staged copies
+    /// that superseded its bytes.
+    ///
+    /// Clearing the journal alone left an edited copy on disk, and the next scan
+    /// re-recorded it as pending moments later — so discarded changes came straight
+    /// back. Re-mounting would drop them too, but a live mount is re-*entered*
+    /// rather than re-read, and issuing a staging clean beside a fresh mount races
+    /// it: each archive op rides its own worker thread and both name the same
+    /// staging path. Removing exactly what was recorded needs neither.
+    fn discard_pending(&mut self, archive: &Path) {
+        let mut drop_files: Vec<(String, PathBuf)> = Vec::new();
+        if let Some(mount) = self.state.mounts.get(archive) {
+            for change in mount.journal.changes() {
+                match change {
+                    // A member the user brought in has no index entry; its bytes sit
+                    // under its own inner path.
+                    crate::archive::Change::Added { inner } => {
+                        drop_files.push((inner.clone(), mount.staging_root.join(inner)));
+                    }
+                    // A replaced one is at its entry's staging path, which differs
+                    // from the inner path for a case-colliding member.
+                    crate::archive::Change::Replaced { inner } => {
+                        if let Some(entry) = mount.index.get(inner) {
+                            drop_files.push((inner.clone(), mount.staging_path(entry)));
+                        }
+                    }
+                    // A delete or rename never wrote anything: they're index edits.
+                    crate::archive::Change::Deleted { .. }
+                    | crate::archive::Change::Renamed { .. } => {}
+                }
+            }
+        }
+        for (_, path) in &drop_files {
+            let _ = std::fs::remove_file(path);
+        }
+        if let Some(mount) = self.state.mounts.get_mut(archive) {
+            for (inner, _) in &drop_files {
+                mount.staged.remove(inner);
+            }
+            mount.journal.clear();
+            mount.editing.clear();
+        }
+        self.state.flash_info("archive: pending changes discarded");
+        // The rows come from the index plus the journal, so they have to be rebuilt
+        // for the deletes and renames to come back.
+        self.state.refresh_listing();
+    }
+
     /// Which archive `:archive write` / `discard` means.
     ///
     /// Inside a mount it's that one. From outside it used to be nothing at all,
@@ -622,13 +670,8 @@ impl App {
             },
             "discard" => match self.archive_to_act_on("discard") {
                 Ok(archive) => {
-                    if let Some(m) = self.state.mounts.get_mut(&archive) {
-                        m.journal.clear();
-                    }
-                    // Re-mount to throw away any edited staged copies along with
-                    // the journal, so "discard" means all of it.
-                    self.state.flash_info("archive: pending changes discarded");
-                    self.request_mount(&archive, true)
+                    self.discard_pending(&archive);
+                    Vec::new()
                 }
                 Err(why) => {
                     self.state.flash_error(why);

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -2630,3 +2630,112 @@ fn writing_with_nothing_pending_says_so() {
         assert_eq!(flash.as_deref(), Some("archive: nothing to write"));
     });
 }
+
+/// `:archive discard` has to drop the staged copies too, not just the journal.
+///
+/// Clearing the journal alone left an edited copy on disk for the next scan to
+/// re-record — so the badge came back and the "discarded" edit was still pending.
+#[test]
+fn discarding_an_edit_drops_the_staged_copy_too() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Read a member (staging it), then change that copy behind spyc's back.
+        app.apply(&Action::Down(1)).unwrap();
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+        let staged = {
+            let mount = app.state.mounts.get(&archive).unwrap();
+            mount.staging_path(mount.index.get("README.md").unwrap())
+        };
+        std::fs::write(&staged, b"# edited\n").unwrap();
+        assert!(app.settle_archive_edits(), "noticed as pending");
+        assert_eq!(
+            app.state
+                .mounts
+                .get(&archive)
+                .unwrap()
+                .journal
+                .counts()
+                .badge(),
+            "~1"
+        );
+
+        let fx = app.cmd_archive("discard");
+        settle(&mut app, fx);
+
+        assert!(!staged.exists(), "the edited copy is gone");
+        assert!(
+            !app.mount_is_dirty(&archive),
+            "and nothing is pending any more"
+        );
+        assert!(
+            !app.settle_archive_edits(),
+            "including on the next scan — this is where it used to come back"
+        );
+
+        // Reading it again gets the archive's own bytes.
+        let fx = app.apply(&Action::Take).unwrap();
+        settle(&mut app, fx);
+        let item = app
+            .state
+            .inventory
+            .items()
+            .find(|i| i.filename == "README.md")
+            .unwrap();
+        assert_eq!(
+            app.state.inventory.read_content(&item.id).as_deref(),
+            Some(b"# pkg\n".as_slice()),
+            "the archive's version, not the discarded edit"
+        );
+    });
+}
+
+/// An added member's staged bytes go too — nothing brought in survives a discard.
+#[test]
+fn discarding_an_added_member_removes_its_staged_bytes() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let brought = dir.join("extra.txt");
+        std::fs::write(&brought, b"brought in\n").unwrap();
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        // Copy a real file into the mount, which records an Add and stages bytes.
+        let fx = app.screen_archive_effect(Effect::FileOp(crate::app::file_ops::FileOp::Copy {
+            paths: vec![brought],
+            dest: archive.clone(),
+        }));
+        settle(&mut app, fx.into_iter().collect());
+        let staged = app
+            .state
+            .mounts
+            .get(&archive)
+            .unwrap()
+            .staging_root
+            .join("extra.txt");
+        assert!(staged.exists(), "the brought-in bytes are staged");
+
+        let fx = app.cmd_archive("discard");
+        settle(&mut app, fx);
+
+        assert!(!staged.exists(), "and discarded with the change");
+        assert!(!app.mount_is_dirty(&archive));
+        assert!(
+            !app.state
+                .cur()
+                .rows
+                .iter()
+                .any(|r| r.display.starts_with("extra.txt")),
+            "the row is gone too"
+        );
+    });
+}


### PR DESCRIPTION
The bug I spotted while writing the checkpoint and hadn't fixed.

## What was wrong

`:archive discard` cleared the journal and re-mounted, relying on the re-mount to throw away the edited staged copies. Since #312 a re-mount of a **live** mount is re-*entered* rather than re-read — so nothing was re-extracted. The edited copies stayed on disk, `settle_archive_edits` re-recorded them as pending moments later, and the discarded change **came straight back**, badge and all.

## Why not just make it re-mount properly

Because that's racy. Each `Effect::Archive` spawns its own worker thread, so issuing `Clean(staging)` beside a fresh `Mount` runs `remove_dir_all` concurrently with an extraction into **the same** `<pid>-<hash>` path. That would leave a half-populated staging tree — which is exactly the shape #335 had to recover from.

Removing precisely what was recorded needs neither a re-mount nor a clean:

| change | staged bytes | discard |
|---|---|---|
| `Replaced` | at the entry's staging path (differs for a case-colliding member) | remove the file |
| `Added` | under its own inner path — no index entry exists | remove the file |
| `Deleted` / `Renamed` | none; they're index edits | nothing to remove |

Then the recorded stats for those members, the editor watch list, and the journal all go, and the listing is rebuilt — which is what brings deleted rows back and takes added ones away.

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- `discarding_an_edit_drops_the_staged_copy_too` — edit a staged member, discard, then assert the copy is gone, the mount is clean, **and the next scan doesn't re-record it** (that last assertion is the bug), and that re-reading the member gets the archive's bytes rather than the discarded edit.
- `discarding_an_added_member_removes_its_staged_bytes` — copy a file in, discard, assert the staged bytes and the row are both gone.
- Both verified to fail against the old arm: `the edited copy is gone` and `and discarded with the change`.

Generated with [Claude Code](https://claude.com/claude-code)
