### PR TITLE
fix(archive): a put member can be read, edited and deleted

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -500,7 +500,10 @@ they land in a session-scoped staging dir that is cleaned up on exit.
 - **Changing an archive** — `R` marks a member for removal, `p` puts an
   inventory item in, `c` copies files in, `M` renames a member (an index edit, so
   no bytes move however large it is), and `e` / `V` edit a member by extracting it
-  and opening your editor on that copy. Everything stays pending until
+  and opening your editor on that copy. A file you bring in is a member from that
+  moment — read it, edit it, rename it — and `R` on one takes it straight back out
+  rather than recording a removal, since the archive never held it. Everything
+  else stays pending until
   `:archive write`; the suffix carries a `+2 ~1 -3` badge meanwhile, and each
   changed member is marked in the listing's own status gutter — and the archive
   file itself is marked `~` in the directory it lives in, so a container holding

--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -141,9 +141,26 @@ impl App {
         let Some((mount, _)) = self.state.mounts.member_of(path) else {
             return Vec::new();
         };
-        let Some(entry) = mount.entry_at(path).cloned() else {
-            self.state.flash_error("archive: no such member");
-            return Vec::new();
+        let entry = match mount.member_at(path) {
+            Some(crate::archive::mount::MemberRef::Archived(entry)) => entry.clone(),
+            // A file the user brought in: the staging tree is the only copy, so
+            // there is nothing to extract and nothing to fall through to.
+            Some(crate::archive::mount::MemberRef::Added { rel, .. }) => {
+                let staged = mount.staging_root.join(rel);
+                if staged.is_dir() {
+                    return Vec::new();
+                }
+                if !staged.exists() {
+                    self.state
+                        .flash_error("archive: the added file's staged copy is gone");
+                    return Vec::new();
+                }
+                return self.do_after_materialize(then, &staged);
+            }
+            None => {
+                self.state.flash_error("archive: no such member");
+                return Vec::new();
+            }
         };
         if entry.kind == crate::archive::index::ArchiveEntryKind::Dir {
             return Vec::new();
@@ -862,9 +879,9 @@ impl App {
         let staged_check = |p: &Path| {
             self.state
                 .mounts
-                .resolve(p)
-                .and_then(|(mount, _)| mount.entry_at(p).map(|e| mount.is_materialized(e)))
-                .unwrap_or(false)
+                .member_of(p)
+                .and_then(|(mount, _)| mount.bytes_at(p))
+                .is_some_and(|bytes| bytes.exists())
         };
         let inventory_names = |ids: &[String]| -> Vec<String> {
             self.state
@@ -982,9 +999,26 @@ impl App {
         for change in changes {
             match change {
                 PendingChange::Delete { archive, inner } => {
+                    // Deleting a file the user brought in un-adds it: the archive
+                    // never held it, so its staged bytes are the only copy and
+                    // leaving them behind would collide with a second put.
+                    let staged = self
+                        .state
+                        .mounts
+                        .get(&archive)
+                        .filter(|mount| mount.journal.is_addition(&inner))
+                        .map(|mount| mount.staging_root.join(&inner));
                     if let Some(mount) = self.state.mounts.get_mut(&archive) {
-                        mount.journal.delete(inner);
+                        match &staged {
+                            Some(_) => {
+                                mount.journal.forget_addition(&inner);
+                            }
+                            None => mount.journal.delete(inner),
+                        }
                         deleted += 1;
+                    }
+                    if let Some(staged) = staged {
+                        let _ = std::fs::remove_file(&staged);
                     }
                 }
                 PendingChange::Rename { archive, from, to } => {
@@ -1011,8 +1045,20 @@ impl App {
             .map(|(n, verb)| format!("{n} {verb}"))
             .collect::<Vec<_>>()
             .join(", ");
-        self.state
-            .flash_info(format!("{what} — :archive write to apply"));
+        // Un-adding the last pending addition leaves nothing to write back, so
+        // pointing at `:archive write` would name a no-op.
+        let touched: Vec<PathBuf> = self
+            .state
+            .mounts
+            .iter()
+            .map(|m| m.archive().to_path_buf())
+            .collect();
+        let still_dirty = touched.iter().any(|a| self.mount_is_dirty(a));
+        self.state.flash_info(if still_dirty {
+            format!("{what} — :archive write to apply")
+        } else {
+            what
+        });
     }
 
     /// The write-back op for a mount, or `None` when there is nothing to write.

--- a/src/app/archive_route.rs
+++ b/src/app/archive_route.rs
@@ -271,10 +271,9 @@ fn classify(
                 .iter()
                 .filter_map(|p| {
                     let (mount, _) = mounts.member_of(p)?;
-                    let entry = mount.entry_at(p)?;
                     Some(PendingChange::Delete {
                         archive: mount.archive().to_path_buf(),
-                        inner: entry.inner.clone(),
+                        inner: mount.member_at(p)?.inner().to_string(),
                     })
                 })
                 .collect::<Vec<_>>();
@@ -488,7 +487,7 @@ fn need(paths: &[PathBuf], mounts: &Mounts, is_staged: &dyn Fn(&Path) -> bool) -
 /// Where a member's extracted bytes live, or would.
 fn staging_path(member: &Path, mounts: &Mounts) -> Option<PathBuf> {
     let (mount, _) = mounts.member_of(member)?;
-    mount.entry_at(member).map(|e| mount.staging_path(e))
+    mount.bytes_at(member)
 }
 
 fn graveyard_paths(op: &super::graveyard_ops::GraveyardOp) -> Vec<PathBuf> {

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -2739,3 +2739,215 @@ fn discarding_an_added_member_removes_its_staged_bytes() {
         );
     });
 }
+
+// ── a member the user brought in is a member ──────────────────────────────
+
+/// Yank a real file and put it into a mount, handing back the inventory ids in
+/// case the test needs to put it again.
+fn put_a_file_into(app: &mut App, archive: &Path, staging: &Path, name: &str, body: &[u8]) {
+    let source = archive.parent().unwrap().join(name);
+    std::fs::write(&source, body).unwrap();
+    settle(
+        app,
+        vec![Effect::Inventory(
+            crate::app::inventory_ops::InventoryOp::Yank {
+                sources: vec![source]
+                    .into_iter()
+                    .map(crate::app::inventory_ops::YankSource::plain)
+                    .collect(),
+            },
+        )],
+    );
+    if !app.state.mounts.contains(archive) {
+        mount_inline(app, archive, staging);
+    }
+    let ids: Vec<String> = app.state.inventory.items().map(|i| i.id.clone()).collect();
+    settle(
+        app,
+        vec![Effect::Inventory(
+            crate::app::inventory_ops::InventoryOp::Put {
+                dest_dir: archive.to_path_buf(),
+                ids,
+            },
+        )],
+    );
+}
+
+/// The bug this fixes: a put file listed fine but refused every read, edit and
+/// delete with "no such member", because it lives in the journal and the staging
+/// tree while `entry_at` only ever asked the index.
+#[test]
+fn a_put_member_can_be_opened_yanked_and_deleted() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let staging = tmp.path().join("staging");
+        let mut app = App::test_app(dir);
+        put_a_file_into(&mut app, &archive, &staging, "brought.txt", b"payload");
+
+        let added = archive.join("brought.txt");
+        assert!(
+            row_names(&app).contains(&"brought.txt".to_string()),
+            "the put file lists: {:?}",
+            row_names(&app)
+        );
+
+        // Opening it reaches the staged bytes. Those are already on disk — a put
+        // wrote them — so the pager opens with no worker round trip at all, which
+        // is why the proof is the pager rather than an effect.
+        app.state.flash = None;
+        let fx = app.open_member(
+            &added,
+            crate::app::archive_ops::MaterializeThen::OpenPager(
+                crate::app::file_ops::PagerDest::Overlay { scroll: None },
+            ),
+        );
+        assert!(fx.is_empty(), "nothing to extract: {fx:?}");
+        assert_eq!(
+            app.state.flash.as_ref().map(|f| f.text.clone()),
+            None,
+            "and it is not refused"
+        );
+        assert_eq!(
+            app.view
+                .pager
+                .as_ref()
+                .expect("the put member is paged")
+                .source_path
+                .as_deref(),
+            Some(staging.join("brought.txt").as_path()),
+            "reading the staged copy the put wrote"
+        );
+        app.view.pager = None;
+
+        // Reading it out — `y`, and by the same route `L` / `f` / copy-out.
+        settle(
+            &mut app,
+            vec![Effect::Inventory(
+                crate::app::inventory_ops::InventoryOp::Yank {
+                    sources: vec![crate::app::inventory_ops::YankSource::plain(added.clone())],
+                },
+            )],
+        );
+        let cached = app
+            .state
+            .inventory
+            .items()
+            .find(|i| i.orig_path == added)
+            .expect("the put member yanks, addressed by its path in the archive");
+        assert_eq!(cached.filename, "brought.txt");
+    });
+}
+
+/// Deleting a put member un-adds it: the row goes, the journal goes clean, and
+/// the staged copy is unlinked so the same name can be put again.
+#[test]
+fn deleting_a_put_member_un_adds_it_and_frees_the_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let staging = tmp.path().join("staging");
+        let mut app = App::test_app(dir);
+        put_a_file_into(&mut app, &archive, &staging, "brought.txt", b"first");
+
+        let added = archive.join("brought.txt");
+        let staged_copy = staging.join("brought.txt");
+        assert!(staged_copy.exists(), "the put staged its bytes");
+
+        app.state.flash = None;
+        settle(
+            &mut app,
+            vec![Effect::Graveyard(
+                crate::app::graveyard_ops::GraveyardOp::Archive { paths: vec![added] },
+            )],
+        );
+        assert!(
+            !row_names(&app).contains(&"brought.txt".to_string()),
+            "the row is gone: {:?}",
+            row_names(&app)
+        );
+        assert!(
+            !app.mount_is_dirty(&archive),
+            "nothing is pending — the archive never held it"
+        );
+        assert!(
+            !staged_copy.exists(),
+            "and its staged copy went with it, so the name is free again"
+        );
+
+        // Free means free: the same file can be put back.
+        put_a_file_into(&mut app, &archive, &staging, "brought.txt", b"second");
+        assert!(
+            row_names(&app).contains(&"brought.txt".to_string()),
+            "a second put of the same name lands: {:?}",
+            row_names(&app)
+        );
+        assert_eq!(std::fs::read(&staged_copy).unwrap(), b"second");
+    });
+}
+
+/// An archived member is unaffected: deleting one is still a recorded removal
+/// that the write-back applies.
+#[test]
+fn deleting_an_archived_member_is_still_recorded() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        settle(
+            &mut app,
+            vec![Effect::Graveyard(
+                crate::app::graveyard_ops::GraveyardOp::Archive {
+                    paths: vec![archive.join("README.md")],
+                },
+            )],
+        );
+        assert!(app.mount_is_dirty(&archive), "the removal is pending");
+        let fx = app.cmd_archive("write");
+        settle(&mut app, fx);
+        assert!(
+            !member_names(&archive).contains(&"README.md".to_string()),
+            "{:?}",
+            member_names(&archive)
+        );
+    });
+}
+
+/// End to end: a put member survives the write-back and is a real archived
+/// member afterwards — the point of making it actionable in the first place.
+#[test]
+fn a_put_member_edited_then_written_carries_its_edit_in() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let staging = tmp.path().join("staging");
+        let mut app = App::test_app(dir);
+        put_a_file_into(&mut app, &archive, &staging, "brought.txt", b"before");
+
+        // Edit it the way an editor or an agent would — straight on the staged copy.
+        std::fs::write(staging.join("brought.txt"), b"after the edit").unwrap();
+
+        let fx = app.cmd_archive("write");
+        settle(&mut app, fx);
+
+        assert!(
+            member_names(&archive).contains(&"brought.txt".to_string()),
+            "{:?}",
+            member_names(&archive)
+        );
+        let mut zip = zip::ZipArchive::new(std::fs::File::open(&archive).unwrap()).unwrap();
+        let mut body = String::new();
+        std::io::Read::read_to_string(&mut zip.by_name("brought.txt").unwrap(), &mut body).unwrap();
+        assert_eq!(body, "after the edit");
+    });
+}

