### PR TITLE
fix(graveyard): run the cap cascade off the startup thread

### DIFF
--- a/src/app/archive_route.rs
+++ b/src/app/archive_route.rs
@@ -510,9 +510,11 @@ fn staging_path(member: &Path, mounts: &Mounts) -> Option<PathBuf> {
 fn graveyard_paths(op: &super::graveyard_ops::GraveyardOp) -> Vec<PathBuf> {
     match op {
         super::graveyard_ops::GraveyardOp::Archive { paths } => paths.clone(),
-        // Restoring or purging targets the graveyard's own store, never a mount.
+        // Restoring, purging, or enforcing the cap targets the graveyard's own
+        // store, never a mount.
         super::graveyard_ops::GraveyardOp::Restore { dest, .. } => vec![dest.clone()],
-        super::graveyard_ops::GraveyardOp::PurgeAll { .. } => Vec::new(),
+        super::graveyard_ops::GraveyardOp::PurgeAll { .. }
+        | super::graveyard_ops::GraveyardOp::CascadeToCap { .. } => Vec::new(),
     }
 }
 

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -372,22 +372,9 @@ impl App {
         if !health_warnings.is_empty() {
             app.state.flash_error(health_warnings.join("; "));
         }
-        // Graveyard cascade: if total exceeds the cap, push the
-        // oldest entries to the system trash (FIFO) until under
-        // the cap. Best-effort and silent on failure (the user
-        // would see a flash from any visible-error path; failures
-        // here are uncommon disk/permissions issues that don't
-        // need to interrupt startup).
-        // `cascade_until_under` owns the under-cap check and returns `(0, 0)`
-        // without evicting, so asking first with our own `load()` only bought a
-        // second walk of the directory on every single launch.
-        let cap = crate::state::graveyard::GRAVEYARD_CAP_BYTES;
-        let (trashed, _errors) = crate::state::graveyard::Graveyard::cascade_until_under(cap);
-        if trashed > 0 {
-            app.state.flash_info(format!(
-                "graveyard: {trashed} item(s) moved to system trash (cap reached)"
-            ));
-        }
+        // The graveyard cap cascade is deliberately NOT here: it is an
+        // `Effect::Graveyard` kicked from `App::run`, so its disk IO stays off
+        // the startup path. See that call site.
 
         if resume {
             app.show_session_picker();

--- a/src/app/graveyard_ops.rs
+++ b/src/app/graveyard_ops.rs
@@ -34,6 +34,14 @@ pub enum GraveyardOp {
     Restore { entry: Box<Entry>, dest: PathBuf },
     /// graveyard `Z`: cascade every entry to the system trash.
     PurgeAll { entries: Vec<Entry> },
+    /// Startup cap enforcement: walk the graveyard once and, if it is over
+    /// `cap`, evict oldest-first until under.
+    ///
+    /// The *decision* runs on the worker too — unlike the other variants, the
+    /// main thread doesn't even walk the directory to find out whether there is
+    /// work, because that walk is itself the cost we are moving off the startup
+    /// path.
+    CascadeToCap { cap: u64 },
 }
 
 /// The result of a [`GraveyardOp`], applied by [`App::apply_graveyard_outcomes`].
@@ -49,6 +57,12 @@ pub enum GraveyardOutcome {
         result: Result<(), String>,
     },
     Purged {
+        trashed: usize,
+        errors: usize,
+    },
+    /// Result of the startup cap cascade. `(0, 0)` — under cap, nothing to do —
+    /// is the overwhelmingly common case and is applied silently.
+    Cascaded {
         trashed: usize,
         errors: usize,
     },
@@ -97,6 +111,10 @@ pub fn run_graveyard_op(op: GraveyardOp) -> GraveyardOutcome {
                 }
             }
             GraveyardOutcome::Purged { trashed, errors }
+        }
+        GraveyardOp::CascadeToCap { cap } => {
+            let (trashed, errors) = Graveyard::cascade_until_under(cap);
+            GraveyardOutcome::Cascaded { trashed, errors }
         }
     }
 }
@@ -159,6 +177,28 @@ impl App {
                 } else {
                     self.state
                         .flash_info(format!("graveyard: trashed {trashed} item(s)"));
+                }
+                self.reload_graveyard_rows();
+            }
+            GraveyardOutcome::Cascaded { trashed, errors } => {
+                // Under cap: nothing happened, so say nothing. This is the path
+                // every ordinary launch takes.
+                if trashed == 0 && errors == 0 {
+                    return;
+                }
+                if errors > 0 {
+                    // The pre-move code discarded this count, so a cascade that
+                    // could never succeed (no system trash, unrestorable legacy
+                    // entries) retried every entry on every launch in silence.
+                    // Name it, because the user has to act to clear it.
+                    self.state.flash_error(format!(
+                        "graveyard: {trashed} moved to system trash, {errors} failed \
+                         — still over cap (see :graveyard)"
+                    ));
+                } else {
+                    self.state.flash_info(format!(
+                        "graveyard: {trashed} item(s) moved to system trash (cap reached)"
+                    ));
                 }
                 self.reload_graveyard_rows();
             }
