### PR TITLE
fix(mcp): the worktree tools anchor on the project, not on an open archive

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -544,7 +544,10 @@ they land in a session-scoped staging dir that is cleaned up on exit.
   inside a mount, reading the container in memory (or your not-yet-written edit,
   if there is one), so asking the agent in the pane about the file you're looking
   at works in here as well. `search_content` / `search_paths` say why they can't
-  instead of reporting "no matches" from walking a single binary file.
+  instead of reporting "no matches" from walking a single binary file. The
+  worktree tools keep working too: they anchor on the project rather than on the
+  container, so an agent can still set up and tear down worktrees while you read a
+  tarball.
 - **`:archive`** — `info` (this mount, or what's mounted when you're outside one),
   `list` (every mounted archive, dirty ones marked), `write` / `discard`,
   `unmount` (drop it and its staged bytes), `cancel`. `write` and `discard` work

--- a/src/app/harness_tests/mcp.rs
+++ b/src/app/harness_tests/mcp.rs
@@ -317,6 +317,40 @@ fn worktree_arg_empty_errors_and_relative_resolves_against_cwd() {
             base.join("sub"),
             "relative path resolved against the focused column's cwd"
         );
+
+        // Inside an archive that cwd is the container *file's* path, so joining
+        // onto it would name a worktree inside a tarball. The project root is
+        // what a relative worktree path means there.
+        let archive = base.join("pkg.tar.gz");
+        let mut b = crate::archive::index::IndexBuilder::new(10);
+        b.push(
+            "member.txt",
+            crate::archive::index::Draft::file(1, crate::archive::index::Locator::Staged),
+        );
+        let (index, _) = b.finish(archive.clone(), crate::archive::ArchiveFormat::TarGz, 10);
+        app.state.mounts.insert(
+            crate::archive::ArchiveMount {
+                index,
+                journal: crate::archive::Journal::default(),
+                staged: crate::archive::journal::StagedStats::new(),
+                capability: crate::archive::Capability::ReadWrite,
+                warnings: Vec::new(),
+                staging_root: base.join("staging"),
+                last_used: 0,
+                depth: 0,
+                editing: Vec::new(),
+            },
+            &[],
+        );
+        app.state.project_home = Some(base.clone());
+        app.state.left.git_cache.current_repo_root = None;
+        app.state.left.listing.dir = archive;
+        assert_eq!(
+            app.resolve_worktree_arg("sub")
+                .expect("relative path still resolves"),
+            base.join("sub"),
+            "not a path inside the container"
+        );
     });
 }
 
@@ -622,6 +656,79 @@ fn wait_for_scope_clear_times_out_when_conflict_persists() {
         match rx.try_recv().expect("timed_out reply") {
             McpResponse::Ok { message } => assert!(message.contains("timed_out")),
             McpResponse::Error { message } => panic!("unexpected error: {message}"),
+        }
+    });
+}
+
+/// A live archive mount used to take every worktree tool down with it: the
+/// focused column's dir becomes the container *file's* path, and git discovery
+/// from there fails with `path is not a directory`. Browsing a tarball is no
+/// reason to lose `create_worktree`.
+#[test]
+fn mcp_create_worktree_works_while_the_column_is_inside_an_archive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let run_git = |dir: &std::path::Path, args: &[&str]| {
+        crate::git::test_support::run_git(dir, args);
+    };
+    crate::state::with_state_root(tmp.path(), || {
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let repo = root.join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "--initial-branch=main"]);
+        std::fs::write(repo.join("f.txt"), "v1\n").unwrap();
+        run_git(&repo, &["add", "f.txt"]);
+        run_git(&repo, &["commit", "-q", "-m", "v1"]);
+
+        let mut app = App::test_app(repo.clone());
+        app.state.update_repo_root(state::Side::Left, &repo);
+        app.state.project_home = Some(repo.clone());
+
+        // Stand the column inside an archive that lives *outside* the repo — the
+        // shape that broke: `~/src/pkg.tar.gz` while the project is `~/src/spyc`.
+        let archive = root.join("pkg.tar.gz");
+        let mut b = crate::archive::index::IndexBuilder::new(10);
+        b.push(
+            "sub/a.txt",
+            crate::archive::index::Draft::file(1, crate::archive::index::Locator::Staged),
+        );
+        let (index, _) = b.finish(archive.clone(), crate::archive::ArchiveFormat::TarGz, 10);
+        app.state.mounts.insert(
+            crate::archive::ArchiveMount {
+                index,
+                journal: crate::archive::Journal::default(),
+                staged: crate::archive::journal::StagedStats::new(),
+                capability: crate::archive::Capability::ReadWrite,
+                warnings: Vec::new(),
+                staging_root: root.join("staging"),
+                last_used: 0,
+                depth: 0,
+                editing: Vec::new(),
+            },
+            &[],
+        );
+        // A mount clears the column's git state, exactly as entering one does.
+        app.state.left.git_cache.current_repo_root = None;
+        app.state.left.listing.dir = archive.clone();
+        assert!(
+            !archive.is_dir(),
+            "the premise: the column is somewhere that is not a directory"
+        );
+
+        let resp = app.execute_mcp_command(crate::mcp_cmd::McpCommand::CreateWorktree {
+            branch: "from-inside-a-mount".to_string(),
+            base: None,
+            open: false,
+        });
+        match resp {
+            crate::mcp_cmd::McpResponse::Ok { message } => {
+                let v: serde_json::Value = serde_json::from_str(&message).unwrap();
+                let path = std::path::PathBuf::from(v["path"].as_str().unwrap());
+                assert!(path.is_dir(), "worktree dir created: {path:?}");
+                assert!(path.join("f.txt").exists(), "off the project's repo");
+            }
+            crate::mcp_cmd::McpResponse::Error { message } => {
+                panic!("create_worktree from inside a mount errored: {message}")
+            }
         }
     });
 }

