### PR TITLE
test(archive): pin the three write-back safety properties a mutation could gut

### DIFF
--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -938,6 +938,75 @@ fn declining_the_write_unmounts_and_discards() {
     });
 }
 
+/// **An archive that genuinely earns read-only gets it, end to end.**
+///
+/// The sibling test below hand-writes the demotion into the mount, so it proves
+/// the refusal honors a `ReadOnly` capability but not that anything ever *sets*
+/// one. Here the archive earns it: a `..` member is skipped on the way in, and a
+/// repack that silently dropped it would hand the user a lossy archive with no
+/// warning. The reason string is asserted as the one `assess` produces, and the
+/// status bar's `ro` marker with it — a capability nothing surfaces is one the
+/// user can't act on.
+#[test]
+fn an_archive_with_a_skipped_member_mounts_read_only_and_says_so() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().to_path_buf();
+        let archive = dir.join("pkg.zip");
+        {
+            let file = std::fs::File::create(&archive).unwrap();
+            let mut w = zip::ZipWriter::new(file);
+            let opts = zip::write::SimpleFileOptions::default().unix_permissions(0o644);
+            w.start_file("README.md", opts).unwrap();
+            w.write_all(b"# pkg\n").unwrap();
+            // Rejected by `index::normalize` on the way in — the member exists in
+            // the container and cannot exist in the mount.
+            w.start_file("../escape.txt", opts).unwrap();
+            w.write_all(b"nope\n").unwrap();
+            w.finish().unwrap();
+        }
+        let mut app = App::test_app(dir);
+        mount_inline(&mut app, &archive, &tmp.path().join("staging"));
+
+        let mount = app.state.mounts.get(&archive).expect("mounted");
+        assert!(
+            !mount.capability.is_writable(),
+            "a skipped member must demote the mount, got {:?}",
+            mount.capability
+        );
+        match &mount.capability {
+            crate::archive::Capability::ReadOnly(why) => assert!(
+                why.contains("unsafe paths"),
+                "the reason has to be the one assess derived: {why}"
+            ),
+            crate::archive::Capability::ReadWrite => panic!("expected ReadOnly, got ReadWrite"),
+        }
+
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(120, 24)).unwrap();
+        terminal.draw(|f| app.render(f)).unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(
+            rendered.contains("zip ro"),
+            "the status bar has to show the mount is read-only"
+        );
+
+        // And the demotion is load-bearing: the write is refused.
+        if let Some(mount) = app.state.mounts.get_mut(&archive) {
+            mount.journal.delete("README.md");
+        }
+        let before = std::fs::read(&archive).unwrap();
+        assert!(app.cmd_archive("write").is_empty(), "no write is attempted");
+        assert_eq!(std::fs::read(&archive).unwrap(), before);
+    });
+}
+
 /// A read-only archive refuses the write rather than producing a lossy one.
 #[test]
 fn a_read_only_mount_refuses_to_be_written() {

--- a/src/archive/write.rs
+++ b/src/archive/write.rs
@@ -948,8 +948,9 @@ mod tests {
         );
     }
 
-    /// Verification is what catches a plan the writer couldn't honor. A plan
-    /// naming a member the index doesn't have fails before anything is replaced.
+    /// A plan naming a member the index doesn't have fails before anything is
+    /// replaced. Caught by `write_zip`'s index lookup, not by `verify` — which is
+    /// what `a_write_only_verify_can_catch_leaves_the_original_alone` covers.
     #[test]
     fn a_plan_referencing_an_unknown_member_is_refused() {
         let tmp = tempfile::tempdir().unwrap();
@@ -966,6 +967,90 @@ mod tests {
         }];
         assert!(repack(&indexed.index, &steps, tmp.path(), &opts()).is_err());
         assert_eq!(std::fs::read(&archive).unwrap(), before);
