### PR TITLE
test(mouse): cover the dispatch entry, the press/release pairing, and the wheel-to-keys caller

### DIFF
--- a/src/app/mouse/forward.rs
+++ b/src/app/mouse/forward.rs
@@ -190,3 +190,171 @@ pub(super) fn mouse_report(
         ctrl: ev.modifiers.contains(K::CONTROL),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::{App, Effect, PaneInput, PaneTarget};
+    use super::super::tests::make_pane_speak_mouse;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+    fn at(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    /// The bytes a `SendToPane` effect carries, or `None` for anything else.
+    fn sent(fx: &[Effect]) -> Option<&[u8]> {
+        match fx {
+            [
+                Effect::SendToPane {
+                    target: PaneTarget::Active,
+                    input: PaneInput::Bytes(bytes),
+                    ..
+                },
+            ] => Some(bytes),
+            _ => None,
+        }
+    }
+
+    /// An App with a mouse-aware pane and a point the layout says is inside it.
+    fn app_with_a_mouse_pane(dir: &std::path::Path) -> (App, (u16, u16)) {
+        let mut app = App::test_app(dir.to_path_buf());
+        app.view.term_size = (120, 24);
+        app.open_pane_tab("cat");
+        make_pane_speak_mouse(&mut app);
+        let layout = app.frame_layout(ratatui::layout::Rect::new(0, 0, 120, 24));
+        let pane = layout.pane.expect("a pane is open");
+        (app, (pane.x + 3, pane.y + 2))
+    }
+
+    /// **A press the child received owes it a release.** claude starts a
+    /// selection on press and fires the actual click on RELEASE, so a press with
+    /// no matching release leaves it drag-selecting forever and never clicking
+    /// anything. The pairing is keyed on the press having been forwarded, not on
+    /// where the pointer is now, so it holds even if the pointer left the pane.
+    #[test]
+    fn a_forwarded_press_is_followed_by_its_release() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let (mut app, (col, row)) = app_with_a_mouse_pane(tmp.path());
+            let frame = ratatui::layout::Rect::new(0, 0, 120, 24);
+            let layout = app.frame_layout(frame);
+
+            let press = app.forward_to_child(
+                at(MouseEventKind::Down(MouseButton::Left), col, row),
+                &layout,
+            );
+            assert!(
+                sent(&press).is_some(),
+                "the press reaches the child: {press:?}"
+            );
+            assert!(
+                app.view.mouse_press_forwarded,
+                "and arms the obligation to deliver the release"
+            );
+
+            // Pointer has left the pane entirely — the release still goes to the
+            // child that saw the press.
+            let release = app.forward_release(
+                at(MouseEventKind::Up(MouseButton::Left), col, row),
+                MouseButton::Left,
+                frame,
+            );
+            assert!(
+                sent(&release).is_some(),
+                "the release reaches the same child: {release:?}"
+            );
+            assert!(
+                !app.view.mouse_press_forwarded,
+                "and the obligation is discharged, not left standing"
+            );
+
+            // A second release is unpaired: the child never saw a press for it,
+            // and an unpaired release is as bad as a missing one.
+            let extra = app.forward_release(
+                at(MouseEventKind::Up(MouseButton::Left), col, row),
+                MouseButton::Left,
+                frame,
+            );
+            assert!(
+                extra.is_empty(),
+                "an unpaired release is not forwarded: {extra:?}"
+            );
+        });
+    }
+
+    /// A press that never reached the child produces no release for it. Without
+    /// this the child would see a button come up that it never saw go down.
+    #[test]
+    fn a_release_whose_press_went_elsewhere_is_not_forwarded() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let (mut app, (col, row)) = app_with_a_mouse_pane(tmp.path());
+            let frame = ratatui::layout::Rect::new(0, 0, 120, 24);
+            // Nothing armed the flag — the press landed on the file list.
+            assert!(!app.view.mouse_press_forwarded);
+            let fx = app.forward_release(
+                at(MouseEventKind::Up(MouseButton::Left), col, row),
+                MouseButton::Left,
+                frame,
+            );
+            assert!(fx.is_empty(), "got {fx:?}");
+        });
+    }
+
+    /// A drag is the middle of one gesture, so it rides the same pairing — but
+    /// must NOT consume it: more drags and then the release still have to arrive.
+    #[test]
+    fn a_drag_rides_the_pairing_without_consuming_it() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let (mut app, (col, row)) = app_with_a_mouse_pane(tmp.path());
+            let frame = ratatui::layout::Rect::new(0, 0, 120, 24);
+            let drag = at(MouseEventKind::Drag(MouseButton::Left), col, row);
+
+            assert!(
+                app.forward_drag(drag, frame).is_empty(),
+                "a drag whose press went elsewhere never reaches the child"
+            );
+
+            app.view.mouse_press_forwarded = true;
+            assert!(
+                sent(&app.forward_drag(drag, frame)).is_some(),
+                "a claimed drag is delivered"
+            );
+            assert!(
+                app.view.mouse_press_forwarded,
+                "and the flag survives, or the release that follows would be dropped"
+            );
+        });
+    }
+
+    /// A wheel tick has no release half, so forwarding one must not arm an
+    /// obligation the child will never be paid — the next real release would
+    /// otherwise be delivered as if it paired with a press.
+    #[test]
+    fn a_forwarded_wheel_tick_arms_no_release() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let (mut app, (col, row)) = app_with_a_mouse_pane(tmp.path());
+            let layout = app.frame_layout(ratatui::layout::Rect::new(0, 0, 120, 24));
+            let fx = app.forward_to_child(at(MouseEventKind::ScrollDown, col, row), &layout);
+            assert!(
+                sent(&fx).is_some(),
+                "the tick still reaches the child: {fx:?}"
+            );
+            assert!(
+                !app.view.mouse_press_forwarded,
+                "a wheel tick owes no release"
+            );
+        });
+    }
+}