--- a/src/app/mcp.rs
+++ b/src/app/mcp.rs
@@ -299,7 +299,10 @@ impl App {
         }
         let raw = std::path::PathBuf::from(path);
         let target = if raw.is_relative() {
-            self.state.cur().listing.dir.join(&raw)
+            // Not the raw column dir: inside an archive mount that is a path
+            // *within the container*, so a relative worktree path would resolve
+            // to somewhere that cannot exist.
+            self.state.worktree_anchor().join(&raw)
         } else {
             raw
         };
@@ -440,7 +443,7 @@ impl App {
                 }
                 let raw = std::path::PathBuf::from(path);
                 let target = if raw.is_relative() {
-                    self.state.cur().listing.dir.join(&raw)
+                    self.state.worktree_anchor().join(&raw)
                 } else {
                     raw
                 };

--- a/src/app/state/mod.rs
+++ b/src/app/state/mod.rs
@@ -855,6 +855,29 @@ impl AppState {
             .unwrap_or_else(|| self.col(side).listing.dir.clone())
     }
 
+    /// The directory a **worktree** operation anchors on: normally the focused
+    /// column's own dir, but the repo/project root when that dir is a place with
+    /// no directory behind it.
+    ///
+    /// Inside an archive mount the column's dir is the *container file's* path —
+    /// `~/src/pkg.tar.gz` — and git discovery from there fails outright
+    /// (`path is not a directory`), taking every worktree tool down with it while
+    /// the user browses an archive. A worktree op is about the repo, not about
+    /// where the cursor happens to be resting, so the mount case falls back to
+    /// [`Self::tool_root`]; a mount clears the column's git state, so that
+    /// resolves to `PROJECT_HOME` — the project the user is working on.
+    ///
+    /// Asked of the mount registry rather than by stat'ing the path: the Model
+    /// already knows which paths are virtual, and it can answer without IO.
+    pub fn worktree_anchor(&self) -> std::path::PathBuf {
+        let dir = &self.cur().listing.dir;
+        if self.mounts.contains(dir) {
+            self.tool_root(self.focused_side())
+        } else {
+            dir.clone()
+        }
+    }
+
     /// The anchor a column's **harpoon** list keys off: its worktree root when
     /// in a repo, else `PROJECT_HOME`. Unlike [`Self::tool_root`] there is *no*
     /// listing-dir fallback — harpoon stays disabled (`None`) outside a repo

--- a/src/app/state/tests/mod.rs
+++ b/src/app/state/tests/mod.rs
@@ -1023,6 +1023,63 @@ fn tool_root_prefers_worktree_then_project_home_then_listing() {
     assert_eq!(s.tool_root(Side::Left), PathBuf::from("/repo/a"));
 }
 
