### PR TITLE
fix(archive): a write-back empties its staging tree in the same op, not beside it

### DIFF
--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -66,6 +66,7 @@ impl App {
             then,
             address: None,
             depth: 0,
+            reset_staging: false,
         })]
     }
 
@@ -123,6 +124,53 @@ impl App {
             then,
             address: Some(at.to_path_buf()),
             depth,
+            reset_staging: false,
+        })]
+    }
+
+    /// Re-read an archive spyc has just rewritten.
+    ///
+    /// A repack renumbers a zip's entries and moves a tar's offsets, so every
+    /// locator in the old index points at the wrong bytes and the mount has to be
+    /// built again from the file on disk. The stale staging tree goes with it —
+    /// **in the same op**, because each archive op runs on its own thread and a
+    /// separate `Clean` would race the extraction refilling that directory.
+    ///
+    /// `nested_source` is the staged copy for an archive that lives inside
+    /// another one; `None` for a file on disk.
+    pub(super) fn request_remount(
+        &mut self,
+        archive: &Path,
+        nested_source: Option<PathBuf>,
+    ) -> Vec<Effect> {
+        let Some(staging_root) = staging_root_for(archive) else {
+            self.state
+                .flash_error("archive: no state directory to stage into");
+            return Vec::new();
+        };
+        let depth = if nested_source.is_some() {
+            self.state
+                .mounts
+                .resolve(archive)
+                .map_or(1, |(parent, _)| parent.depth + 1)
+        } else {
+            0
+        };
+        self.runtime.archive_cancel =
+            std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        vec![Effect::Archive(ArchiveOp::Mount {
+            path: nested_source.unwrap_or_else(|| archive.to_path_buf()),
+            staging_root,
+            limits: self.state.config.archive.limits(),
+            max_entries: self.state.config.archive.max_entries,
+            // Already read once at this size — re-reading it is not a new
+            // decision for the user to make.
+            confirmed: true,
+            cancel: std::sync::Arc::clone(&self.runtime.archive_cancel),
+            then: None,
+            address: Some(archive.to_path_buf()),
+            depth,
+            reset_staging: true,
         })]
     }
 