--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -369,6 +369,7 @@ impl super::App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::App;
 
     /// The default (uninverted): a downward tick is positive, an upward tick is
     /// negative — "scroll down = toward the end", matching the pager and an
@@ -450,5 +451,199 @@ mod tests {
             gesture_and_delta(MouseEventKind::ScrollDown, 7, false),
             Some((Gesture::Wheel, 7))
         );
+    }
+
+    // ── the dispatch entry itself ──
+    //
+    // `handle_mouse` reassembles the frame, hit-tests the pointer, and turns the
+    // routed sink into effects and focus moves. The `MouseSink` half is pinned by
+    // `route.rs`'s own tests; what follows drives the whole entry, because the
+    // gate, the focus side effect and the wheel's sign live only here.
+
+    use std::time::{Duration, Instant};
+
+    /// A synthetic report at `(col, row)` with no modifiers.
+    fn at(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        }
+    }
+
+    /// An App with a known frame size, plus a point the layout itself says is
+    /// inside the file list — computed rather than guessed, so a layout change
+    /// moves the click instead of silently aiming it somewhere else.
+    fn app_and_a_point_in_the_list(dir: &std::path::Path) -> (App, (u16, u16)) {
+        let mut app = App::test_app(dir.to_path_buf());
+        app.view.term_size = (120, 24);
+        app.state.config.mouse.scroll_lines = 1;
+        let layout = app.frame_layout(ratatui::layout::Rect::new(0, 0, 120, 24));
+        let point = (layout.list.x + 2, layout.list.y + 1);
+        (app, point)
+    }
+
+    /// A pane tab that speaks the mouse, the way a real child says so: the DEC
+    /// mode is written to `cat`'s stdin and comes back through the pty, so the
+    /// pane's own vt100 parser sees the request exactly as it would from claude.
+    /// (The `\n` matters — the line discipline echoes a bare ESC as `^[`, so
+    /// only cat's own re-emit carries the real escape.)
+    ///
+    /// `?1002` — button-event tracking — because that is what a child wanting
+    /// drags asks for; under `?1000` a drag encodes to nothing, correctly.
+    pub(super) fn make_pane_speak_mouse(app: &mut App) {
+        let tabs = app.runtime.pane_tabs.as_mut().expect("a pane tab");
+        tabs.active_mut()
+            .send_bytes(b"\x1b[?1002h\n")
+            .expect("write to the pty");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            tabs.active_mut().drain_output();
+            if tabs.active().wants_mouse() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("the pane never reported mouse mode");
+    }
+
+    /// **The capture gate.** A terminal or multiplexer can report the mouse when
+    /// spyc never asked — a foreground child that died without resetting, for
+    /// one. Acting on those with the feature off is how a stray middle click
+    /// pasted the clipboard and a right click opened the leader menu.
+    #[test]
+    fn a_middle_click_pastes_only_while_capture_is_on() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let (mut app, (col, row)) = app_and_a_point_in_the_list(tmp.path());
+            let click = at(MouseEventKind::Down(MouseButton::Middle), col, row);
+
+            crate::set_mouse_capture_for_test(false);
+            assert!(
+                app.handle_mouse(click).is_empty(),
+                "a report spyc never asked for must do nothing"
+            );
+
+            crate::set_mouse_capture_for_test(true);
+            assert!(
+                matches!(
+                    app.handle_mouse(click).as_slice(),
+                    [Effect::PasteFromClipboard]
+                ),
+                "with capture on the same click pastes"
+            );
+            crate::set_mouse_capture_for_test(false);
+        });
+    }
+
+    /// The wheel moves the column under the POINTER and **stops** at the ends.
+    /// Not `Action::Up`/`Down`: those move the focused column and wrap through
+    /// `rem_euclid`, which is what made scrolling feel like it was flying out of
+    /// control.
+    #[test]
+    fn the_wheel_moves_the_pointed_list_and_never_wraps_past_the_end() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let (mut app, (col, row)) = app_and_a_point_in_the_list(tmp.path());
+            app.seed_rows(&["a", "b", "c"]);
+            crate::set_mouse_capture_for_test(true);
+
+            let down = at(MouseEventKind::ScrollDown, col, row);
+            let up = at(MouseEventKind::ScrollUp, col, row);
+            assert!(
+                app.handle_mouse(down).is_empty(),
+                "the wheel emits no effect"
+            );
+            assert_eq!(app.state.left.cursor.index, 1, "down moves toward the end");
+
+            for _ in 0..10 {
+                app.handle_mouse(down);
+            }
+            assert_eq!(
+                app.state.left.cursor.index, 2,
+                "the wheel stops on the last row rather than wrapping to the top"
+            );
+            for _ in 0..10 {
+                app.handle_mouse(up);
+            }
+            assert_eq!(
+                app.state.left.cursor.index, 0,
+                "and stops on the first row going back"
+            );
+            crate::set_mouse_capture_for_test(false);
+        });
+    }
+
+    /// **The pointer decides, not the keyboard.** The whole hit-test is built on
+    /// this: with the keyboard in the right column, a wheel tick over the LEFT one
+    /// scrolls the left. Reading focus instead would scroll whichever column the
+    /// user last clicked in, which is the one thing a wheel is never about.
+    #[test]
+    fn the_wheel_scrolls_the_column_under_the_pointer_not_the_focused_one() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let right_dir = tmp.path().join("other");
+            std::fs::create_dir_all(&right_dir).unwrap();
+            let (mut app, _) = app_and_a_point_in_the_list(tmp.path());
+            app.seed_rows(&["a", "b", "c"]);
+            app.open_second_commander_at(&right_dir);
+            assert_eq!(
+                app.state.vsplit.map(|v| v.focus),
+                Some(super::super::state::Side::Right),
+                "the keyboard is in the right column"
+            );
+            crate::set_mouse_capture_for_test(true);
+
+            let layout = app.frame_layout(ratatui::layout::Rect::new(0, 0, 120, 24));
+            let left = (layout.list.x + 1, layout.list.y + 1);
+            let before_right = app.state.right.as_ref().expect("split").cursor.index;
+
+            app.handle_mouse(at(MouseEventKind::ScrollDown, left.0, left.1));
+
+            assert_eq!(
+                app.state.left.cursor.index, 1,
+                "the pointed (left) column moved"
+            );
+            assert_eq!(
+                app.state.right.as_ref().expect("split").cursor.index,
+                before_right,
+                "the focused (right) column did not"
+            );
+            crate::set_mouse_capture_for_test(false);
+        });
+    }
+
+    /// Right-click opens the which-key popup **now**. The `chord_hint_delay_ms`
+    /// debounce exists so a keyboard user mid-chord isn't startled by a popup; a
+    /// deliberate right click has no such problem, so the due instant is set in
+    /// the past for `settle_chord_hint` to build on this same iteration.
+    #[test]
+    fn a_right_click_enters_the_leader_and_shows_the_hint_without_the_delay() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let (mut app, (col, row)) = app_and_a_point_in_the_list(tmp.path());
+            crate::set_mouse_capture_for_test(true);
+            assert!(app.view.chord_hint_due.is_none());
+
+            let fx = app.handle_mouse(at(MouseEventKind::Down(MouseButton::Right), col, row));
+
+            assert!(fx.is_empty(), "the menu is state, not an effect");
+            assert_eq!(
+                app.state.resolver.pending_display().as_deref(),
+                Some("leader-"),
+                "the resolver is mid-chord on the leader"
+            );
+            let due = app.view.chord_hint_due.expect("a hint is due");
+            assert!(
+                due <= Instant::now(),
+                "the popup must be due already, not after the keyboard debounce"
+            );
+            crate::set_mouse_capture_for_test(false);
+        });
     }
 }