+/// A worktree op anchors on the column's dir normally, but that dir is the
+/// container *file's* path while the user is inside an archive — git discovery
+/// from there fails with "path is not a directory", which took out every worktree
+/// tool for as long as an archive was open. A worktree op is about the repo, so
+/// the mount case falls back to the repo/project root.
+#[test]
+fn worktree_anchor_leaves_a_mount_for_the_project_root() {
+    use crate::app::state::Side;
+    let mut s = test_state();
+    let archive = PathBuf::from("/src/pkg.tar.gz");
+    s.left.listing.dir = PathBuf::from("/src");
+    s.project_home = Some(PathBuf::from("/src/spyc"));
+    s.left.git_cache.current_repo_root = None;
+
+    // Outside a mount the column's own dir is the anchor, untouched.
+    assert_eq!(s.worktree_anchor(), PathBuf::from("/src"));
+
+    // Register a mount and stand inside it: the archive's own path, and then a
+    // directory within it — neither is a place git can be discovered from.
+    let mut b = crate::archive::index::IndexBuilder::new(10);
+    b.push(
+        "sub/a.txt",
+        crate::archive::index::Draft::file(1, crate::archive::index::Locator::Zip { index: 0 }),
+    );
+    let (index, _) = b.finish(archive.clone(), crate::archive::ArchiveFormat::TarGz, 10);
+    s.mounts.insert(
+        crate::archive::ArchiveMount {
+            index,
+            journal: crate::archive::Journal::default(),
+            staged: crate::archive::journal::StagedStats::new(),
+            capability: crate::archive::Capability::ReadWrite,
+            warnings: Vec::new(),
+            staging_root: PathBuf::from("/staging"),
+            last_used: 0,
+            depth: 0,
+            editing: Vec::new(),
+        },
+        &[],
+    );
+
+    for inside in [archive.clone(), archive.join("sub")] {
+        s.left.listing.dir = inside.clone();
+        assert_eq!(
+            s.worktree_anchor(),
+            PathBuf::from("/src/spyc"),
+            "a column at {} anchors on the project, not on the container",
+            inside.display()
+        );
+    }
+
+    // A mount clears the column's git state, but if a repo root is known it wins
+    // over PROJECT_HOME — same precedence as `tool_root`.
+    s.left.git_cache.current_repo_root = Some(PathBuf::from("/src/other-repo"));
+    assert_eq!(s.worktree_anchor(), PathBuf::from("/src/other-repo"));
+    assert_eq!(s.tool_root(Side::Left), s.worktree_anchor());
+}
+
 /// `harpoon_root` deliberately DROPS tool_root's listing-dir fallback: outside a
 /// repo with no PROJECT_HOME it returns `None` (harpoon disabled) rather than
 /// spawning a per-dir bookmark file. The `None` arm is what distinguishes it

