### PR TITLE
refactor(config): one config-root resolver, and drop the dead hostname shell-out

### DIFF
--- a/src/app/util.rs
+++ b/src/app/util.rs
@@ -190,23 +190,16 @@ fn hostname_best_effort() -> String {
 
 /// `uname(2)`'s `nodename` is the kernel's `gethostname` value — read it
 /// with a syscall instead of fork-execing the `hostname` binary.
-#[cfg(unix)]
+///
+/// Not cfg-gated: spyc targets unix + WSL only (Windows-native was explicitly
+/// rejected), so a non-unix build is expected to fail here the way it already
+/// fails on `uzers`, `rustix::termios` and the pty layer.
 fn system_nodename() -> Option<String> {
     rustix::system::uname()
         .nodename()
         .to_str()
         .ok()
         .map(str::to_owned)
-}
-
-/// Non-unix fallback: spyc ships only unix builds, but keep the binary
-/// shell-out so any non-unix compile retains its hostname behavior.
-#[cfg(not(unix))]
-fn system_nodename() -> Option<String> {
-    let out = std::process::Command::new("hostname").output().ok()?;
-    out.status
-        .success()
-        .then(|| String::from_utf8_lossy(&out.stdout).trim().to_string())
 }
 
 /// Strip ANSI escape sequences from a string and drop remaining

--- a/src/ui/syntax.rs
+++ b/src/ui/syntax.rs
@@ -16,8 +16,10 @@
 //! Additional `.sublime-syntax` files can be layered on top by dropping
 //! them into one of these directories (first hit wins for a given scope):
 //!
-//! - `$XDG_CONFIG_HOME/spyc/syntaxes/` (XDG default)
-//! - `~/.config/spyc/syntaxes/` (fallback when `XDG_CONFIG_HOME` is unset)
+//! - `<config_root>/syntaxes/`, i.e. `$XDG_CONFIG_HOME/spyc/syntaxes/` or
+//!   `~/.config/spyc/syntaxes/` — resolved by [`crate::state::config_root`],
+//!   the single config-root resolver, so it honors the same precedence (and the
+//!   same test override) as `init.lua` and the `lua/` script dir.
 //!
 //! Files are best-effort; a malformed grammar is logged via
 //! `spyc_debug!` and the rest of the directory is still loaded.
@@ -60,19 +62,15 @@ fn build_syntax_set() -> SyntaxSet {
     builder.build()
 }
 
-/// Resolve the user syntaxes directory. Honors `XDG_CONFIG_HOME`,
-/// falls back to `~/.config/spyc/syntaxes/`. Returns `None` only on
-/// exotic systems where neither `XDG_CONFIG_HOME` nor `HOME` is set.
+/// Resolve the user syntaxes directory: `<config_root>/syntaxes/`.
+///
+/// Goes through [`crate::state::config_root`] — the single config-root resolver
+/// — rather than reading `XDG_CONFIG_HOME` / `HOME` again. Resolving it twice
+/// meant syntax loading silently ignored the resolver's thread-local test
+/// override, so a test that redirected the config root still read the real
+/// `~/.config/spyc/syntaxes`. `None` only where the resolver finds no root.
 fn user_syntaxes_dir() -> Option<PathBuf> {
-    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
-        return Some(PathBuf::from(xdg).join("spyc").join("syntaxes"));
-    }
-    std::env::var_os("HOME").map(|h| {
-        PathBuf::from(h)
-            .join(".config")
-            .join("spyc")
-            .join("syntaxes")
-    })
+    crate::state::config_root().map(|r| r.join("syntaxes"))
 }
 
 /// Theme name from syntect's bundled defaults. Dark theme that pairs
@@ -141,6 +139,31 @@ pub fn highlight_to_lines(filename: &str, content: &str) -> Option<Vec<Line<'sta
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The point of routing through `config_root`: the resolver's thread-local
+    /// test override now reaches syntax loading. Reading `XDG_CONFIG_HOME`
+    /// directly here meant an override was silently ignored, so a test that
+    /// redirected the config root still pointed at the real `~/.config/spyc`.
+    #[test]
+    fn syntaxes_dir_follows_the_config_root_override() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let got = crate::state::with_config_root(tmp.path(), user_syntaxes_dir);
+        assert_eq!(
+            got,
+            Some(tmp.path().join("syntaxes")),
+            "syntax loading must honor the shared resolver's override"
+        );
+    }
+
+    /// And it is the *same* root the rest of the config layer resolves, not a
+    /// parallel answer that happens to agree today.
+    #[test]
+    fn syntaxes_dir_hangs_off_the_shared_config_root() {
+        assert_eq!(
+            user_syntaxes_dir(),
+            crate::state::config_root().map(|r| r.join("syntaxes"))
+        );
+    }
 
     #[test]
     fn highlights_makefile_by_bare_filename() {


### PR DESCRIPTION
## L6 + L7 — internal consistency (no new dependencies)

Two cleanups, combined as the brief allows.

### L7 — `syntax.rs` must use the shared config resolver

`user_syntaxes_dir` hand-resolved `XDG_CONFIG_HOME` / `~/.config/spyc/syntaxes`, duplicating `crate::state::config_root`.

**The duplication wasn't merely untidy — it was a latent test-isolation bug.** `config_root` carries a thread-local override (`with_config_root`), and resolving the path a second time meant syntax loading *silently bypassed it*: a test that redirected the config root still read the real `~/.config/spyc/syntaxes`. Now:

```rust
fn user_syntaxes_dir() -> Option<PathBuf> {
    crate::state::config_root().map(|r| r.join("syntaxes"))
}
```

Two tests, per the brief:
- `syntaxes_dir_follows_the_config_root_override` — proves the override now reaches syntax loading
- `syntaxes_dir_hangs_off_the_shared_config_root` — proves it's the *same* root the rest of the config layer resolves, not a parallel answer that happens to agree today

**Sweep result** — the brief asked that afterwards only `src/state/mod.rs` reads those vars. Confirmed:

```
$ grep -rn 'var_os("XDG_CONFIG_HOME")\|var_os("XDG_STATE_HOME")' src --include='*.rs'
src/state/mod.rs:62:    if let Some(xdg) = std::env::var_os("XDG_STATE_HOME") {
src/state/mod.rs:86:    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
```

Every other hit in the broader grep is a doc comment or an error-message string (e.g. "no state directory (\$XDG_STATE_HOME / \$HOME unset)"), which are describing the resolver rather than re-implementing it — correctly left alone.

### L6 — retire the `hostname` subprocess fallback

`system_nodename`'s `cfg(not(unix))` arm shelled out to the `hostname` binary. spyc targets unix + WSL only (Windows-native was explicitly rejected), so that arm was dead code — a non-unix build already fails on `uzers`, `rustix::termios` and the pty layer.

Took the brief's preferred option: **deleted**, rather than swapping in the `hostname` crate. The `#[cfg(unix)]` gate went with it, since there is no longer a second arm to select between — leaving a lone `#[cfg(unix)]` would imply a counterpart that doesn't exist. A non-unix compile now fails at `rustix::system::uname`, which is the seam, and the doc comment says so.

`grep -rc 'Command::new("hostname")' src` → 0 remaining.

`make check-ci` → `=== GATE: PASS ===`

Generated with [Claude Code](https://claude.com/claude-code)