--- a/src/app/mouse/scroll.rs
+++ b/src/app/mouse/scroll.rs
@@ -201,3 +201,147 @@ impl super::super::App {
         }]
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::{App, Effect, PaneInput};
+    use std::time::{Duration, Instant};
+
+    /// Every byte the effects would write to the pty.
+    fn bytes(fx: &[Effect]) -> Vec<u8> {
+        fx.iter()
+            .filter_map(|e| match e {
+                Effect::SendToPane {
+                    input: PaneInput::Bytes(b),
+                    ..
+                } => Some(b.clone()),
+                _ => None,
+            })
+            .flatten()
+            .collect()
+    }
+
+    /// A pane that looks to spyc like codex with its `^T` transcript open, at the
+    /// bottom of it.
+    ///
+    /// The screen content is what `send_agent_view_scroll_keys` scrapes, so it is
+    /// written through the pty and echoed back rather than injected — the marker
+    /// and the `100%` footer arrive as codex's own would. `cat` is the child; only
+    /// the command string decides which profile answers.
+    fn codex_pane_showing_the_transcript(dir: &std::path::Path) -> App {
+        let mut app = App::test_app(dir.to_path_buf());
+        app.view.term_size = (120, 24);
+        app.state.config.mouse.pane_scroll_view = crate::config::PaneScrollView::Native;
+        app.open_pane_tab("cat");
+        let tabs = app.runtime.pane_tabs.as_mut().expect("a pane tab");
+        tabs.active_entry_mut().info.command = "codex".to_string();
+        tabs.active_mut()
+            .send_bytes("T R A N S C R I P T\n\u{2500}\u{2500} 100% \u{2500}\u{2500}\n".as_bytes())
+            .expect("write to the pty");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            tabs.active_mut().drain_output();
+            let visible = tabs.active().visible_lines();
+            if visible.iter().any(|l| l.contains("T R A N S C R I P T"))
+                && visible
+                    .iter()
+                    .rev()
+                    .find(|l| l.contains('\u{2500}'))
+                    .is_some_and(|l| l.contains(" 100% "))
+            {
+                return app;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("the pane never showed the transcript marker and footer");
+    }
+
+    /// **One flick past the bottom closes the view once.** The scrape still reads
+    /// "open" for a tick or two after the close key lands — codex hasn't redrawn
+    /// the composer yet — so without the pending guard riding out that stale read
+    /// every remaining tick of the flick sends another `q`, straight into the
+    /// composer's text input as literal typing.
+    ///
+    /// Drives `send_agent_view_scroll_keys` itself. The route-level test of the
+    /// same name re-implements this loop, so it stays green when the caller is
+    /// wrong; this one doesn't.
+    #[test]
+    fn one_flick_past_the_bottom_sends_the_close_key_once_through_the_caller() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let mut app = codex_pane_showing_the_transcript(tmp.path());
+            let profile = crate::agent::detect("codex");
+            let marker = profile
+                .transcript_open_marker()
+                .expect("codex marks its transcript");
+
+            // Five downward ticks, the shape of one trackpad flick.
+            let closes = (0..5)
+                .filter(|_| {
+                    let fx = app.send_agent_view_scroll_keys(profile, marker, 1);
+                    bytes(&fx).contains(&b'q')
+                })
+                .count();
+            assert_eq!(
+                closes, 1,
+                "the close key went out {closes}× on one flick — each extra one is a `q` typed into codex's composer"
+            );
+        });
+    }
+
+    /// A downward tick with the view open but NOT at the bottom scrolls it, using
+    /// codex's own binding — it must not close on the way down.
+    #[test]
+    fn a_tick_inside_the_transcript_scrolls_instead_of_closing() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let mut app = App::test_app(tmp.path().to_path_buf());
+            app.view.term_size = (120, 24);
+            app.state.config.mouse.pane_scroll_view = crate::config::PaneScrollView::Native;
+            app.open_pane_tab("cat");
+            let tabs = app.runtime.pane_tabs.as_mut().expect("a pane tab");
+            tabs.active_entry_mut().info.command = "codex".to_string();
+            // Marker present, no `100%` footer: open, mid-history.
+            tabs.active_mut()
+                .send_bytes(
+                    "T R A N S C R I P T\n\u{2500}\u{2500} 40% \u{2500}\u{2500}\n".as_bytes(),
+                )
+                .expect("write to the pty");
+            let deadline = Instant::now() + Duration::from_secs(10);
+            while Instant::now() < deadline {
+                tabs.active_mut().drain_output();
+                if tabs
+                    .active()
+                    .visible_lines()
+                    .iter()
+                    .any(|l| l.contains("T R A N S C R I P T"))
+                {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+
+            let profile = crate::agent::detect("codex");
+            let marker = profile.transcript_open_marker().expect("marked");
+            let out = bytes(&app.send_agent_view_scroll_keys(profile, marker, 1));
+            assert!(!out.is_empty(), "a tick mid-transcript has to do something");
+            assert!(
+                !out.contains(&b'q'),
+                "and it must not be the close key: {out:?}"
+            );
+        });
+    }
+
+    /// With no pane there is nothing to scroll — and nothing to panic on.
+    #[test]
+    fn a_tick_with_no_pane_does_nothing() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let mut app = App::test_app(tmp.path().to_path_buf());
+            assert!(app.send_scroll_keys(1).is_empty());
+        });
+    }
+}


