### PR TITLE
fix(session): a live codex tab saves the rollout it was pinned to, not nothing

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1205,9 +1205,11 @@ spyc auto-saves your workspace on quit and can restore it on startup.
   then verify the submit landed — re-sending Enter while the command
   is still visibly unsubmitted, since Claude's async startup can eat
   a lone `\r`.
-  Codex tabs spawn `codex resume <UUID>` directly. When no UUID was
-  captured (pane killed before exit), codex falls back to `codex resume
-  --last`, which uses codex's native cwd-filtered picker. `zot` tabs
+  Codex tabs spawn `codex resume <UUID>` directly — the UUID being the
+  rollout spyc pinned to that tab while it ran, so a tab still working at
+  quit resumes exactly rather than guessing. When no UUID was ever pinned,
+  codex falls back to `codex resume --last`, which uses codex's native
+  cwd-filtered picker. `zot` tabs
   restore with `zot --continue` (zot's resume-most-recent-for-cwd);
   specific-session resume and transcript scrollback are a follow-up
   pending its on-disk session-file format.

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -122,7 +122,7 @@ resumes differs, and the differences leak:
 | agent | resume mechanism |
 |---|---|
 | **claude** | spyc spawns fresh, then **types `/resume <id>` into stdin** once the banner settles. The `--resume` CLI flag has a mount-crash regression, so the stdin route is deliberate, not a workaround for convenience. |
-| **codex** | baked into the spawn command — `codex resume <uuid>`, or `resume --last`. |
+| **codex** | baked into the spawn command — `codex resume <uuid>`, or `resume --last`. The uuid comes from the tab's *pinned* rollout claim, not from codex's exit banner, so a tab that was still running at quit resumes exactly too. |
 | **agy** | `--continue` (resumes the most recent for this cwd). |
 | **zot** | `--continue`. spyc doesn't capture a specific session path yet, so restore always continues the most recent. |
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -171,11 +171,11 @@ pub trait AgentProfile: Sync {
     }
 
     /// SAVE: confirm the session id pinned to this tab
-    /// ([`crate::pane::tabs::TabInfo::live_session_id`] — from a status-hook
-    /// payload or an injected `/resume`) still names a real conversation, so save
-    /// can prefer it over the spawn-proximity resolver. `Some((id, name))` when it
-    /// checks out; `None` when it's stale or the agent has no history to check it
-    /// against.
+    /// ([`crate::pane::tabs::TabInfo::pinned_session_id`] — a status-hook payload,
+    /// an injected `/resume`, or a claimed codex rollout) still names a real
+    /// conversation, so save can prefer it over the spawn-proximity resolver.
+    /// `Some((id, name))` when it checks out; `None` when it's stale or the agent
+    /// has no history to check it against.
     fn validate_live_session_id(&self, _cwd: &Path, _id: &str) -> Option<(String, Option<String>)> {
         None
     }
@@ -572,6 +572,16 @@ impl AgentProfile for CodexProfile {
         let id = crate::state::sessions::extract_codex_resume_token(&lines)
             .filter(|tok| !claimed.contains(tok));
         (id, None)
+    }
+    /// Codex's pinned id is taken as-is: `codex_pin` read it out of a rollout
+    /// file's *name*, so there is no separate history to check it against — the
+    /// claim already was the observation. If that file has since gone,
+    /// `codex resume <uuid>` fails where the user can see it, which beats
+    /// `--last` silently attaching to whichever rollout in the cwd was written
+    /// last (the #230 shape). Claude validates instead, because its id arrives
+    /// from a hook payload that can name a conversation already gone.
+    fn validate_live_session_id(&self, _cwd: &Path, id: &str) -> Option<(String, Option<String>)> {
+        Some((id.to_string(), None))
     }
     fn command_without_resume(&self, cmd: &str) -> String {
         resume::command_without_codex_resume(cmd)

--- a/src/app/session.rs
+++ b/src/app/session.rs
@@ -100,64 +100,73 @@ impl App {
         // pane the same ID and they all collapsed onto one
         // conversation at restore.
         let mut claimed: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let tabs: Vec<SavedTab> =
-            self.runtime
-                .pane_tabs
-                .as_mut()
-                .map(|pt| {
-                    pt.tabs_mut()
-                        .iter_mut()
-                        .map(|t| {
-                            let profile = crate::agent::detect(&t.info.command);
-                            let kind = profile.kind();
-                            // Resolve the (session_id, session_name) to persist.
-                            // Prefer this tab's PINNED claude session id (set at
-                            // restore from the exact `/resume <sid>`) when its JSONL
-                            // still exists — that's the conversation this pane is
-                            // definitively running, so it bypasses the spawn-proximity
-                            // resolver that crosses panes restored together. Otherwise
-                            // fall back to the profile resolver, which honors `claimed`
-                            // internally so multi-pane saves don't collapse onto one
-                            // conversation.
-                            let (agent_session_id, agent_session_name) =
-                                match t.info.live_session_id.as_deref().and_then(|id| {
-                                    profile.validate_live_session_id(&t.info.cwd, id)
-                                }) {
-                                    Some((id, name)) => (Some(id), name),
-                                    None => profile.resolve_resume_target(
-                                        &t.pane,
-                                        &t.info.cwd,
-                                        t.info.spawn_epoch_secs,
-                                        &claimed,
-                                    ),
-                                };
-                            if let Some(ref id) = agent_session_id {
-                                claimed.insert(id.clone());
-                            }
-                            // The sid lives in agent_session_id; baking
-                            // --resume / `resume` into `command` would survive
-                            // past a resolver miss and pollute the next restore.
-                            let saved_command = profile.command_without_resume(&t.info.command);
-                            SavedTab {
-                                command: saved_command,
-                                // Strip any `[exited N]` suffix — that's
-                                // runtime display state for a tab whose
-                                // child has died, not persistent identity.
-                                // Without this, restoring a session that
-                                // saw a tab exit at any point shows the
-                                // freshly-respawned process tagged with
-                                // a stale "exited" suffix.
-                                label: crate::pane::tabs::strip_exit_suffix(&t.info.label),
-                                cwd: t.info.cwd.clone(),
-                                agent_kind: kind,
-                                agent_session_id,
-                                agent_session_name,
-                                claim_owner: t.info.claim_owner.clone(),
-                            }
-                        })
-                        .collect()
-                })
-                .unwrap_or_default();
+        let tabs: Vec<SavedTab> = self
+            .runtime
+            .pane_tabs
+            .as_mut()
+            .map(|pt| {
+                pt.tabs_mut()
+                    .iter_mut()
+                    .map(|t| {
+                        let profile = crate::agent::detect(&t.info.command);
+                        let kind = profile.kind();
+                        // Resolve the (session_id, session_name) to persist.
+                        // Prefer this tab's PINNED session id — claude's
+                        // `live_session_id` (set at restore from the exact
+                        // `/resume <sid>`) or codex's `codex_session_id` (the
+                        // rollout `codex_pin` claimed for it). That's the
+                        // conversation this pane is definitively running, so it
+                        // bypasses the spawn-proximity resolver that crosses panes
+                        // restored together. Otherwise fall back to the profile
+                        // resolver, which honors `claimed` internally so multi-pane
+                        // saves don't collapse onto one conversation — and which
+                        // for a *live* tab has nothing to read, since both agents
+                        // only print their id on the way out.
+                        let (agent_session_id, agent_session_name) = match t
+                            .info
+                            .pinned_session_id()
+                            // The pinned path honors `claimed` too: two tabs
+                            // pinned to one conversation would otherwise both
+                            // save it and both restore into it, which is the
+                            // collapse this whole block exists to prevent.
+                            .filter(|id| !claimed.contains(*id))
+                            .and_then(|id| profile.validate_live_session_id(&t.info.cwd, id))
+                        {
+                            Some((id, name)) => (Some(id), name),
+                            None => profile.resolve_resume_target(
+                                &t.pane,
+                                &t.info.cwd,
+                                t.info.spawn_epoch_secs,
+                                &claimed,
+                            ),
+                        };
+                        if let Some(ref id) = agent_session_id {
+                            claimed.insert(id.clone());
+                        }
+                        // The sid lives in agent_session_id; baking
+                        // --resume / `resume` into `command` would survive
+                        // past a resolver miss and pollute the next restore.
+                        let saved_command = profile.command_without_resume(&t.info.command);
+                        SavedTab {
+                            command: saved_command,
+                            // Strip any `[exited N]` suffix — that's
+                            // runtime display state for a tab whose
+                            // child has died, not persistent identity.
+                            // Without this, restoring a session that
+                            // saw a tab exit at any point shows the
+                            // freshly-respawned process tagged with
+                            // a stale "exited" suffix.
+                            label: crate::pane::tabs::strip_exit_suffix(&t.info.label),
+                            cwd: t.info.cwd.clone(),
+                            agent_kind: kind,
+                            agent_session_id,
+                            agent_session_name,
+                            claim_owner: t.info.claim_owner.clone(),
+                        }
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
 
         // Anchor the session on `project_home` (explicit) → `start_dir`
         // (where spyc was launched) → `listing.dir` (last resort).
@@ -787,8 +796,89 @@ impl App {
 
 #[cfg(test)]
 mod tests {
-    use super::{AutosaveAction, autosave_action};
+    use super::{App, AutosaveAction, autosave_action};
     use std::time::{Duration, Instant};
+
+    /// A live codex tab must save the rollout uuid spyc pinned to it.
+    ///
+    /// `resolve_resume_target` reads codex's **exit banner**, which a tab that's
+    /// still running at quit has never printed — so save persisted `None` and
+    /// restore spawned `codex resume --last`, which attaches to whichever rollout
+    /// in the cwd was written most recently, including another spyc instance's.
+    /// The uuid was sitting in `info.codex_session_id` the whole time.
+    #[test]
+    fn a_live_codex_tab_saves_the_rollout_uuid_it_is_pinned_to() {
+        const UUID: &str = "0198c2f4-1a2b-7c3d-8e4f-5a6b7c8d9e0f";
+        let tmp = tempfile::tempdir().expect("tempdir");
+        crate::state::with_state_root(tmp.path(), || {
+            let mut app = App::test_app(tmp.path().to_path_buf());
+            // `cat` gives a harmless long-lived pty; `agent::detect` keys on the
+            // command string, so relabelling it is what makes this a codex tab.
+            app.open_pane_tab("cat");
+            {
+                let info = &mut app
+                    .runtime
+                    .pane_tabs
+                    .as_mut()
+                    .expect("a tab was opened")
+                    .tabs_mut()[0]
+                    .info;
+                info.command = "codex".to_string();
+                info.codex_session_id = Some(UUID.to_string());
+            }
+
+            let snapshot = app.build_session_snapshot();
+            let saved = &snapshot.tabs[0];
+            assert_eq!(saved.agent_session_id.as_deref(), Some(UUID));
+            // And the id has to survive into the spawn, or saving it changed
+            // nothing the user can see.
+            assert_eq!(
+                crate::agent::detect(&saved.command)
+                    .reconstruct_restore(
+                        &saved.command,
+                        saved.agent_session_id.as_deref(),
+                        tmp.path()
+                    )
+                    .command,
+                format!("codex resume {UUID}"),
+                "a restored tab must resume that exact rollout, not --last"
+            );
+        });
+    }
+
+    /// Two tabs pinned to the same conversation must not both save it: restoring
+    /// them would put two panes in one conversation, which is the collapse #230
+    /// was filed for. The pinned path honors `claimed` for the same reason the
+    /// spawn-proximity resolver always has.
+    #[test]
+    fn two_tabs_pinned_to_one_conversation_do_not_both_save_it() {
+        const UUID: &str = "0198c2f4-1a2b-7c3d-8e4f-5a6b7c8d9e0f";
+        let tmp = tempfile::tempdir().expect("tempdir");
+        crate::state::with_state_root(tmp.path(), || {
+            let mut app = App::test_app(tmp.path().to_path_buf());
+            app.open_pane_tab("cat");
+            app.open_pane_tab("cat");
+            for entry in app
+                .runtime
+                .pane_tabs
+                .as_mut()
+                .expect("two tabs were opened")
+                .tabs_mut()
+            {
+                entry.info.command = "codex".to_string();
+                entry.info.codex_session_id = Some(UUID.to_string());
+            }
+
+            let snapshot = app.build_session_snapshot();
+            assert_eq!(snapshot.tabs.len(), 2);
+            let claims = snapshot
+                .tabs
+                .iter()
+                .filter(|t| t.agent_session_id.as_deref() == Some(UUID))
+                .count();
+            assert_eq!(claims, 1, "only one tab may claim a conversation");
+        });
+    }
 
     #[test]
     fn autosave_idle_when_not_dirty() {


### PR DESCRIPTION
**H6** of the pre-2.1 review (`D-clipboard-pane-agent.md`, D5) — `high`.

`build_session_snapshot` resolved the id to persist from `live_session_id`, which codex never sets — it pins `codex_session_id` instead (`src/pane/tabs.rs:186-188` says so explicitly). So codex always fell through to `resolve_resume_target`, which reads the **exit banner** out of `pane.recent_lines(200)`. A tab still running at quit has never printed one.

A live codex tab therefore saved `agent_session_id: None` and restored as `codex resume --last` — while `info.codex_session_id` held the exact uuid `app::codex_pin` had claimed for it.

`--last` is not a benign fallback. `is_resume_without_id` puts both resolvers on their mtime-ranked branches (`assign_codex_sessions`'s `.max_by_key(mtime_secs)`, `pick_best_rollout`'s `resuming` arm), so the busiest rollout in the cwd wins — including another spyc instance's. Their own test `the_same_candidates_invert_when_the_pane_is_resuming` shows it. That's #230's failure mode, reached from the save side.

`TabInfo::pinned_session_id()` exists for exactly this, and was already used by the transcript view, the image gallery and the status suffix — just not by save.

## The fix

Save reads `pinned_session_id()`, and `CodexProfile` implements `validate_live_session_id` by **accepting the id as-is**. That's the one judgement call here, so stating it: `codex_pin` read the uuid out of a rollout file's *name*, so there is no separate history to check it against — the claim already was the observation. If that file has since gone, `codex resume <uuid>` fails where the user can see it, which beats `--last` silently attaching to someone else's conversation. Claude still validates, because its id arrives from a hook payload that can name a conversation already deleted.

The pinned path now honors `claimed` too. Codex ids flow through it for the first time here, and two tabs pinned to one conversation would otherwise both save it and both restore into it — the collapse the surrounding block exists to prevent.

## Red before, green after

| test | on `main` | here |
|---|---|---|
| `a_live_codex_tab_saves_the_rollout_uuid_it_is_pinned_to` | `FAILED` — `left: None, right: Some("0198c2f4-…")` | `ok` |
| `two_tabs_pinned_to_one_conversation_do_not_both_save_it` | (new) — bite-checked: dropping the `claimed` filter fails it with `only one tab may claim a conversation` | `ok` |

The first asserts through to the spawn command, not just the saved field — `codex resume <uuid>`, not `--last` — because saving an id that doesn't reach the spawn changes nothing the user can see.

Gate: `=== GATE: PASS ===`, 2364 lib tests, 0 ignored.

Docs: `docs/HARNESS.md` (the per-agent resume table), FEATURES.md (agent session resume).

Generated with [Claude Code](https://claude.com/claude-code)