@@ -259,5 +299,93 @@ mod tests {
         assert!(app.apply_graveyard_outcomes());
         assert!(app.flash_text().unwrap().contains("removed 3"));
         assert!(!app.apply_graveyard_outcomes());
+    }
+
+    // ── startup cap cascade, off-thread ───────────────────────────
+
+    /// Under cap — what every ordinary launch does. The worker still runs, but
+    /// it evicts nothing, and the user must not be told about a non-event.
+    #[test]
+    fn cascade_to_cap_under_cap_is_a_silent_no_op() {
+        let root = tempdir().unwrap();
+        crate::state::with_state_root(root.path(), || {
+            let work = tempdir().unwrap();
+            let src = work.path().join("small.txt");
+            writeln!(std::fs::File::create(&src).unwrap(), "tiny").unwrap();
+            let _ = run_graveyard_op(GraveyardOp::Archive { paths: vec![src] });
+
+            let out = run_graveyard_op(GraveyardOp::CascadeToCap {
+                cap: crate::state::graveyard::GRAVEYARD_CAP_BYTES,
+            });
+            let GraveyardOutcome::Cascaded { trashed, errors } = out else {
+                panic!("expected Cascaded");
+            };
+            assert_eq!((trashed, errors), (0, 0), "one tiny file is under cap");
+
+            let mut app = App::test_app(std::env::temp_dir());
+            app.runtime
+                .graveyard_results
+                .lock()
+                .unwrap()
+                .push(GraveyardOutcome::Cascaded {
+                    trashed: 0,
+                    errors: 0,
+                });
+            assert!(app.apply_graveyard_outcomes(), "outcome is still drained");
+            assert!(
+                app.flash_text().is_none(),
+                "a no-op cascade must not flash: {:?}",
+                app.flash_text()
+            );
+            // The entry is untouched — nothing was evicted.
+            assert_eq!(Graveyard::load().entries.len(), 1);
+        });
+    }
+
+    /// A cascade whose evictions all fail must SAY so. The pre-move code
+    /// discarded the error count, so a graveyard that could never drain below
+    /// cap retried every entry on every launch with no way for the user to tell.
+    #[test]
+    fn a_failing_cascade_reports_instead_of_failing_silently() {
+        let mut app = App::test_app(std::env::temp_dir());
+        app.runtime
+            .graveyard_results
+            .lock()
+            .unwrap()
+            .push(GraveyardOutcome::Cascaded {
+                trashed: 2,
+                errors: 5,
+            });
+        assert!(app.apply_graveyard_outcomes());
+        let flash = app.flash_text().expect("a failing cascade must flash");
+        assert!(
+            flash.contains('5'),
+            "should name the failure count: {flash}"
+        );
+        assert!(
+            flash.contains("still over cap"),
+            "should say the state persists: {flash}"
+        );
+    }
+
+    /// A successful cascade names what it moved, so the user can find the files
+    /// in the OS trash.
+    #[test]
+    fn a_successful_cascade_names_what_it_moved() {
+        let mut app = App::test_app(std::env::temp_dir());
+        app.runtime
+            .graveyard_results
+            .lock()
+            .unwrap()
+            .push(GraveyardOutcome::Cascaded {
+                trashed: 3,
+                errors: 0,
+            });
+        assert!(app.apply_graveyard_outcomes());
+        let flash = app.flash_text().expect("flash expected");
+        assert!(
+            flash.contains('3') && flash.contains("system trash"),
+            "{flash}"
+        );
     }
 }

--- a/src/app/run.rs
+++ b/src/app/run.rs
@@ -462,6 +462,27 @@ impl App {
                 .clone(),
         };
 
+        // Enforce the graveyard cap OFF the startup path. The single directory
+        // walk plus each eviction's decompress + system-trash call is disk IO
+        // proportional to the graveyard's size, and running it inside
+        // `App::new` meant a full graveyard reached the user as a launch that
+        // appeared to hang — no TUI yet, so nothing on screen explained it.
+        //
+        // Emitted here rather than in `bootstrap` for the same reason as
+        // `load_init_lua` above: the worker wakes the loop through the channel
+        // `run_setup` installs, and `run_effects` needs the `foreground_exec`
+        // built just above. The op decides for itself whether there is anything
+        // to evict, so the main thread never touches the directory.
+        self.run_effects(
+            vec![Effect::Graveyard(
+                super::graveyard_ops::GraveyardOp::CascadeToCap {
+                    cap: crate::state::graveyard::GRAVEYARD_CAP_BYTES,
+                },
+            )],
+            terminal,
+            &foreground_exec,
+        );
+
         // (Pre-v1.50.84 the loop carried `last_pane_render` and
         // `last_active_drain` timestamps to throttle pane renders /
         // parses while the user was typing. Both became unnecessary


