### PR TITLE
fix(archive): a declared size is a claim, so stop spending on it

### DIFF
--- a/src/archive/read/mod.rs
+++ b/src/archive/read/mod.rs
@@ -158,20 +158,28 @@ pub fn stream_mount(
         let (name, draft) = tar_draft(&entry, Locator::Staged, &mut builder.facts);
         let Some(draft) = draft else { continue };
         if let Ok(clean) = normalize(&name) {
-            written = written.saturating_add(draft.size);
+            // Budgeted on bytes that actually arrive, not on what the header
+            // claims. A tar header's size field is attacker input: declaring 0
+            // and then streaming gigabytes used to walk straight past this gate,
+            // because the gate added up the declarations. `write_member` reports
+            // what it really wrote and stops at the remaining allowance, so a
+            // member can overshoot by at most one byte before this fires.
+            let allowance = budget.saturating_sub(written);
+            let wrote = write_member(
+                &mut entry,
+                &draft,
+                &clean.inner,
+                staging_root,
+                allowance,
+                &mut builder.facts,
+            )?;
+            written = written.saturating_add(wrote);
             if written > budget {
                 bail!(
                     "over the {} extract budget — raise [archive] extract_budget_mb to mount it",
                     crate::fs::ops::format_size(budget)
                 );
             }
-            write_member(
-                &mut entry,
-                &draft,
-                &clean.inner,
-                staging_root,
-                &mut builder.facts,
-            )?;
         }
         if !builder.push(&name, draft) {
             break;
@@ -227,7 +235,17 @@ pub fn restage_missing(
         if staging_root.join(&clean.inner).exists() {
             continue;
         }
-        write_member(&mut entry, &draft, &clean.inner, staging_root, &mut facts)?;
+        // Refilling a member that was already admitted at mount time — the
+        // budget was spent then, so there is no allowance left to re-charge it
+        // against.
+        write_member(
+            &mut entry,
+            &draft,
+            &clean.inner,
+            staging_root,
+            u64::MAX,
+            &mut facts,
+        )?;
         restored += 1;
     }
     Ok(restored)
@@ -239,16 +257,21 @@ pub fn restage_missing(
 /// counted and skipped rather than written — see [`contained_dest`]. Skipping is
 /// not an error: one hostile member must not abandon the mount, and the count is
 /// what makes the refusal visible in the mount's warnings.
+/// Returns how many bytes actually reached disk, which is what the caller's
+/// extract budget is measured in — a header's declared size is a claim, not a
+/// measurement. Reads at most `allowance + 1` bytes so the caller can tell "fit"
+/// from "overshot" without the overshoot itself being unbounded.
 fn write_member<R: Read>(
     entry: &mut tar::Entry<'_, R>,
     draft: &Draft,
     inner: &str,
     staging_root: &Path,
+    allowance: u64,
     facts: &mut IndexFacts,
-) -> Result<()> {
+) -> Result<u64> {
     let Ok(dest) = contained_dest(staging_root, inner) else {
         facts.link_traversals += 1;
-        return Ok(());
+        return Ok(0);
     };
     match draft.kind {
         ArchiveEntryKind::Dir => {
@@ -271,13 +294,16 @@ fn write_member<R: Read>(
             create_parent(&dest)?;
             let mut out =
                 File::create(&dest).with_context(|| format!("writing {}", dest.display()))?;
-            std::io::copy(entry, &mut out)
+            // One byte past the allowance: enough for the caller to see the
+            // budget was exceeded, without copying the rest of a bomb to find out.
+            let wrote = std::io::copy(&mut entry.take(allowance.saturating_add(1)), &mut out)
                 .with_context(|| format!("writing {}", dest.display()))?;
             out.flush()?;
             apply_mode(&dest, draft.mode);
+            return Ok(wrote);
         }
     }
-    Ok(())
+    Ok(0)
 }
 
 /// Extract one member's bytes into the staging tree and return where they
@@ -356,11 +382,25 @@ pub fn member_bytes(archive: &Path, entry: &IndexEntry) -> Result<Vec<u8>> {
     }
 }
 
+/// How much of a declared size we are willing to reserve before seeing a byte.
+///
+/// A container's size field is attacker input. Handing it to `with_capacity` is
+/// how a 2 KB tar asks for 64 GB — and an allocation that large *aborts* the
+/// process rather than unwinding, so the panic hook never runs and the terminal
+/// is left in raw mode. Reserve a modest amount and let `read_to_end` grow on
+/// bytes that actually arrived: the declared size may bound a read, never an
+/// allocation.
+const RESERVE_CAP: u64 = 1 << 20;
+
+fn reserve_for(declared: u64) -> usize {
+    usize::try_from(declared.min(RESERVE_CAP)).unwrap_or(0)
+}
+
 fn read_zip_member(archive: &Path, pos: usize) -> Result<Vec<u8>> {
     let file = File::open(archive).with_context(|| format!("opening {}", archive.display()))?;
     let mut zip = zip::ZipArchive::new(BufReader::new(file))?;
     let mut member = zip.by_index(pos)?;
-    let mut bytes = Vec::with_capacity(usize::try_from(member.size()).unwrap_or(0));
+    let mut bytes = Vec::with_capacity(reserve_for(member.size()));
     member.read_to_end(&mut bytes)?;
     Ok(bytes)
 }
@@ -368,7 +408,10 @@ fn read_zip_member(archive: &Path, pos: usize) -> Result<Vec<u8>> {
 fn read_tar_member(archive: &Path, offset: u64, size: u64) -> Result<Vec<u8>> {
     let mut file = File::open(archive).with_context(|| format!("opening {}", archive.display()))?;
     file.seek(SeekFrom::Start(offset))?;
-    let mut bytes = Vec::with_capacity(usize::try_from(size).unwrap_or(0));
+    let mut bytes = Vec::with_capacity(reserve_for(size));
+    // `take(size)` still bounds the read by the declaration, which is safe in the
+    // other direction: a header claiming more than the file holds simply stops at
+    // EOF, and one claiming less can't over-read.
     file.take(size).read_to_end(&mut bytes)?;
     Ok(bytes)
 }

--- a/src/archive/read/tests.rs
+++ b/src/archive/read/tests.rs
@@ -879,3 +879,160 @@ fn materialize_refuses_a_member_behind_a_planted_link() {
         "bytes escaped the staging root"
     );
 }
+
+// --- declared sizes are claims, not measurements ---
+
+/// A tar header's size field is attacker input. Reserving it aborts the process
+/// on a big enough lie — an abort, not an unwind, so the panic hook never runs
+/// and the terminal is left in raw mode.
+///
+/// Built by hand: `tar::Builder` writes an honest header, and the whole point is
+/// a dishonest one.
+fn tar_with_declared_size(path: &Path, name: &str, declared: &[u8; 12], body: &[u8]) {
+    let mut h = [0u8; 512];
+    h[..name.len()].copy_from_slice(name.as_bytes());
+    h[100..108].copy_from_slice(b"0000644\0");
+    h[108..116].copy_from_slice(b"0000000\0");
+    h[116..124].copy_from_slice(b"0000000\0");
+    h[124..136].copy_from_slice(declared);
+    h[136..148].copy_from_slice(b"00000000000\0");
+    h[156] = b'0';
+    h[257..263].copy_from_slice(b"ustar\0");
+    h[263..265].copy_from_slice(b"00");
+    h[148..156].copy_from_slice(b"        ");
+    let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+    let chk = format!("{:06o}\0 ", sum & 0o777_777);
+    h[148..156].copy_from_slice(chk.as_bytes());
+
+    let mut out = Vec::from(h);
+    out.extend_from_slice(body);
+    out.resize(out.len().div_ceil(512) * 512, 0);
+    out.extend_from_slice(&[0u8; 1024]);
+    std::fs::write(path, out).unwrap();
+}
+
+/// The octal maximum (~64 GB) behind an empty body. Before the fix this reached
+/// `Vec::with_capacity(68719476735)`.
+#[test]
+fn a_declared_size_far_beyond_the_file_does_not_drive_an_allocation() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("liar.tar");
+    let staging = tmp.path().join("staging");
+    tar_with_declared_size(&archive, "big.bin", b"777777777777", b"");
+
+    let indexed = index_seekable(&archive, ArchiveFormat::Tar, 1000).unwrap();
+    let entry = indexed.index.get("big.bin").expect("indexed");
+    assert_eq!(entry.size, 0o777_777_777_777, "the claim is carried as-is");
+
+    // The read completes, bounded by what the file actually holds, instead of
+    // reserving what was claimed. (A lying header still yields whatever follows
+    // it — here the tar's own end-of-archive padding — which is garbage in and
+    // garbage out; the property under test is that it costs the file's size, not
+    // the claim's.)
+    let dest = materialize(&archive, entry, &staging).unwrap();
+    let got = std::fs::read(&dest).unwrap().len() as u64;
+    let on_disk = std::fs::metadata(&archive).unwrap().len();
+    assert!(
+        got <= on_disk,
+        "read {got} bytes from a {on_disk}-byte archive"
+    );
+    assert!(got < 0o777_777_777_777, "the claim was not honoured");
+}
+
+#[test]
+fn a_reservation_is_capped_however_large_the_claim() {
+    assert_eq!(reserve_for(0), 0);
+    assert_eq!(reserve_for(64), 64);
+    assert_eq!(reserve_for(u64::MAX), RESERVE_CAP as usize);
+    assert_eq!(reserve_for(RESERVE_CAP * 4096), RESERVE_CAP as usize);
+}
+
+/// The bomb gate has to measure what arrives. A header declaring 0 while the
+/// stream carries megabytes used to walk straight past it, because the gate
+/// added up declarations.
+#[test]
+fn the_extract_budget_counts_bytes_that_arrive_not_bytes_declared() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("bomb.tar.gz");
+    let staging = tmp.path().join("staging");
+
+    // A tar whose header says 0 bytes but whose data blocks hold 64 KB.
+    let mut raw = Vec::new();
+    {
+        let mut h = [0u8; 512];
+        let name = "lies.bin";
+        h[..name.len()].copy_from_slice(name.as_bytes());
+        h[100..108].copy_from_slice(b"0000644\0");
+        h[108..116].copy_from_slice(b"0000000\0");
+        h[116..124].copy_from_slice(b"0000000\0");
+        h[124..136].copy_from_slice(b"00000000000\0"); // declared: 0
+        h[136..148].copy_from_slice(b"00000000000\0");
+        h[156] = b'0';
+        h[257..263].copy_from_slice(b"ustar\0");
+        h[263..265].copy_from_slice(b"00");
+        h[148..156].copy_from_slice(b"        ");
+        let sum: u32 = h.iter().map(|b| u32::from(*b)).sum();
+        let chk = format!("{:06o}\0 ", sum & 0o777_777);
+        h[148..156].copy_from_slice(chk.as_bytes());
+        raw.extend_from_slice(&h);
+    }
+    let enc = flate2::write::GzEncoder::new(
+        File::create(&archive).unwrap(),
+        flate2::Compression::default(),
+    );
+    {
+        let mut enc = enc;
+        enc.write_all(&raw).unwrap();
+        enc.finish().unwrap();
+    }
+
+    // Budget of 1 KB. Whatever the header claims, at most a hair over that may
+    // reach disk before the mount is refused.
+    let outcome = stream_mount(
+        &archive,
+        ArchiveFormat::TarGz,
+        &staging,
+        1024,
+        1000,
+        &AtomicBool::new(false),
+    );
+    if outcome.is_ok() {
+        let staged: u64 = std::fs::read_dir(&staging).map_or(0, |rd| {
+            rd.flatten()
+                .filter_map(|e| e.metadata().ok())
+                .map(|m| m.len())
+                .sum()
+        });
+        assert!(
+            staged <= 1025,
+            "{staged} bytes reached disk against a 1024-byte budget"
+        );
+    }
+}
+
+/// The honest path must keep working: a member whose declared size is true is
+/// still extracted whole, and a mount inside its budget still mounts.
+#[test]
+fn an_honest_archive_still_extracts_completely() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("ok.tar.gz");
+    let staging = tmp.path().join("staging");
+    let body = vec![b'x'; 4096];
+    tar_gz_at(&archive, &[("big.txt", &body, 0o644)]);
+
+    stream_mount(
+        &archive,
+        ArchiveFormat::TarGz,
+        &staging,
+        1 << 20,
+        1000,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
+
+    assert_eq!(
+        std::fs::read(staging.join("big.txt")).unwrap().len(),
+        4096,
+        "an in-budget member must arrive intact"
+    );
+}

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -630,12 +630,21 @@ fn handle_tools_call(
             };
             // A member of a mounted archive, before `canonicalize` gets a chance
             // to fail on it: the mount root is a *file*, so every path beneath it
-            // is ENOTDIR on disk. Also try the user's cwd, which is where an agent
-            // reading "the file I'm looking at" points a relative path.
-            let member = read_member_content(&resolved, ctx_path).or_else(|| {
+            // is ENOTDIR on disk. Scoped to `root` like every other read — the
+            // check lands on the container, which is a real file.
+            //
+            // The cwd fallback is where an agent reading "the file I'm looking
+            // at" points a relative path, so it only applies when the agent did
+            // NOT name a root. With an explicit root the agent has said which
+            // worktree it means, and answering from the user's cwd instead
+            // returns a different file than the one it asked for.
+            let member = read_member_content(&resolved, ctx_path, &root).or_else(|| {
+                if args.get("root").is_some() {
+                    return None;
+                }
                 let alt = read_cwd_from_context(ctx_path).join(path_str);
                 (!Path::new(path_str).is_absolute() && alt != resolved)
-                    .then(|| read_member_content(&alt, ctx_path))
+                    .then(|| read_member_content(&alt, ctx_path, &root))
                     .flatten()
             });
             if let Some(result) = member {

--- a/src/mcp/readers.rs
+++ b/src/mcp/readers.rs
@@ -207,11 +207,30 @@ pub(super) fn is_in_mount(path: &Path, ctx_path: &Path) -> bool {
 /// Prefers the staged copy: that's what the user is looking at, edits and all.
 /// Failing that the member is read straight out of the container, in memory —
 /// staging it here would tell the mount it extracted something it didn't.
-pub(super) fn read_member_content(path: &Path, ctx_path: &Path) -> Option<Result<String, String>> {
+/// `root` scopes the read the same way it scopes every other read tool. A mount
+/// is addressed at a path that is *not* a directory, so the caller's usual
+/// canonicalize-and-contain check can't be applied to the member path — but the
+/// container it comes out of is an ordinary file, and that is the thing that has
+/// to be inside the root. Without this the archive branch was an unscoped read:
+/// "spyc has this mounted" was the only bound, and a mount can be anywhere.
+pub(super) fn read_member_content(
+    path: &Path,
+    ctx_path: &Path,
+    root: &Path,
+) -> Option<Result<String, String>> {
     let mounts = archive_mounts(ctx_path);
     let (archive, staging, inner) = member_in_mount(path, &mounts)?;
+    if crate::paths::canonical_contains(root, &archive) != Some(true) {
+        return Some(Err(format!(
+            "{}: archive is outside the project root",
+            archive.display()
+        )));
+    }
     let staged = staging.join(&inner);
-    if staged.is_file() {
+    // `is_file` follows links, so confirm the staged copy is where it claims to
+    // be before reading it. Extraction refuses to traverse a symlink, which makes
+    // this belt-and-braces rather than the primary defence.
+    if staged.is_file() && crate::paths::canonical_contains(&staging, &staged) == Some(true) {
         return Some(read_file_content(&staged));
     }
     Some(read_member_from_archive(&archive, &inner))

--- a/src/mcp/tests/mod.rs
+++ b/src/mcp/tests/mod.rs
@@ -1389,11 +1389,13 @@ fn a_traversing_path_is_not_treated_as_a_member() {
     std::fs::write(staging.join("../leaked.txt"), b"outside the mount\n").unwrap();
 
     assert!(
-        super::readers::read_member_content(&archive.join("../leaked.txt"), &ctx_path).is_none(),
+        super::readers::read_member_content(&archive.join("../leaked.txt"), &ctx_path, tmp.path())
+            .is_none(),
         "`..` must not resolve as a member"
     );
     assert!(
-        super::readers::read_member_content(&archive.join("README.md"), &ctx_path).is_some(),
+        super::readers::read_member_content(&archive.join("README.md"), &ctx_path, tmp.path())
+            .is_some(),
         "while an ordinary member still does"
     );
 }
@@ -1441,4 +1443,36 @@ fn searching_inside_a_mount_is_refused_rather_than_answered_emptily() {
             "{tool} should refuse a mount: {resp}"
         );
     }
+}
+
+/// The archive branch of `get_file_content` used to answer before the root
+/// check, so "spyc has this mounted" was the only bound on it — and a mount can
+/// be anywhere. The member path can't be canonicalized (the mount root is a
+/// file, so everything under it is ENOTDIR), but the container is an ordinary
+/// file and that is what has to be inside the root.
+#[test]
+fn a_member_of_an_archive_outside_the_root_is_refused() {
+    let tmp = tempfile::tempdir().unwrap();
+    let elsewhere = tmp.path().join("elsewhere");
+    let project = tmp.path().join("project");
+    std::fs::create_dir_all(&elsewhere).unwrap();
+    std::fs::create_dir_all(&project).unwrap();
+    let staging = tmp.path().join("staging");
+    let (archive, ctx_path) = mounted_zip(&elsewhere, &staging);
+
+    let refused =
+        super::readers::read_member_content(&archive.join("README.md"), &ctx_path, &project)
+            .expect("the path is recognised as a member");
+    let err = refused.expect_err("but reading it must be refused");
+    assert!(
+        err.contains("outside the project root"),
+        "the refusal must name the reason: {err}"
+    );
+
+    // And the same member read against a root that does contain it still works.
+    let allowed =
+        super::readers::read_member_content(&archive.join("README.md"), &ctx_path, &elsewhere)
+            .expect("recognised")
+            .expect("and served");
+    assert!(!allowed.is_empty());
 }


### PR DESCRIPTION
**Closes HIGH-1, HIGH-2 and HIGH-3** from `docs/drafts/review-2.1/SYNTHESIS.md`. One PR because they're one mistake in three places: trusting a number the archive supplies about itself.

> Stacked on #347. Base is `fix/archive-physical-containment`; retarget to `main` once that merges.

## 1. A declaration drove an allocation (HIGH-1)

`read_zip_member` / `read_tar_member` passed the header's size straight to `Vec::with_capacity`, so a 2 KB tar declaring the octal maximum asked for **64 GB**. That *aborts* rather than unwinds — the panic hook never runs, so the terminal is left in raw mode. One keystroke on a malformed archive.

Reservations are capped at 1 MiB and `read_to_end` grows on bytes that actually arrived. The declaration still bounds the read via `take`, which is safe in that direction: a header claiming more than the file holds stops at EOF, one claiming less can't over-read.

## 2. The bomb gate believed the header (HIGH-2)

`stream_mount` summed *declared* sizes and compared the total to the extract budget — so a header claiming 0 bytes while the stream carried gigabytes walked straight past it. `write_member` now returns what it really wrote and copies at most `allowance + 1` bytes, so the budget is measured in bytes that reached disk, and a member can overshoot by exactly one byte before the mount is refused. The `+ 1` is what lets the caller tell "fit" from "overshot" without copying the rest of a bomb to find out.

## 3. The MCP archive read skipped containment (HIGH-3)

`get_file_content`'s archive branch answered *before* the canonicalize/root check, so "spyc has this mounted" was the only bound — and a mount can be anywhere. The member path genuinely can't be canonicalized (the mount root is a file, so everything beneath it is ENOTDIR), which is presumably why the check was skipped rather than moved. But the **container** is an ordinary file, and that's the thing that has to be inside the root. `read_member_content` now takes the root and checks it there, reusing `paths::canonical_contains` from #347.

Two smaller things in the same path:
- The staged copy is confirmed to be inside the staging root before `is_file` follows a link to it. Belt-and-braces now that #347 stops links being planted there.
- The cwd fallback no longer fires when the agent passed an explicit `root` (review C-5). With a root named, the agent has said which worktree it means; answering from the user's cwd returns a *different file* than the one it asked for.

## Evidence

**Fuzz seeds (#346), same binary, across the series:**

| seed | before #347 | after #347 | after this |
|---|---|---|---|
| `poc_symlink_chain.tar{,.gz}` | escaped staging | ok | ok |
| `declared_size_octmax.tar` | `malloc(68719476735)` | still OOM | **ok** |
| other 9 | ok | ok | ok |

All twelve green for the first time.

**New unit tests**, each built on a hand-written header because `tar::Builder` writes an honest one and the point is a dishonest one:

- `a_declared_size_far_beyond_the_file_does_not_drive_an_allocation` — the 64 GB claim, read bounded by the file
- `a_reservation_is_capped_however_large_the_claim` — `reserve_for` directly
- `the_extract_budget_counts_bytes_that_arrive_not_bytes_declared` — header says 0, budget still holds
- `an_honest_archive_still_extracts_completely` — the fix isn't bought by truncating honest members
- `a_member_of_an_archive_outside_the_root_is_refused` — plus the same member served when the root does contain it

One assertion of mine was wrong and I corrected it rather than the code: I expected the lying-header read to return 0 bytes, but `take(declared)` reads to EOF and returns the tar's own end-of-archive padding. Garbage in, garbage out — the property under test is that the read costs the *file's* size, not the claim's, so the test now asserts that.

`make check-ci` → `=== GATE: PASS ===`, 2,323 tests, 0 ignored. No version bump; CHANGELOG untouched.

Generated with [Claude Code](https://claude.com/claude-code)