--- a/src/archive/journal.rs
+++ b/src/archive/journal.rs
@@ -192,6 +192,32 @@ impl Journal {
         (self.effective(inner) != inner).then_some(MemberChange::Renamed)
     }
 
+    /// Whether `inner` is a file the user brought in and hasn't written back.
+    pub fn is_addition(&self, inner: &str) -> bool {
+        self.additions().any(|added| added == inner)
+    }
+
+    /// Un-add a pending addition, as deleting one does.
+    ///
+    /// Recording a `Deleted` against it instead would also hide the row, but the
+    /// archive never held those bytes — so the pair would describe removing
+    /// something that was never there, and the staged copy would linger under a
+    /// name a second put of the same file then collides with. Dropping the
+    /// addition outright is what "delete a file I just brought in" means.
+    ///
+    /// Renames of the addition go with it: they name a path that no longer
+    /// exists, and leaving one behind keeps the listing on its slow path forever.
+    /// Returns whether anything was pending.
+    pub fn forget_addition(&mut self, inner: &str) -> bool {
+        let before = self.changes.len();
+        self.changes.retain(|change| match change {
+            Change::Added { inner: added } => added != inner,
+            Change::Renamed { from, .. } => from != inner,
+            _ => true,
+        });
+        self.changes.len() != before
+    }
+
     /// Whether a staged copy supersedes this member's archived bytes.
     pub fn is_replaced(&self, inner: &str) -> bool {
         self.changes
@@ -331,6 +357,53 @@ mod tests {
         );
         j.delete("scratch.txt");
         assert_eq!(j.additions().collect::<Vec<_>>(), ["notes.md"]);
+    }
+
+    /// Deleting a file the user brought in un-adds it rather than recording a
+    /// removal of something the archive never held — which is also what frees the
+    /// name for a second put of the same file.
+    #[test]
+    fn un_adding_an_addition_leaves_no_trace_of_it() {
+        let mut j = Journal::default();
+        j.add("brought.txt");
+        j.add("keep.txt");
+        assert!(j.is_addition("brought.txt"));
+
+        assert!(j.forget_addition("brought.txt"));
+        assert!(!j.is_addition("brought.txt"));
+        assert_eq!(j.additions().collect::<Vec<_>>(), ["keep.txt"]);
+        assert!(
+            !j.is_deleted("brought.txt"),
+            "no removal is recorded for bytes the archive never had"
+        );
+        assert_eq!(j.counts().deleted, 0);
+        assert!(!j.forget_addition("brought.txt"), "and it is idempotent");
+    }
+
+    /// A rename of the addition names a path that no longer exists, so it goes
+    /// too — left behind it would hold the listing on its slow path forever.
+    #[test]
+    fn un_adding_takes_its_rename_with_it() {
+        let mut j = Journal::default();
+        j.add("brought.txt");
+        j.rename("brought.txt", "renamed.txt");
+        assert!(j.has_renames());
+
+        assert!(j.forget_addition("brought.txt"));
+        assert!(!j.is_dirty(), "nothing is left pending");
+        assert!(!j.has_renames());
+    }
+
+    /// An archived member is untouched by the addition path: deleting one is
+    /// still a recorded removal, because the bytes really are in the container.
+    #[test]
+    fn un_adding_does_not_apply_to_an_archived_member() {
+        let mut j = Journal::default();
+        assert!(!j.is_addition("src/main.rs"));
+        assert!(!j.forget_addition("src/main.rs"));
+        j.delete("src/main.rs");
+        assert!(j.is_deleted("src/main.rs"));
+        assert_eq!(j.counts().deleted, 1);
     }
 
     #[test]