@@ -327,22 +375,15 @@ impl App {
                 // offsets, so every locator in the old index now points at the
                 // wrong bytes. The mount has to be *dropped* for that to happen —
                 // a live one is re-entered rather than re-indexed, which is right
-                // everywhere except here.
+                // everywhere except here. A nested archive is read from its staged
+                // copy, which the write just replaced in place.
                 let nested = self
                     .state
                     .mounts
                     .get(&archive)
                     .and_then(|m| (m.depth > 0).then(|| m.source().to_path_buf()));
-                let mut effects = match self.state.mounts.remove(&archive) {
-                    Some(staging) => clean_effects(vec![staging]),
-                    None => Vec::new(),
-                };
-                effects.extend(match &nested {
-                    // A nested archive is read from its staged copy, which the
-                    // write just replaced in place.
-                    Some(source) => self.request_nested_mount(&archive, source, None),
-                    None => self.request_mount(&archive, true),
-                });
+                self.state.mounts.remove(&archive);
+                let effects = self.request_remount(&archive, nested);
                 // Writing an archive that lives inside another one changes a file
                 // in that one's staging, so the outer now has a pending change of
                 // its own. Say so rather than leaving it to the quit warning.

--- a/src/app/archive_ops.rs
+++ b/src/app/archive_ops.rs
@@ -66,6 +66,15 @@ pub enum ArchiveOp {
         address: Option<PathBuf>,
         /// Nesting depth to record on the mount — 0 for a file on disk.
         depth: usize,
+        /// Empty the staging tree before reading, for a re-read of an archive
+        /// whose bytes changed underneath it (a write-back).
+        ///
+        /// It rides *inside* this op rather than arriving as a separate
+        /// [`ArchiveOp::Clean`] because every archive op gets its own thread: a
+        /// clean issued beside a mount races `remove_dir_all` against the
+        /// extraction filling the same directory. Doing both here is the only
+        /// ordering guarantee available.
+        reset_staging: bool,
     },
     /// Extract one member so something can read it.
     Materialize {
@@ -170,22 +179,29 @@ pub fn run_archive_op(op: ArchiveOp) -> ArchiveOutcome {
             then,
             address,
             depth,
-        } => carry_then(
-            readdress(
-                mount(
+            reset_staging,
+        } => {
+            // Before the read, on this thread — see `reset_staging`.
+            if reset_staging {
+                let _ = std::fs::remove_dir_all(&staging_root);
+            }
+            carry_then(
+                readdress(
+                    mount(
+                        &path,
+                        &staging_root,
+                        &limits,
+                        max_entries,
+                        confirmed,
+                        &cancel,
+                    ),
                     &path,
-                    &staging_root,
-                    &limits,
-                    max_entries,
-                    confirmed,
-                    &cancel,
+                    address,
+                    depth,
                 ),
-                &path,
-                address,
-                depth,
-            ),
-            then,
-        ),
+                then,
+            )
+        }
         ArchiveOp::Materialize {
             archive,
             entry,
@@ -503,7 +519,67 @@ mod tests {
             then: None,
             address: None,
             depth: 0,
+            reset_staging: false,
         })
+    }
+
+    /// A re-read after a write-back empties the staging tree **on the worker
+    /// thread, before reading** — not as a separate `Clean` op, which would race
+    /// the extraction refilling the same directory from its own thread.
+    #[test]
+    fn a_reset_mount_empties_the_staging_tree_before_reading_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        let archive = tmp.path().join("pkg.tar.gz");
+        let staging = tmp.path().join("staging");
+        // A streamed archive is the case that matters: its mount writes every
+        // member into staging, so a concurrent removal has something to collide
+        // with.
+        let tar = {
+            let mut b = tar::Builder::new(Vec::new());
+            for (name, body) in [("a.txt", &b"alpha"[..]), ("d/b.txt", &b"beta"[..])] {
+                let mut h = tar::Header::new_gnu();
+                h.set_size(body.len() as u64);
+                h.set_mode(0o644);
+                h.set_mtime(1_000_000);
+                h.set_entry_type(tar::EntryType::Regular);
+                b.append_data(&mut h, name, body).unwrap();
+            }
+            b.into_inner().unwrap()
+        };
+        let gz = {
+            use std::io::Write as _;
+            let mut e = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+            e.write_all(&tar).unwrap();
+            e.finish().unwrap()
+        };
+        std::fs::write(&archive, gz).unwrap();
+
+        // A stale tree, as the mount before a write-back leaves behind.
+        std::fs::create_dir_all(staging.join("gone")).unwrap();
+        std::fs::write(staging.join("gone/stale.txt"), b"from the old index").unwrap();
+
+        let out = run_archive_op(ArchiveOp::Mount {
+            path: archive.clone(),
+            staging_root: staging.clone(),
+            limits: BudgetLimits::default(),
+            max_entries: 1000,
+            confirmed: true,
+            cancel: Arc::new(AtomicBool::new(false)),
+            then: None,
+            address: Some(archive),
+            depth: 0,
+            reset_staging: true,
+        });
+        assert!(matches!(out, ArchiveOutcome::Mounted { .. }), "got {out:?}");
+        assert!(
+            !staging.join("gone/stale.txt").exists(),
+            "the stale tree is gone"
+        );
+        assert_eq!(
+            std::fs::read(staging.join("a.txt")).unwrap(),
+            b"alpha",
+            "and the fresh members were extracted after it, not into a half-removed tree"
+        );
     }
 
     #[test]

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -40,6 +40,7 @@ fn mount_inline(app: &mut App, archive: &Path, staging: &Path) -> Vec<Effect> {
         then: None,
         address: None,
         depth: 0,
+        reset_staging: false,
     });
     assert!(
         matches!(outcome, ArchiveOutcome::Mounted { .. }),
@@ -2949,5 +2950,74 @@ fn a_put_member_edited_then_written_carries_its_edit_in() {
         let mut body = String::new();
         std::io::Read::read_to_string(&mut zip.by_name("brought.txt").unwrap(), &mut body).unwrap();
         assert_eq!(body, "after the edit");
+    });
+}
+
+/// After a write-back the mount is rebuilt from the file on disk, and the stale
+/// staging tree is emptied **by that same op** — never by a `Clean` issued
+/// alongside it.
+///
+/// Every archive op gets its own thread, so a `Clean` and a `Mount` naming one
+/// staging root run concurrently: `remove_dir_all` walking the tree while the
+/// extraction refills it produced `creating <staging>/…: File exists (os error
+/// 17)` against a real 459-member tarball, reproducible about one run in ten.
+/// A race can't be proved absent by running it, so the guard is structural.
+#[test]
+fn a_write_back_re_reads_without_a_clean_racing_its_staging_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        settle(
+            &mut app,
+            vec![Effect::Graveyard(
+                crate::app::graveyard_ops::GraveyardOp::Archive {
+                    paths: vec![archive.join("README.md")],
+                },
+            )],
+        );
+
+        // Run the write, then take exactly what its outcome asks for next.
+        let write = app.cmd_archive("write");
+        for effect in write {
+            let Effect::Archive(op) = effect else {
+                continue;
+            };
+            let outcome = run_archive_op(op);
+            app.runtime.archive_results.lock().unwrap().push(outcome);
+        }
+        let (_, after_write) = app.apply_archive_outcomes();
+
+        let mut mount_roots = Vec::new();
+        let mut clean_roots = Vec::new();
+        for effect in &after_write {
+            match effect {
+                Effect::Archive(ArchiveOp::Mount {
+                    staging_root,
+                    reset_staging,
+                    ..
+                }) => {
+                    assert!(
+                        *reset_staging,
+                        "the re-read empties the tree itself, so no separate Clean is needed"
+                    );
+                    mount_roots.push(staging_root.clone());
+                }
+                Effect::Archive(ArchiveOp::Clean { staging_roots }) => {
+                    clean_roots.extend(staging_roots.iter().cloned());
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(mount_roots.len(), 1, "one re-read: {after_write:?}");
+        assert!(
+            !clean_roots.contains(&mount_roots[0]),
+            "a Clean on {:?} would race the re-read filling it — cleans: {clean_roots:?}",
+            mount_roots[0]
+        );
     });
 }