--- a/src/app/worktree_ops.rs
+++ b/src/app/worktree_ops.rs
@@ -37,7 +37,8 @@ use super::{App, Message};
 /// validated). Built by [`App::plan_worktree_job`] on the main loop.
 pub enum WorktreeJob {
     /// `create_worktree`: add a worktree for `branch`, discovering the repo from
-    /// `dir` (the focused column's listing dir).
+    /// `dir` ([`crate::app::state::AppState::worktree_anchor`] — the focused
+    /// column's dir, or the project root when that column is inside an archive).
     Create {
         dir: std::path::PathBuf,
         branch: String,
@@ -208,9 +209,10 @@ impl App {
                 } else {
                     // Anchor on the FOCUSED column's repo (consistent with `W n`):
                     // `worktree::add` discovers the enclosing repo from any dir
-                    // inside it.
+                    // inside it — so the anchor has to *be* a directory, which a
+                    // column inside an archive mount is not.
                     Ok(WorktreeJob::Create {
-                        dir: self.state.cur().listing.dir.clone(),
+                        dir: self.state.worktree_anchor(),
                         branch: branch.to_string(),
                         // Caller's explicit `base` override, else PROJECT_HOME's
                         // default branch (POLA: not whatever the focused column

--- a/src/mcp/readers.rs
+++ b/src/mcp/readers.rs
@@ -394,11 +394,17 @@ pub(super) fn read_context_or_empty(ctx_path: &Path) -> String {
 /// can't be resolved — a bare/unborn entry, or a repo with no base branch),
 /// and `locked`/`lock_reason` (the `claim_worktree` lease — a cooperating
 /// session's `remove`/`clean` refuses a locked worktree).
-/// Runs on the socket thread — pure git + the context file's cwd, no `App`.
+/// Runs on the socket thread — pure git + the context file, no `App`.
 /// Returns `[]` outside a repo. (Column-`b` flags still need context the
 /// snapshot doesn't yet expose.)
+///
+/// Anchored on `search_root` (the focused column's worktree root) rather than the
+/// raw `cwd`, matching every other read tool. The two agree whenever the cursor is
+/// in a repo; where they differ, `cwd` is the worse answer — inside an archive
+/// mount it is the container *file's* path, which discovers no repo, so listing
+/// the worktrees of the project came back as an empty set rather than as an error.
 pub(super) fn list_worktrees_json(ctx_path: &Path) -> String {
-    list_worktrees_json_at(&read_cwd_from_context(ctx_path))
+    list_worktrees_json_at(&search_root(ctx_path))
 }
 
 /// Root-based core of [`list_worktrees_json`]: the same worktree inventory, but
@@ -463,7 +469,9 @@ fn resolve_worktree_path(ctx_path: &Path, path_arg: &str) -> PathBuf {
     if raw.is_absolute() {
         raw
     } else {
-        read_cwd_from_context(ctx_path).join(raw)
+        // `search_root`, not the raw cwd: inside an archive that cwd is the
+        // container file's path, and a worktree is never inside one.
+        search_root(ctx_path).join(raw)
     }
 }
 
@@ -698,6 +706,47 @@ fn hunk_header(h: &Hunk) -> String {
 mod tests {
     use super::*;
     use crate::git::test_support::run_git;
+
+    /// While a column is inside an archive the context's `cwd` is the container
+    /// *file's* path, which discovers no repo — so the worktree inventory came
+    /// back as `[]`, reading as "this project has no worktrees" rather than as a
+    /// failure. `search_root` still names the repo, so it is what this anchors on.
+    #[test]
+    fn the_inventory_survives_a_cwd_inside_an_archive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(tmp.path()).unwrap();
+        let repo = root.join("repo");
+        std::fs::create_dir(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "--initial-branch=main"]);
+        std::fs::write(repo.join("a.txt"), "a\n").unwrap();
+        run_git(&repo, &["add", "."]);
+        run_git(&repo, &["commit", "-q", "-m", "c1"]);
+
+        // The cursor is inside a tarball that isn't even in the repo.
+        let inside = root.join("pkg.tar.gz").join("sub");
+        let ctx = tmp.path().join("ctx.json");
+        std::fs::write(
+            &ctx,
+            json!({
+                "cwd": inside.display().to_string(),
+                "search_root": repo.display().to_string(),
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            list_worktrees_json_at(&inside),
+            "[]",
+            "the premise: nothing is discoverable from a path inside a container"
+        );
+        let v: Value = serde_json::from_str(&list_worktrees_json(&ctx)).unwrap();
+        assert_eq!(
+            v.as_array().map(Vec::len),
+            Some(1),
+            "but the project's own worktree is still listed: {v}"
+        );
+    }
 
     #[test]
     fn reports_inventory_dirty_and_current() {


### PR DESCRIPTION
Found while setting up the worktree for #337 — the MCP tool refused because a column was sitting inside the fika tarball:

```
worktree add: open repo: Failed to access a directory, or path is not a directory:
  '/Users/derekmarshall/src/fika-reporting-etg-2026-06-03.tar.gz'
```

## What was wrong

A mount is an index, not a directory, so the focused column's dir is the container **file's** path. Every worktree tool anchored on that dir (or on the context file's raw `cwd`), and git discovery from a non-directory fails.

`list_worktrees` failed **worse — silently**. `worktree::list` on a path with no repo behind it returns `None`, so the inventory came back `[]`. That reads as *"this project has no worktrees"*, which is a wrong answer rather than an error.

## The fix

A worktree op is about the repo, not about where the cursor happens to be resting. `AppState::worktree_anchor` returns the column's own dir normally, and the repo/project root when that column is inside a mount.

It asks the **mount registry** rather than stat'ing the path — the Model already knows which paths are virtual, and can answer without IO, which keeps it out of the no-OS-in-the-Model rule. A mount clears the column's git state, so the fallback lands on `PROJECT_HOME`: the project the user is working on, which is what "make me a worktree" means while they're reading an unrelated tarball.

**Five sites, not the one that was reported.** Having found the family I fixed the family, since a half-fixed one is worse than a documented whole:

| site | tool | before |
|---|---|---|
| `worktree_ops.rs` | `create_worktree` | loud error |
| `readers.rs` | `list_worktrees` | silent `[]` |
| `mcp.rs` | `remove` / `clean` relative path | joined into the container |
| `mcp.rs` | `open_worktree` relative path | joined into the container |
| `readers.rs` | `claim` / `release` relative path | joined into the container |

`list_worktrees` and the claim/release resolve move from the raw `cwd` to `search_root`, which is what every other read tool already uses — the two agree whenever the cursor is in a repo, and where they differ `cwd` is the worse answer.

`get_file_content` deliberately keeps using `cwd`: it is already mount-aware and *wants* the container, so it's left alone.

## Verification

Each was checked to bite. Reverting the create fix reproduces the reported string verbatim:

```
create_worktree from inside a mount errored: worktree add: open repo:
  Failed to access a directory, or path is not a directory: '.../pkg.tar.gz'
```

and reverting the list fix reproduces the silent empty inventory:

```
assertion `left == right` failed: but the project's own worktree is still listed: []
```

Three tests: the pure `worktree_anchor` decision (both arms, plus that it agrees with `tool_root` when a repo root is known), `create_worktree` end-to-end against a real repo with the column parked inside a mount, and `list_worktrees` with a `cwd` inside a container. The list test asserts its own premise first — `list_worktrees_json_at(inside) == "[]"` — so it can't pass vacuously.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)