### PR DESCRIPTION
**H9** of the pre-2.1 review (`F-tests-guards.md`, F2/F3/F4) — `high`.

`handle_mouse`, `forward.rs` and `scroll.rs` had no tests at all — the three places where a mouse event actually becomes behavior. Ten tests, every one bite-checked against the mutation it exists to catch:

| mutation | test that now fails |
|---|---|
| capture gate removed | `a_middle_click_pastes_only_while_capture_is_on` |
| `chord_hint_due` never set | `a_right_click_enters_the_leader_and_shows_the_hint_without_the_delay` |
| wheel reads focus instead of the pointer | `the_wheel_scrolls_the_column_under_the_pointer_not_the_focused_one` |
| `mouse_press_forwarded` never armed | `a_forwarded_press_is_followed_by_its_release` |
| release stops consuming the pairing | same |
| the `pending_view_confirmed` guard reverted to `if is_open` | `one_flick_past_the_bottom_sends_the_close_key_once_through_the_caller` |

## The one that matters most

That last row is the finding's sharpest point. The existing route-level `one_flick_past_the_bottom_sends_the_close_key_once` re-implements the caller loop inside the test, so putting the shipped bug back leaves it **green**. The new test drives `send_agent_view_scroll_keys` itself and fails with:

```
the close key went out 3× on one flick — each extra one is a `q` typed into codex's composer
```

Verified both ways in the same run: route-level `ok`, caller-level `FAILED`.

## How the fixtures work

Panes are made to speak the mouse **the way a real child does** rather than by poking the parser: the DEC mode is written to `cat`'s stdin and comes back through the pty, so the pane's own vt100 sees `?1002h` exactly as it would from claude. The trailing newline is load-bearing — the line discipline echoes a bare ESC as `^[`, so only cat's own re-emit carries the real escape. `?1002` (button-event tracking) rather than `?1000`, because under 1000 a drag correctly encodes to nothing.

The codex scroll tests seed the `T R A N S C R I P T` marker and the `100%` footer through the same path, since that screen text is precisely what the scrape reads.

Click coordinates come from `frame_layout` rather than being guessed, so a layout change moves the click instead of silently aiming it somewhere else.

No production behavior changes. Gate: `=== GATE: PASS ===`, 2389 lib tests, 0 ignored.

Generated with [Claude Code](https://claude.com/claude-code)