### PR TITLE
build: ask cargo where target/ is, so a shared build dir works

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,11 +157,12 @@ make release-tag VERSION=x.y.z        # step 2, on main after that PR merged: ve
 
 **Crate shape: lib + bin.** `src/lib.rs` owns every module + the `run()` entry point; `src/main.rs` is a thin shim. The split lets `fuzz/` (a standalone workspace; nightly, on-demand) link the lib. New fuzz entry points go through the `pub mod fuzz` facade in `lib.rs`, not by widening module visibility.
 
-**Leave no `target/` behind — `cargo clean` when you're done with a worktree.** One gate run leaves ~4 GB of build cache and the worktree-per-PR layout multiplies it: thirteen parked worktrees reached **57 GB**. The rebuild is worth the disk, so clean eagerly rather than banking the cache — and `remove_worktree` as soon as a PR merges, which takes the cache with it. **`fuzz/` is a separate workspace, so the root `cargo clean` doesn't touch `fuzz/target`** — another ~2.6 GB per worktree, surviving the obvious command:
+**Build output is disk-expensive: one gate run leaves ~4 GB, and worktree-per-PR multiplies it** — thirteen parked worktrees reached **57 GB**. Two rules follow, and which one applies depends on whether the machine shares a build directory (`[build] target-dir` in `~/.cargo/config.toml`, or `CARGO_TARGET_DIR`; `make` asks cargo via `TARGET_DIR`, so never hardcode `target/` in a recipe):
 
-```sh
-cargo clean && cargo clean --manifest-path fuzz/Cargo.toml
-```
+- **Sharing one** (recommended, and what this developer runs): dependencies compile once for every worktree. `cargo clean` there wipes the cache out from under every other worktree and agent — **prune by age instead**, `cargo sweep --time 7`. Cargo holds an exclusive lock on the directory, so concurrent builds serialize; that's the accepted trade, and `rust-analyzer.toml` keeps the language server out of the same lock.
+- **Per-worktree `target/`**: `cargo clean` when you're done with a worktree — the rebuild is worth the disk. **`fuzz/` is a separate workspace, so the root clean doesn't touch `fuzz/target`**, another ~2.6 GB that survives the obvious command: `cargo clean && cargo clean --manifest-path fuzz/Cargo.toml`.
+
+Either way, `remove_worktree` as soon as a PR merges — thirteen live worktrees is the anomaly no cache layout fixes.
 
 ## Roadmap
 

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,14 @@ BINARY   := spyc
 VERSION  := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
 DIST_DIR := dist
 
+# Where cargo actually writes build output. `target/` by default, but a shared
+# `CARGO_TARGET_DIR` / `[build] target-dir` redirects it — worth doing when a
+# worktree-per-PR layout would otherwise carry a ~4 GB `target/` each. Ask cargo
+# rather than assuming, or `make install` silently installs nothing. Recursive
+# `=`, so only the rules that need a built binary pay the `cargo metadata` call.
+TARGET_DIR = $(or $(CARGO_TARGET_DIR),$(shell cargo metadata --no-deps --format-version 1 \
+  | python3 -c 'import json,sys;print(json.load(sys.stdin)["target_directory"])' 2>/dev/null),target)
+
 # Rust flags shared across release builds.
 RELEASE_FLAGS := --locked --release
 
@@ -127,13 +135,13 @@ demos: ## Re-record the README demo GIFs (needs vhs; TAPE=spyc|pager|vsplit|lua|
 		echo "vhs not found — install with: brew install vhs"; \
 		exit 1; \
 	}
