### PR TITLE
docs(agents): leave no target/ behind — and fuzz/ needs its own clean

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,12 @@ make release-tag VERSION=x.y.z        # step 2, on main after that PR merged: ve
 
 **Crate shape: lib + bin.** `src/lib.rs` owns every module + the `run()` entry point; `src/main.rs` is a thin shim. The split lets `fuzz/` (a standalone workspace; nightly, on-demand) link the lib. New fuzz entry points go through the `pub mod fuzz` facade in `lib.rs`, not by widening module visibility.
 
+**Leave no `target/` behind — `cargo clean` when you're done with a worktree.** One gate run leaves ~4 GB of build cache and the worktree-per-PR layout multiplies it: thirteen parked worktrees reached **57 GB**. The rebuild is worth the disk, so clean eagerly rather than banking the cache — and `remove_worktree` as soon as a PR merges, which takes the cache with it. **`fuzz/` is a separate workspace, so the root `cargo clean` doesn't touch `fuzz/target`** — another ~2.6 GB per worktree, surviving the obvious command:
+
+```sh
+cargo clean && cargo clean --manifest-path fuzz/Cargo.toml
+```
+
 ## Roadmap
 
 See [`ROADMAP.md`](ROADMAP.md).


### PR DESCRIPTION
Thirteen parked worktrees reached **57 GB**, almost all build cache. The worktree-per-PR layout means every agent that runs the gate leaves ~4 GB somewhere nobody looks again, and `remove_worktree` — the teardown half of the documented flow — was the step that kept getting skipped.

The rule states the trade explicitly (the rebuild is worth the disk, so clean eagerly rather than bank the cache) and carries the part that actually bit during the cleanup: **`fuzz/` is a standalone workspace, so a root `cargo clean` leaves `fuzz/target` alone.** Three of those survived the first pass at 2.6 GB each — hence spelling the command out.

Cleanup already done on this machine: 57 GiB → 2.6 GiB across the 13 worktrees.

## Test plan

- `make check-ci` green (AGENTS.md is read by the source-scan guards, so the gate is meaningful for a docs-only change here).

Generated with [Claude Code](https://claude.com/claude-code)