### PR TITLE
fix(archive): an in-flight message stops claiming the work is still running

### DIFF
--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -55,7 +55,7 @@ impl App {
         self.runtime.archive_cancel =
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         self.state
-            .flash_info(format!("reading {}…", display_name(path)));
+            .flash_progress(format!("reading {}…", display_name(path)));
         vec![Effect::Archive(ArchiveOp::Mount {
             path: path.to_path_buf(),
             staging_root,
@@ -113,7 +113,7 @@ impl App {
         self.runtime.archive_cancel =
             std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         self.state
-            .flash_info(format!("reading {}…", display_name(at)));
+            .flash_progress(format!("reading {}…", display_name(at)));
         vec![Effect::Archive(ArchiveOp::Mount {
             path: source.to_path_buf(),
             staging_root,
@@ -250,6 +250,13 @@ impl App {
     }
 
     fn apply_one_archive_outcome(&mut self, outcome: ArchiveOutcome) -> Vec<Effect> {
+        // An outcome means the op it was announcing is over, so the in-flight
+        // message goes now — before the arms below get their say. Done here rather
+        // than per-arm because the one that leaked was the arm with nothing to
+        // report: entering an archive that had no warnings left "reading …" on
+        // screen, reading as though more were coming. Only a `Progress` flash is
+        // cleared, so a warning or error already showing survives.
+        self.state.clear_progress_flash();
         match outcome {
             ArchiveOutcome::Mounted {
                 index,
@@ -1001,7 +1008,7 @@ impl App {
             return None;
         }
         self.state
-            .flash_info(format!("extracting {} member(s)…", entries.len()));
+            .flash_progress(format!("extracting {} member(s)…", entries.len()));
         Some(Effect::Archive(ArchiveOp::MaterializeMany {
             archive,
             entries,
@@ -1147,7 +1154,7 @@ impl App {
             }
             Some(Ok(op)) => {
                 self.state
-                    .flash_info(format!("writing {}…", display_name(archive)));
+                    .flash_progress(format!("writing {}…", display_name(archive)));
                 Some(Effect::Archive(op))
             }
         }

--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -3021,3 +3021,108 @@ fn a_write_back_re_reads_without_a_clean_racing_its_staging_tree() {
         );
     });
 }
+
+// ── an in-flight message doesn't outlive its operation ────────────────────
+
+/// The user's report: after entering an archive, `reading pkg.zip…` stayed on
+/// the status bar, reading as though more were still to come.
+///
+/// A flash has no lifetime of its own, and the mount arm only speaks up when the
+/// archive had something odd about it — so a clean mount left the in-flight
+/// message as the last thing said.
+#[test]
+fn the_reading_message_goes_once_the_archive_is_mounted() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        build_zip(&archive);
+        let mut app = App::test_app(dir);
+
+        let fx = app.request_mount(&archive, true);
+        let flash = app.state.flash.as_ref().expect("the wait is announced");
+        assert_eq!(flash.text, "reading pkg.zip…");
+        assert!(matches!(flash.kind, crate::app::FlashKind::Progress));
+
+        settle(&mut app, fx);
+
+        assert_eq!(
+            app.state.flash.as_ref().map(|f| f.text.clone()),
+            None,
+            "nothing is left claiming the read is still going"
+        );
+        assert!(app.state.mounts.contains(&archive), "and it did mount");
+    });
+}
+
+/// The clear must not eat what the mount had to say. Two members differing only
+/// by case is a real warning — and the reason the arm flashes at all.
+///
+/// Duplicate *identical* names would be the sharper fixture, but `ZipWriter`
+/// refuses to write them, which is why the read-only test builds its capability
+/// by hand.
+#[test]
+fn a_mount_with_something_to_report_still_reports_it() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("collide.zip");
+        let f = std::fs::File::create(&archive).unwrap();
+        let mut w = zip::ZipWriter::new(f);
+        let opts = zip::write::SimpleFileOptions::default();
+        for name in ["same.txt", "SAME.txt"] {
+            w.start_file(name, opts).unwrap();
+            w.write_all(b"body").unwrap();
+        }
+        w.finish().unwrap();
+        let mut app = App::test_app(dir);
+
+        let fx = app.request_mount(&archive, true);
+        settle(&mut app, fx);
+
+        let flash = app
+            .state
+            .flash
+            .as_ref()
+            .expect("the note survives the clear");
+        assert!(
+            flash.text.contains("differ only by case"),
+            "it is the note, not the in-flight message: {}",
+            flash.text
+        );
+        assert!(
+            !matches!(flash.kind, crate::app::FlashKind::Progress),
+            "a note is not progress"
+        );
+    });
+}
+
+/// An error is a real message too: a failed read replaces the in-flight one
+/// rather than being cleared along with it.
+#[test]
+fn a_failed_read_leaves_its_error_on_screen() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let broken = dir.join("broken.zip");
+        std::fs::write(&broken, b"PK\x03\x04 and then nothing usable").unwrap();
+        let mut app = App::test_app(dir);
+
+        let fx = app.request_mount(&broken, true);
+        settle(&mut app, fx);
+
+        let flash = app.state.flash.as_ref().expect("the failure is reported");
+        assert!(
+            matches!(flash.kind, crate::app::FlashKind::Error),
+            "an error replaced the in-flight message rather than being cleared with it"
+        );
+        // Not a `contains("reading")` check: the error's own context chain says
+        // "reading zip <path>", so the wording overlaps the progress message and
+        // only the kind distinguishes them.
+        assert!(
+            flash.text.contains("Could not find EOCD"),
+            "and it still names the cause: {}",
+            flash.text
+        );
+    });
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -366,6 +366,11 @@ pub struct FlashMessage {
 pub enum FlashKind {
     Info,
     Error,
+    /// An operation is in flight. Reads like `Info`, but it names something that
+    /// hasn't finished — so whatever the operation lands as replaces it, and a
+    /// completion with nothing to say clears it rather than leaving a message
+    /// that claims work is still going on.
+    Progress,
 }
 
 /// State for returning to the pager after `v` (edit) exits.

--- a/src/app/render/inner.rs
+++ b/src/app/render/inner.rs
@@ -341,7 +341,9 @@ impl App {
             self.draw_chrome_rows(frame, rect, lines);
         } else if let Some(flash) = &self.state.flash {
             let color = match flash.kind {
-                FlashKind::Info => self.view.theme.take,
+                // Progress reads as info: the difference is how long it lives,
+                // not how it looks.
+                FlashKind::Info | FlashKind::Progress => self.view.theme.take,
                 FlashKind::Error => self.view.theme.cursor_bg,
             };
             let line = Line::from(Span::styled(

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -885,6 +885,32 @@ impl AppState {
         });
     }
 
+    /// Announce work that is starting, to be replaced or cleared when it lands.
+    ///
+    /// A flash has no lifetime of its own — it shows until something else
+    /// replaces it — so an in-flight message left behind by a completion that had
+    /// nothing to say goes on claiming the work is still running.
+    pub fn flash_progress<S: Into<String>>(&mut self, text: S) {
+        self.flash = Some(FlashMessage {
+            text: text.into(),
+            kind: FlashKind::Progress,
+        });
+    }
+
+    /// Drop an in-flight message now that its operation has finished.
+    ///
+    /// Only ever clears a [`FlashKind::Progress`], so a real message that landed
+    /// in the meantime — a warning about the archive, an error — survives.
+    pub fn clear_progress_flash(&mut self) {
+        if self
+            .flash
+            .as_ref()
+            .is_some_and(|f| matches!(f.kind, FlashKind::Progress))
+        {
+            self.flash = None;
+        }
+    }
+
     /// Flash the outcome of a "save pane contents to file" action: the
     /// saved file's basename on success, the error text on failure. Shared
     /// by the two pane-scrollback save handlers (the `PaneScrollSave` action

--- a/src/app/state/tests/mod.rs
+++ b/src/app/state/tests/mod.rs
@@ -461,6 +461,47 @@ fn flash_error_sets_message() {
 }
 
 #[test]
+fn flash_progress_sets_message() {
+    let mut s = test_state();
+    s.flash_progress("reading pkg.zip…");
+    let flash = s.flash.as_ref().unwrap();
+    assert_eq!(flash.text, "reading pkg.zip…");
+    assert!(matches!(flash.kind, FlashKind::Progress));
+}
+
+/// The clear is narrow on purpose: an in-flight message goes when its work
+/// finishes, but a real message that landed meanwhile is what the user needs to
+/// read, so it stays.
+#[test]
+fn clearing_progress_leaves_a_real_message_alone() {
+    let mut s = test_state();
+
+    s.flash_progress("reading pkg.zip…");
+    s.clear_progress_flash();
+    assert!(s.flash.is_none(), "an in-flight message goes");
+
+    s.flash_info("1 member(s) differ only by case");
+    s.clear_progress_flash();
+    assert_eq!(
+        s.flash.as_ref().map(|f| f.text.clone()),
+        Some("1 member(s) differ only by case".to_string()),
+        "a note stays"
+    );
+
+    s.flash_error("could not read it");
+    s.clear_progress_flash();
+    assert_eq!(
+        s.flash.as_ref().map(|f| f.text.clone()),
+        Some("could not read it".to_string()),
+        "an error stays"
+    );
+
+    s.flash = None;
+    s.clear_progress_flash();
+    assert!(s.flash.is_none(), "and clearing nothing is fine");
+}
+
+#[test]
 fn flash_saved_file_reports_basename_on_success() {
     let mut s = test_state();
     s.flash_saved_file(Ok(std::path::PathBuf::from("/tmp/foo/spyc_pane_x.txt")));


### PR DESCRIPTION
> this status message also hangs around when it should maybe just say read instead of reading — because it's confusing (makes you think more is about to happen)

## What was wrong

`FlashMessage` has no TTL: a flash shows until something else replaces it. The mount arm only flashes when the archive had something worth warning about, so a clean mount replaced nothing and the in-flight message stayed put. Verified before fixing:

```
flash right after request_mount = Some("reading pkg.zip…")
flash after the mount landed    = Some("reading pkg.zip…")
```

## The fix

Rather than rewording it to "read", the message goes when its work does — a message that describes finished work is still noise, just quieter.

`FlashKind::Progress` marks a flash as naming work in flight, and `clear_progress_flash` drops one once it lands. It renders identically to `Info`; the difference is how long it lives, not how it looks, so this isn't a change to the UI language.

The clear sits at the top of `apply_one_archive_outcome` rather than in each arm — any outcome means the op being announced is over, and the arm that leaked was precisely the one with nothing to report. A new outcome arm can't forget it.

It only ever clears a `Progress`, so a real message that arrived meanwhile survives. That mattered more than the fix itself: a clear that swallowed the archive's warning would be worse than a stale message, so it's tested in both directions.

Archive's three in-flight messages — `reading …`, `extracting N member(s)…`, `writing …` — are relabelled. The graveyard and pane ones are left alone; those are already replaced by their own completion messages.

## Verification

Removing the clear reproduces your report exactly:

```
the_reading_message_goes_once_the_archive_is_mounted ... FAILED
  left: Some("reading pkg.zip…")
 right: None
```

Guards that the clear stays narrow: a case-colliding zip still shows `1 member(s) differ only by case`, and a corrupt zip still shows its error with the cause intact.

Two fixture notes worth recording, both of which had me briefly believing the fix was broken when the tests were:

- `ZipWriter` **refuses** duplicate filenames (`InvalidArchive("Duplicate filename")`), so the obvious "duplicate member" fixture can't be built at all — which is why the read-only test constructs its `Capability` by hand. Case collisions are the writable equivalent.
- The corrupt-zip error text *contains the word "reading"* (`reading zip <path>: invalid Zip archive: Could not find EOCD`), because the anyhow context chain says so. Asserting on the wording would have been a false negative; the assertion is on the kind, plus that the cause survives.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)