+    }
+
+    /// **The verify step earns its keep.** A plan whose stored name the archive
+    /// reads back differently — here `./a.txt`, which the zip stores verbatim and
+    /// [`crate::archive::index::normalize`] resolves to `a.txt` — is written
+    /// without complaint by every layer *except* verify. So this is the one shape
+    /// only verify can refuse, and it must: the alternative is an archive whose
+    /// member the user can no longer address.
+    ///
+    /// Asserts the refusal came from verify by name, because the neighbouring
+    /// unknown-member test is caught earlier and reads as if it covered this.
+    #[test]
+    fn a_write_only_verify_can_catch_leaves_the_original_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let archive = tmp.path().join("pkg.zip");
+        zip_at(&archive, &[("a.txt", b"alpha", 0o644)]);
+        let before = std::fs::read(&archive).unwrap();
+        let indexed = read::index_seekable(&archive, ArchiveFormat::Zip, 1000).unwrap();
+
+        let steps = vec![RepackStep {
+            out: "./a.txt".to_string(),
+            source: StepSource::Archived {
+                inner: "a.txt".to_string(),
+            },
+        }];
+        let err = repack(&indexed.index, &steps, tmp.path(), &opts()).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("doesn't match the plan"),
+            "the refusal must come from verify, not an earlier guard: {msg}"
+        );
+        assert_eq!(
+            std::fs::read(&archive).unwrap(),
+            before,
+            "a repack that fails verification never touches the original"
+        );
+    }
+
+    /// **Verify runs before the rename, and before the snapshot.** Both of those
+    /// orderings are the safety property `repack`'s docstring names, and neither
+    /// is visible in a passing write: only a write that verify *rejects* can tell
+    /// the difference. A doomed repack must leave the original in place AND leave
+    /// the graveyard empty — filling it with snapshots of writes that never
+    /// happened is how the undo affordance stops being one.
+    #[test]
+    fn a_rejected_write_neither_replaces_the_original_nor_snapshots_it() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let archive = tmp.path().join("pkg.zip");
+            zip_at(&archive, &[("a.txt", b"alpha", 0o644)]);
+            let before = std::fs::read(&archive).unwrap();
+            let indexed = read::index_seekable(&archive, ArchiveFormat::Zip, 1000).unwrap();
+
+            let steps = vec![RepackStep {
+                out: "./a.txt".to_string(),
+                source: StepSource::Archived {
+                    inner: "a.txt".to_string(),
+                },
+            }];
+            assert!(
+                repack(
+                    &indexed.index,
+                    &steps,
+                    tmp.path(),
+                    &RepackOptions {
+                        snapshot_original: true,
+                        free_space_margin: 0,
+                    },
+                )
+                .is_err()
+            );
+            assert_eq!(
+                std::fs::read(&archive).unwrap(),
+                before,
+                "verify has to run while the original is still the original"
+            );
+            assert!(
+                crate::state::graveyard::Graveyard::load()
+                    .entries
+                    .iter()
+                    .all(|e| e.filename != "pkg.zip"),
+                "a write that never happened must not be snapshotted"
+            );
+        });
     }
 
     /// No temp files left behind, whether the write succeeded or failed — the


### PR DESCRIPTION
**H8** of the pre-2.1 review (`F-tests-guards.md`, F1b/F1c/F1d) — `high`.

The archive write-back's stated safety properties were all unprotected: each could be removed with the entire suite green. I re-ran every bite on `089a830` before touching anything — **2365 tests pass under all four**:

| mutation | on `main` | here |
|---|---|---|
| `verify`'s body → `Ok(())` | 2365 pass | 2 tests fail |
| `verify` moved after `tmp.persist(archive)` | 2365 pass | 2 tests fail |
| `assess(&facts, format)` → constant `ReadWrite` | 2365 pass | 1 test fails |
| status bar's `" ro"` marker blanked | 2365 pass | 1 test fails |

No production behavior changes — this is regression protection for the next edit.

## The three tests, and why these shapes

**`a_write_only_verify_can_catch_leaves_the_original_alone`** — a step whose stored name the archive reads back *differently*: `./a.txt`, which the zip stores verbatim and `index::normalize` resolves to `a.txt`. Every layer writes it without complaint except `verify`, which makes it the one shape only verify can refuse. It asserts the error came from verify **by name** (`doesn't match the plan`), because the neighbouring `a_plan_referencing_an_unknown_member_is_refused` is actually caught by `write_zip`'s index lookup while its docstring claimed *"Verification is what catches a plan the writer couldn't honor"* — corrected here.

**`a_rejected_write_neither_replaces_the_original_nor_snapshots_it`** — the same rejection, now pinning the *ordering* both docstrings call the safety property: the original stays byte-identical **and** the graveyard stays empty. A passing write cannot distinguish verify-first from verify-last; only a rejected one can. Filling the graveyard with snapshots of writes that never happened is how the undo affordance stops being one.

**`an_archive_with_a_skipped_member_mounts_read_only_and_says_so`** — builds an archive that genuinely *earns* the demotion (a `..` member, skipped on the way in) instead of hand-writing the reason into the mount the way the existing `a_read_only_mount_refuses_to_be_written` does. Asserts the reason string `assess` derived, the `ro` marker in a rendered `TestBackend` frame, and that the write is then refused. Without the render assertion, a capability nothing surfaces is one the user can't act on.

Gate: `=== GATE: PASS ===`, 2368 lib tests, 0 ignored.

Generated with [Claude Code](https://claude.com/claude-code)