### PR DESCRIPTION
The second of the bugs found hand-driving `~/src/fika-reporting-etg-2026-06-03.tar.gz`, and the one that broke `:archive write` outright:

```
fika-reporting-etg-2026-06-03.tar.gz: creating
  /Users/…/.local/state/spyc/archives/5355-b67dcac20d8966da/fika-reporting/collectors:
  File exists (os error 17)
```

## What was wrong

A write-back re-reads the archive — a repack renumbers a zip's entries and moves a tar's offsets, so every locator in the old index points at the wrong bytes. That re-read went out as **two effects in one batch**:

```rust
let mut effects = match self.state.mounts.remove(&archive) {
    Some(staging) => clean_effects(vec![staging]),   // Effect::Archive(Clean)
    None => Vec::new(),
};
effects.extend(… self.request_mount(&archive, true));   // Effect::Archive(Mount)
```

`staging_root_for` is deterministic (pid + hash of the archive path), so both name **the same directory**. And `run_effects` spawns a thread per `Effect::Archive` — so `remove_dir_all` walks the tree while `stream_mount` fills it. `create_dir_all` then loses its own TOCTOU: EEXIST, then an `is_dir` check of a directory the remover had just unlinked, so the error surfaces instead of being absorbed.

Only compressed tars are exposed in practice — a zip mount extracts nothing — which matches where it was seen.

Reproduced empirically against the real tarball, 30 attempts, failing at attempt 9:

```
attempt 8: clean=false mount_ok=true
attempt 9: clean=false mount_ok=false
  MOUNT ERROR: creating …/spyc-repro-race-12769-9/fika-reporting/data: File exists (os error 17)
```

The half-populated trees this leaves behind are exactly the shape #335 taught the writer to recover from — which is why it stayed hidden as long as it did.

## The fix

The reset rides **inside** `ArchiveOp::Mount` as `reset_staging: bool`, so one worker empties the tree and then reads it. Ordering within a single op is the only guarantee available when every op gets its own thread.

`request_remount` is the only caller that sets it, and it also carries the `confirmed: true` / `address` / `depth` handling the write path needs. The six ordinary mount call sites are untouched.

Worth noting this hazard was already written down — it's why [#336](https://github.com/Tripstack-Corp/spyc/pull/336) made `:archive discard` deliberately *not* re-mount. The write path had been doing it anyway.

## Verification

The guard is **structural, not timed** — a race can't be proved absent by running it, and a timing-dependent test would be exactly the CI flake this repo doesn't allow. It asserts the invariant instead: after a write, no `Clean` is emitted for the staging root that the same batch's `Mount` is about to fill.

Confirmed to bite — restoring the old two-effect form fails it:

```
a_write_back_re_reads_without_a_clean_racing_its_staging_tree ... FAILED
```

Plus a worker-level test that `reset_staging` empties a stale tree *before* extracting, using a streamed `.tar.gz` (the case where staging is actually written).

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)
