### PR TITLE
feat(git): mark the main worktree in the W l picker, and tilde-collapse its paths

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -358,7 +358,12 @@ spyc's workflow: browse files above, talk to Claude below.
 - **W l** opens a **worktree picker** — `j`/`k` (or arrows) move the
   highlighted row, `Enter` switches the *focused* column to it, `/`
   searches (the cursor lands on the match), and `1`-`9` quick-switch by
-  number (focus `b` first to put a worktree there). With the MCP tools
+  number (focus `b` first to put a worktree there). Rows list the main
+  worktree first (git's ordering), each showing the branch checked out
+  in it; the main one is marked **`(main worktree)`** and the one the
+  focused column is in `← current`. The marker is what tells you which
+  row is your git home when a feature branch is checked out there
+  directly — the branch column can't. With the MCP tools
   (`create_worktree` / `open_worktree` /
   `remove_worktree` / `clean_worktree`) an agent can spin up a worktree,
   open it in `b`, work, and tear it down — while `a` stays on the main

--- a/src/app/git_state.rs
+++ b/src/app/git_state.rs
@@ -281,13 +281,17 @@ impl App {
 /// sits in. The branch column names whatever is checked out there, so without
 /// the main marker a main worktree holding a feature branch reads exactly like a
 /// linked one — and then "where do I switch back to?" has no answer on screen.
+///
+/// The path is tilde-collapsed like every other user-facing path display; the
+/// switch target comes from `state.pending_worktrees`, which keeps the real
+/// absolute paths, so shortening the label can't misdirect a jump.
 fn worktree_row(i: usize, wt: &crate::git::worktree::Worktree, cur_dir: &Path) -> String {
     format!(
         "  [{}]  {:<30} {:>8}  {}{}{}",
         i + 1,
         wt.branch,
         wt.head,
-        wt.path.display(),
+        crate::paths::display_tilde(&wt.path),
         if wt.primary { " (main worktree)" } else { "" },
         if wt.path == cur_dir {
             " ← current"
@@ -379,6 +383,32 @@ mod tests {
         assert!(
             !row.contains("(main worktree)"),
             "a bare repo has no main worktree: {row}"
+        );
+    }
+
+    /// Paths under `$HOME` collapse to `~/…` like every other user-facing path
+    /// display (DESIGN.md), and the markers still land after the shortened path.
+    #[test]
+    fn row_path_is_tilde_collapsed() {
+        let Some(home) = std::env::var_os("HOME") else {
+            return;
+        };
+        let home = home.to_string_lossy().trim_end_matches('/').to_string();
+        let path = format!("{home}/src/proj");
+        let row = super::worktree_row(0, &wt(&path, "fold-rule-8", true), Path::new(&path));
+        assert!(
+            row.contains("~/src/proj (main worktree) ← current"),
+            "path should be tilde-collapsed with markers intact: {row}"
+        );
+        assert!(!row.contains(&home), "absolute home prefix leaked: {row}");
+    }
+
+    #[test]
+    fn row_path_outside_home_is_left_absolute() {
+        let row = super::worktree_row(0, &wt("/srv/checkout", "main", true), Path::new("/nope"));
+        assert!(
+            row.contains("/srv/checkout"),
+            "a non-home path stays as-is: {row}"
         );
     }
 

--- a/src/app/git_state.rs
+++ b/src/app/git_state.rs
@@ -254,21 +254,7 @@ impl App {
                 let lines: Vec<String> = worktrees
                     .iter()
                     .enumerate()
-                    .map(|(i, wt)| {
-                        let current = if wt.path == cur_dir {
-                            " ← current"
-                        } else {
-                            ""
-                        };
-                        format!(
-                            "  [{}]  {:<30} {:>8}  {}{}",
-                            i + 1,
-                            wt.branch,
-                            wt.head,
-                            wt.path.display(),
-                            current,
-                        )
-                    })
+                    .map(|(i, wt)| worktree_row(i, wt, &cur_dir))
                     .collect();
                 let mut view = pager::PagerView::new_plain(
                     "git worktrees — j/k+Enter or 1-9 to switch, / to search, q to close",
@@ -288,6 +274,27 @@ impl App {
                 .flash_error("not in a git repository (or no worktrees)"),
         }
     }
+}
+
+/// One `W l` picker row: `[n]  branch  head  path`, marked ` (main worktree)`
+/// for the repo's main checkout and ` ← current` for the one the focused column
+/// sits in. The branch column names whatever is checked out there, so without
+/// the main marker a main worktree holding a feature branch reads exactly like a
+/// linked one — and then "where do I switch back to?" has no answer on screen.
+fn worktree_row(i: usize, wt: &crate::git::worktree::Worktree, cur_dir: &Path) -> String {
+    format!(
+        "  [{}]  {:<30} {:>8}  {}{}{}",
+        i + 1,
+        wt.branch,
+        wt.head,
+        wt.path.display(),
+        if wt.primary { " (main worktree)" } else { "" },
+        if wt.path == cur_dir {
+            " ← current"
+        } else {
+            ""
+        },
+    )
 }
 
 /// Relativize an absolute `path` to a repo-relative, forward-slash path under
@@ -326,6 +333,61 @@ mod tests {
         assert_eq!(
             repo_relative(Path::new("/home/u/proj/README.md"), root).as_deref(),
             Some("README.md")
+        );
+    }
+
+    fn wt(path: &str, branch: &str, primary: bool) -> crate::git::worktree::Worktree {
+        crate::git::worktree::Worktree {
+            path: std::path::PathBuf::from(path),
+            head: "abc1234".to_string(),
+            branch: branch.to_string(),
+            primary,
+        }
+    }
+
+    /// The whole point of the marker: the main worktree is identifiable even
+    /// when the branch checked out in it isn't the default one.
+    #[test]
+    fn main_worktree_row_is_marked_whatever_branch_it_holds() {
+        let row = super::worktree_row(0, &wt("/src/proj", "fold-rule-8", true), Path::new("/nope"));
+        assert!(
+            row.contains("(main worktree)"),
+            "main worktree row must say so: {row}"
+        );
+        assert!(row.contains("fold-rule-8"), "branch still shown: {row}");
+    }
+
+    #[test]
+    fn linked_worktree_row_is_not_marked_main() {
+        let row = super::worktree_row(
+            1,
+            &wt("/src/proj.worktrees/feat", "feat", false),
+            Path::new("/nope"),
+        );
+        assert!(
+            !row.contains("(main worktree)"),
+            "a linked worktree is not the main one: {row}"
+        );
+    }
+
+    /// A bare repo has no working tree to mark, and its row already reads
+    /// `(bare)` — so the marker must not claim otherwise.
+    #[test]
+    fn bare_repo_row_is_not_marked_main() {
+        let row = super::worktree_row(0, &wt("/src/proj.git", "(bare)", false), Path::new("/nope"));
+        assert!(row.contains("(bare)"), "bare label kept: {row}");
+        assert!(
+            !row.contains("(main worktree)"),
+            "a bare repo has no main worktree: {row}"
+        );
+    }
+
+    #[test]
+    fn both_markers_appear_when_the_user_is_in_the_main_worktree() {
+        let row = super::worktree_row(0, &wt("/src/proj", "main", true), Path::new("/src/proj"));
+        assert!(
+            row.ends_with("(main worktree) ← current"),
+            "main marker precedes the current marker: {row}"
         );
     }
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -33,6 +33,12 @@ pub struct Worktree {
     pub head: String,
     /// Branch name, "(detached)", or "(bare)".
     pub branch: String,
+    /// The repo's MAIN worktree (git's term) — the checkout at the common dir,
+    /// not a linked one. The `branch` column names whatever is checked out
+    /// there, so this is the only thing that identifies the main worktree once
+    /// it holds a feature branch. False for a bare repo's entry: it has no
+    /// working tree at all, and its row already reads `(bare)`.
+    pub primary: bool,
 }
 
 /// Short-7 commit prefix for a repo's HEAD, or empty if HEAD can't resolve
@@ -80,6 +86,7 @@ pub fn list(dir: &Path) -> Option<Vec<Worktree>> {
             path: workdir,
             head: head_short(&main),
             branch: head_branch_label(&main),
+            primary: true,
         }),
         // Bare repo: no main working tree, but git still lists the bare
         // entry first. Keep the "(bare)" label the callers expect.
@@ -87,6 +94,7 @@ pub fn list(dir: &Path) -> Option<Vec<Worktree>> {
             path: common_dir,
             head: head_short(&repo),
             branch: "(bare)".to_string(),
+            primary: false,
         }),
     }
 
@@ -101,7 +109,12 @@ pub fn list(dir: &Path) -> Option<Vec<Worktree>> {
             Ok(wt_repo) => (head_short(&wt_repo), head_branch_label(&wt_repo)),
             Err(_) => (String::new(), "(detached)".to_string()),
         };
-        worktrees.push(Worktree { path, head, branch });
+        worktrees.push(Worktree {
+            path,
+            head,
+            branch,
+            primary: false,
+        });
     }
 
     if worktrees.is_empty() {
@@ -932,6 +945,31 @@ mod tests {
             paths, main_paths,
             "listing must be identical whether opened from main or a linked worktree"
         );
+    }
+
+    #[test]
+    fn only_the_main_worktree_is_flagged_primary() {
+        let (_tmp, main) = init_repo();
+        let target = add(&main, "feature", None).expect("add");
+
+        // From either vantage point exactly one entry — the main worktree — is
+        // primary. The `W l` picker's "(main worktree)" marker rides this flag,
+        // and it's the only thing naming the main checkout once a feature branch
+        // is checked out there, so a linked worktree wearing it would send the
+        // user to the wrong dir.
+        for from in [&main, &target] {
+            let listed = list(from).expect("list");
+            let flagged: Vec<_> = listed
+                .iter()
+                .filter(|w| w.primary)
+                .map(|w| w.path.clone())
+                .collect();
+            assert_eq!(
+                flagged,
+                vec![main.clone()],
+                "listing from {from:?} should flag only the main worktree"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Two commits, one per shape — the changelog gets a `feat` line and a `fix` line.

## 1. `feat(git)`: mark the main worktree

`W l`'s branch column names whatever is checked out in each worktree, so a **main worktree holding a feature branch reads exactly like a linked one** — and "which row is my git home?" has no answer on screen.

Found by hand-driving a repo whose primary checkout sits on a feature branch with **no linked worktrees at all**: the list showed a single row, `[1] fold-rule-8 … ← current`, which is git-correct (one working tree) but gave no sign that this *was* the main checkout.

Distinct from `96a558a` ("list main worktree from the common dir"), which fixed main *going missing* when listing from inside a linked worktree. That one's intact and still guarded; this is the labelling gap it leaves behind.

- `git::worktree::Worktree` gains `primary`, set only for the checkout at the repo's common dir. A bare repo's entry stays unflagged — no working tree, and its row already reads `(bare)`.
- The row renders it as `(main worktree)`, ahead of the existing `← current`.
- Row formatting moves out of the closure into `worktree_row` so the markers are testable without a repo on disk.

## 2. `fix(git)`: tilde-collapse the paths

DESIGN.md says every user-facing path display goes through `paths::display_tilde`; these rows printed raw absolute paths, so the home prefix ate width the branch and markers need. Display only — `Enter` / `1`-`9` switch via `state.pending_worktrees`, which keeps the absolute paths, so a shortened label can't misdirect a jump. Paths outside `$HOME` are untouched, and MCP output stays absolute (DESIGN.md exempts it).

Together:

```
  [1]  fold-rule-8       c0350bd  ~/src/trippane (main worktree) ← current
  [2]  feat/x            abc1234  ~/src/trippane.worktrees/feat/x
```

## Tests

- `only_the_main_worktree_is_flagged_primary` — real repo + linked worktree, listed from **both** vantage points; exactly one entry flagged, and it's main.
- Six `worktree_row` unit tests: marked whatever branch main holds, linked not marked, bare not marked, marker ordering `(main worktree) ← current`, `$HOME` collapsed with markers intact, non-home path left absolute.

`make check-ci` → `=== GATE: PASS ===` on both commits.

## Not in scope

An entry that switches the primary checkout *back to* `main` — that's a branch checkout, not a worktree switch (same path you're standing in, and it can fail on a dirty tree). Separate design call.