-	@test -x target/release/spyc || { \
+	@test -x $(TARGET_DIR)/release/spyc || { \
 		echo "no release binary — run: cargo build --release"; \
 		exit 1; \
 	}
 	@for tape in $(or $(TAPE),spyc pager vsplit lua review agents); do \
 		echo "── recording $$tape ──"; \
-		PATH="$(CURDIR)/target/release:$$PATH" vhs docs/assets/demo/$$tape.tape || exit 1; \
+		PATH="$(abspath $(TARGET_DIR))/release:$$PATH" vhs docs/assets/demo/$$tape.tape || exit 1; \
 	done
 
 .PHONY: fuzz
@@ -195,15 +203,15 @@ aislop-baseline: ## Regenerate .aislop/baseline.json from the current scan
 release: ## Optimized release for the current platform
 	@echo "building $(BINARY) v$(VERSION) (release — final crate is the linker, may take a moment)…"
 	cargo build $(RELEASE_FLAGS)
-	@echo "→ target/release/$(BINARY)"
-	@ls -lh target/release/$(BINARY)
+	@echo "→ $(TARGET_DIR)/release/$(BINARY)"
+	@ls -lh $(TARGET_DIR)/release/$(BINARY)
 
 .PHONY: release-debug
 release-debug: ## Optimized build with debug symbols (for `sample`, `lldb`, `perf`)
 	@echo "building $(BINARY) v$(VERSION) (release-debug — symbols included)…"
 	cargo build --locked --profile release-debug
-	@echo "→ target/release-debug/$(BINARY)"
-	@ls -lh target/release-debug/$(BINARY)
+	@echo "→ $(TARGET_DIR)/release-debug/$(BINARY)"
+	@ls -lh $(TARGET_DIR)/release-debug/$(BINARY)
 
 # --- Changelog & release tagging (git-cliff) ---------------------------------
 # CHANGELOG.md is git-cliff-generated from v1.57.0 onward (older entries are
@@ -403,7 +411,7 @@ PREFIX ?= $(HOME)/.local
 .PHONY: install
 install: release ## Install to ~/.local/bin (builds release first; override with PREFIX=/usr/local)
 	install -d $(PREFIX)/bin
-	install -m 755 target/release/$(BINARY) $(PREFIX)/bin/$(BINARY)
+	install -m 755 $(TARGET_DIR)/release/$(BINARY) $(PREFIX)/bin/$(BINARY)
 ifeq ($(shell uname),Darwin)
 	codesign -s - -v $(PREFIX)/bin/$(BINARY)
 endif
@@ -417,7 +425,7 @@ endif
 .PHONY: install-debug
 install-debug: release-debug ## Install symbolicated build as $(PREFIX)/bin/spyc.debug (for profiling)
 	install -d $(PREFIX)/bin
-	install -m 755 target/release-debug/$(BINARY) $(PREFIX)/bin/$(BINARY).debug
+	install -m 755 $(TARGET_DIR)/release-debug/$(BINARY) $(PREFIX)/bin/$(BINARY).debug
 ifeq ($(shell uname),Darwin)
 	codesign -s - -v $(PREFIX)/bin/$(BINARY).debug
 endif

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,0 +1,12 @@
+# rust-analyzer, per project — read by the server itself, so it applies whatever
+# spawns it (an editor, or `claude`, which starts one per agent session).
+#
+# `cargo.targetDir` gives rust-analyzer's own `cargo check` a subdirectory of the
+# build directory instead of the build directory itself. Without it the server
+# and every build contend for cargo's exclusive lock on that directory, and each
+# blocks the other — visible as "Blocking waiting for file lock on build
+# directory" mid-build, or an editor whose diagnostics stall for a whole compile.
+# That contention is mild with one checkout and one server; it is not with
+# several worktrees, several agent sessions, and a shared `[build] target-dir`.
+[cargo]
+targetDir = true


### PR DESCRIPTION
Six recipes named `target/release/...` literally. Point a machine at a shared build directory — one cache for every worktree instead of ~4 GB each — and `make install` installs nothing, `make demos` can't find the binary to record, and the size reports print a path that doesn't exist. The failure is silent in the worst place: install exits 0.

**`TARGET_DIR`** asks `cargo metadata` for the real directory, honouring `CARGO_TARGET_DIR` first and falling back to `target`. Recursive `=`, so only recipes needing a built binary pay the call — `make build` and the gate don't. The demos PATH entry goes through `$(abspath …)`, because the tape `cd`s into its fixture before spawning spyc and a relative PATH entry would stop resolving there.

**`rust-analyzer.toml`** keeps the language server's own cargo out of the shared directory's lock. That lock is exclusive, so with several worktrees, several agent sessions each spawning a server, and one shared cache, the server and every build take turns — an editor stalling for a whole compile, builds reporting `Blocking waiting for file lock on build directory`. The file is read by the server itself rather than by a client, which is what makes it work here: these servers are spawned by `claude`, not by an editor with a settings.json.

**`AGENTS.md`** splits the disk rule by layout, because the right action inverts: with a shared directory `cargo clean` wipes the cache out from under every other worktree and agent, so it becomes `cargo sweep --time 7` (prune by age). Per-worktree `target/` keeps the eager clean, including the `fuzz/` workspace the root clean misses.

## Test plan

Verified against a live shared directory (`[build] target-dir` in `~/.cargo/config.toml`):

- `TARGET_DIR` resolves to the shared path; `CARGO_TARGET_DIR=… make` overrides it.
- `make check-ci` green, and leaves **no `./target`** — output landed in the shared dir.
- `make release` → binary at the shared path; `make install PREFIX=/tmp/install-verify` produced a working `spyc 2.1.0-CURRENT (9067366)`.
- CI is unaffected: it sets its own `CARGO_TARGET_DIR: target-cov` for coverage, which `TARGET_DIR` honours first.

Generated with [Claude Code](https://claude.com/claude-code)