--- a/src/archive/mount.rs
+++ b/src/archive/mount.rs
@@ -21,6 +21,40 @@ use super::{ArchiveFormat, listing};
 /// capped separately.
 pub const MAX_MOUNTS: usize = 8;
 
+/// A member the user can act on.
+///
+/// Two things can occupy a path inside a mount, and only one of them is in the
+/// index: a member the archive stores, and a file the user brought in, which
+/// exists as a journal entry plus bytes in the staging tree until the next
+/// write-back. Asking the index alone is how a put file came to list fine but
+/// refuse every read, edit and delete with "no such member".
+#[derive(Debug)]
+pub enum MemberRef<'a> {
+    /// Stored in the archive. Its bytes may or may not be staged yet.
+    Archived(&'a IndexEntry),
+    /// Brought in by the user. There is nothing in the container to extract —
+    /// the staging tree holds the only copy, at `rel` under the staging root.
+    Added { inner: String, rel: PathBuf },
+}
+
+impl MemberRef<'_> {
+    /// The member's path in the archive's own namespace — the journal key.
+    pub fn inner(&self) -> &str {
+        match self {
+            Self::Archived(entry) => &entry.inner,
+            Self::Added { inner, .. } => inner,
+        }
+    }
+
+    /// Where its bytes live under the staging root.
+    pub fn staging_rel(&self) -> PathBuf {
+        match self {
+            Self::Archived(entry) => entry.staging_rel(),
+            Self::Added { rel, .. } => rel.clone(),
+        }
+    }
+}
+
 /// One mounted archive.
 #[derive(Debug)]
 pub struct ArchiveMount {
@@ -83,6 +117,38 @@ impl ArchiveMount {
     pub fn entry_at(&self, path: &Path) -> Option<&IndexEntry> {
         let shown = self.index.inner_of(path)?;
         self.index.get(&self.journal.original_of(&shown))
+    }
+
+    /// The member behind an absolute mount path, archived **or** merely added.
+    ///
+    /// The one place that knows those are the two ways a path inside a mount can
+    /// be real. Everything that acts on a member goes through this rather than
+    /// [`Self::entry_at`], which answers the narrower question "what does the
+    /// archive store here?" and is `None` for a file the user brought in.
+    pub fn member_at(&self, path: &Path) -> Option<MemberRef<'_>> {
+        let shown = self.index.inner_of(path)?;
+        if shown.is_empty() {
+            // The container itself is not one of its own members.
+            return None;
+        }
+        let inner = self.journal.original_of(&shown);
+        if let Some(entry) = self.index.get(&inner) {
+            return Some(MemberRef::Archived(entry));
+        }
+        // An addition's bytes were staged under the path it was added at, and a
+        // later rename moves no bytes — the same path `plan_repack` reads from.
+        self.journal
+            .additions()
+            .any(|added| added == inner)
+            .then(|| MemberRef::Added {
+                rel: PathBuf::from(&inner),
+                inner,
+            })
+    }
+
+    /// Absolute path of a member's bytes, staged or not yet.
+    pub fn bytes_at(&self, path: &Path) -> Option<PathBuf> {
+        Some(self.staging_root.join(self.member_at(path)?.staging_rel()))
     }
 
     /// Absolute staging path for a member's bytes.
@@ -317,6 +383,65 @@ mod tests {
         mounts.defer_cleanup(orphan.clone());
 
         assert_eq!(mounts.drain_all(), vec![orphan]);
+    }
+
+    /// A file the user put in is a member the moment it's recorded — not only
+    /// once it's been written back. The index doesn't know it, which is why
+    /// `entry_at` alone left every read, edit and delete of a put file refusing
+    /// with "no such member".
+    #[test]
+    fn a_pending_addition_is_a_member_the_index_never_heard_of() {
+        let mut mounts = Mounts::default();
+        mounts.insert(mount_at("/src/pkg.zip", &["a.txt"]), &[]);
+        let m = mounts.get_mut(Path::new("/src/pkg.zip")).unwrap();
+        m.journal.add("brought.txt");
+
+        let added = Path::new("/src/pkg.zip/brought.txt");
+        assert!(
+            m.entry_at(added).is_none(),
+            "the archive stores nothing there"
+        );
+        let member = m.member_at(added).expect("but it is still a member");
+        assert!(matches!(member, MemberRef::Added { .. }));
+        assert_eq!(member.inner(), "brought.txt");
+        assert_eq!(
+            m.bytes_at(added),
+            Some(PathBuf::from("/staging/_src_pkg.zip/brought.txt")),
+            "its bytes are the staged copy the put wrote"
+        );
+    }
+
+    /// A rename moves no bytes, so a renamed addition still reads from where it
+    /// was staged — the same path `plan_repack` takes it from.
+    #[test]
+    fn a_renamed_addition_still_resolves_to_its_original_staged_bytes() {
+        let mut mounts = Mounts::default();
+        mounts.insert(mount_at("/src/pkg.zip", &["a.txt"]), &[]);
+        let m = mounts.get_mut(Path::new("/src/pkg.zip")).unwrap();
+        m.journal.add("brought.txt");
+        m.journal.rename("brought.txt", "renamed.txt");
+
+        let member = m
+            .member_at(Path::new("/src/pkg.zip/renamed.txt"))
+            .expect("addressed by the name it shows under");
+        assert_eq!(
+            member.inner(),
+            "brought.txt",
+            "keyed in the archive's namespace"
+        );
+        assert_eq!(member.staging_rel(), PathBuf::from("brought.txt"));
+    }
+
+    #[test]
+    fn an_archived_member_resolves_to_its_index_entry() {
+        let mut mounts = Mounts::default();
+        mounts.insert(mount_at("/src/pkg.zip", &["a/b.txt"]), &[]);
+        let m = mounts.get(Path::new("/src/pkg.zip")).unwrap();
+        let member = m.member_at(Path::new("/src/pkg.zip/a/b.txt")).unwrap();
+        assert!(matches!(member, MemberRef::Archived(_)));
+        assert_eq!(member.inner(), "a/b.txt");
+        // The container itself resolves to no member, added or archived.
+        assert!(m.member_at(Path::new("/src/pkg.zip")).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Found by hand-driving the fika tarball: put a file into a mount, then try to edit or remove it.

## What was wrong

A file brought into a mount **listed** fine, **renamed** fine and was **written back** fine — but every read, edit and delete of it refused with `archive: no such member`.

Two things can occupy a path inside a mount: a member the archive stores, and one the user put there, which exists only as a journal entry plus bytes in the staging tree. `ArchiveMount::entry_at` only ever asked the index. Everything that worked avoided it; everything that failed went through it:

| op on a put member | before |
|---|---|
| lists in the browser | ✅ `journal.additions()` |
| `M` rename | ✅ `member_of` — pure path math |
| `:archive write` carries it in | ✅ `plan_repack` handles additions |
| `Enter` / `e` edit | ❌ `archive: no such member` |
| `R` delete | ❌ `archive: no such member` |
| `y` yank, `L`, `f`, copy-out | ❌ `archive: nothing readable in the selection` |

## The fix

`ArchiveMount::member_at` becomes the one place that knows both kinds of member exist, returning `MemberRef::{Archived, Added}`. Four sites resolve through it: `open_member`, the delete arm in `archive_route.rs`, the staged-bytes lookup behind every read (`staging_path`), and the "is it staged?" predicate.

`entry_at` keeps its narrower meaning — *what does the archive store here* — and stays `None` for an addition, which is the honest answer rather than a hole.

**Deleting a put member un-adds it** instead of recording a removal. The archive never held those bytes, so a `Deleted` paired with the `Added` would describe removing something that was never there, and the staged copy would linger under a name the next put of the same file then collides with.

## Verification

The tests were checked to actually bite — reverting only the app-side wiring fails the two put-specific tests while the archived-member control and the write-back end-to-end stay green:

```
a_put_member_can_be_opened_yanked_and_deleted ... FAILED
deleting_a_put_member_un_adds_it_and_frees_the_name ... FAILED
deleting_an_archived_member_is_still_recorded ... ok
a_put_member_edited_then_written_carries_its_edit_in ... ok
```

`make check-ci` → `=== GATE: PASS ===`.

## Not in this PR

Two further findings from the same session, filed separately: the write-back races its own staging tree (`Clean` and `Mount` issued concurrently on one root — reproduced 1-in-10 against the real tarball), and a put row lists as `size=0` with an epoch mtime and always `File`, so a put *directory* is mislabeled.

Generated with [Claude Code](https://claude.com/claude-code)