### PR DESCRIPTION
Follow-up to #367 (merged). That fix made the cascade walk the directory once instead of once per entry; this takes the remaining work off the startup thread entirely.

## Why the O(N²) fix wasn't enough

Even walking the graveyard once, the cascade is disk IO proportional to its size: one directory walk, then per evicted entry a **zstd decompress + tar extract into a temp dir + a system-trash call**. It ran synchronously inside `App::new`, *before the TUI exists* — so all of it reached the user as a launch with nothing on screen.

**This is the same defect `graveyard_ops.rs` was created to fix.** From its own module doc:

> `handle_remove_confirm_key` / `undo_last_remove` / `handle_graveyard_purge_all_confirm` **used to call** `Graveyard::write_entry` + `remove_tree` / `restore` / `cascade_entry_to_trash` **INLINE in the key-dispatch path — seconds-to-minutes of blocking CPU+disk IO on the single event-loop thread**

The startup cascade was simply missed by that refactor — it was the one graveyard op that never went through `Effect`.

## The change

`GraveyardOp::CascadeToCap { cap }` runs on the same detached worker as the other ops and lands a `GraveyardOutcome::Cascaded` that `apply_graveyard_outcomes` flashes from the pre-recv drain.

**The decision runs on the worker too**, which is the one way this variant differs from its siblings. The others do their cheap part on the main thread first (pick an entry, clone a path list); here the "cheap part" would be the directory walk — precisely the cost being moved. `cascade_until_under` already returns `(0, 0)` when under cap, so the op is emitted unconditionally and **the main thread never touches the graveyard directory at all**.

Kicked from `App::run`, not `bootstrap`, for the same reason `load_init_lua` is: the worker wakes the loop through the channel `run_setup` installs, and `run_effects` needs the `foreground_exec` built just above it. `bootstrap` now performs **no** graveyard IO.

## Stops swallowing the failure count

The old call site bound it to `_errors` and dropped it. A cascade that could *never* succeed — no system trash available, unrestorable legacy entries — silently retried every entry on **every launch**: a permanently slow boot with nothing to explain it. Now:

- `(0, 0)` under cap → **silent** (what every ordinary launch does)
- errors > 0 → flashes the count and says it's *still over cap*, pointing at `:graveyard`

This closes the diagnostic gap I flagged in #367. Worth asking Spencer whether he ever saw a *"moved to system trash"* flash — if not, his evictions were failing, and this is the message he needed.

## Checked, not assumed

**Concurrency:** `delete_entry` unlinks the `.json` before the `.tar.zst`, and `read_entries` only iterates `.json` files — so a `:graveyard` opened *while* the cascade runs cannot observe a half-deleted entry. No new race introduced by making it concurrent.

**An exhaustive match caught the gap:** `archive_route.rs`'s `graveyard_paths` needed the new variant, and that match is exhaustive on purpose so a new op is a build error rather than a silent pass-through. A cap cascade touches the graveyard's own store and never a mount, so it classifies with `PurgeAll`: no paths.

## Tests

`make check-ci` → `=== GATE: PASS ===`, 22 graveyard tests green.

- `cascade_to_cap_under_cap_is_a_silent_no_op` — the worker runs, evicts nothing, the entry is untouched, **and the outcome produces no flash**. The common path must not narrate a non-event.
- `a_failing_cascade_reports_instead_of_failing_silently`
- `a_successful_cascade_names_what_it_moved`

## ⚠️ Measured, and deliberately NOT fixed here

`health::check` **also** runs synchronously in `App::new` and walks the graveyard **twice** (`check_paired_dir`, then `check_graveyard_size`):

| graveyard entries | `health::check` |
|---|---|
| 500 | 24 ms |
| 2000 | 211 ms |
| 5000 | **557 ms** |

Linear, not quadratic — but not free, and it runs on **every** launch regardless of the cap. So it's a standing contributor to "broke the load times" that is independent of the cascade, and it will still be there after this PR.

It can't simply move off-thread: `bootstrap` runs it *before* loading state because it cleans up orphaned files first, so state loading depends on it having finished. Merging its two walks into one is the obvious contained fix (roughly halving the cost) and wants its own PR.

Generated with [Claude Code](https://claude.com/claude-code)