### PR TITLE
perf(health): the startup scan stops opening every metadata file

### DIFF
--- a/src/state/health.rs
+++ b/src/state/health.rs
@@ -20,25 +20,27 @@ pub fn check(state_dir: &Path) -> HealthReport {
     let mut warnings = Vec::new();
     let mut cleaned = 0usize;
 
-    cleaned += check_paired_dir(
+    let (inv_cleaned, _inv_bytes) = check_paired_dir(
         &state_dir.join("inventory"),
         &mut warnings,
         "inventory",
         &["dat"],
     );
+    cleaned += inv_cleaned;
     // The graveyard payload is `<uuid>.tar.zst` (current) or `<uuid>.dat`
     // (pre-v1.41.0 legacy, migrated by the cascade). Both must be recognized
     // as the metadata json's partner — otherwise every valid entry's json is
     // mistaken for an orphan and deleted, permanently breaking undo.
-    cleaned += check_paired_dir(
+    let (gy_cleaned, gy_bytes) = check_paired_dir(
         &state_dir.join("graveyard"),
         &mut warnings,
         "graveyard",
         &["tar.zst", "dat"],
     );
+    cleaned += gy_cleaned;
     check_marks(&state_dir.join("marks.toml"), &mut warnings);
     check_sessions(&state_dir.join("sessions"), &mut warnings);
-    check_graveyard_size(&state_dir.join("graveyard"), &mut warnings);
+    warn_on_graveyard_size(gy_bytes, &mut warnings);
     check_frecency(&state_dir.join("frecency.json"), &mut warnings);
 
     HealthReport { warnings, cleaned }
@@ -54,35 +56,64 @@ pub fn check(state_dir: &Path) -> HealthReport {
 /// `zst` and stem `<uuid>.tar`, so naive extension/stem pairing would
 /// never match it against `<uuid>.json` and would delete every live
 /// entry as an "orphan".
+///
+/// **Opens nothing.** Pairing is decided from filenames, and a corrupt
+/// metadata file is detected from the size `read_dir` already reports. This
+/// used to `read_to_string` + `serde_json::from_str` *every* `<stem>.json` on
+/// every launch to prove it parsed, which cost 526ms of the 550ms this
+/// function took on a 5000-entry graveyard — 5000 file opens, on the
+/// synchronous startup path.
+///
+/// That validation was guarding a state that cannot occur: both writers
+/// ([`crate::state::graveyard::Graveyard::write_entry_as`] and
+/// [`crate::state::inventory`]) emit their json through
+/// [`crate::fs::write_atomic`], which writes a temp file and renames it. A
+/// rename is atomic, so a `<stem>.json` here is either absent or complete —
+/// never half-written. A zero-length one is still treated as corrupt, since
+/// that check is free.
+///
+/// Anything unparseable that does slip in (bit rot, a hand-edited file) is
+/// skipped by the readers rather than crashing them —
+/// `graveyard::read_entries` and the inventory loader both `.ok()?` the parse —
+/// so the cost of not catching it eagerly is a stale pair on disk, not a
+/// failure. The size warning below still counts its bytes.
+///
+/// Returns `(removed, total_bytes)`; the byte total is summed from the same
+/// walk so the caller doesn't need a second pass over the directory.
 fn check_paired_dir(
     dir: &Path,
     warnings: &mut Vec<String>,
     label: &str,
     payload_suffixes: &[&str],
-) -> usize {
+) -> (usize, u64) {
     let Ok(entries) = std::fs::read_dir(dir) else {
-        return 0; // directory missing is fine — first run
+        return (0, 0); // directory missing is fine — first run
     };
 
     let mut jsons = std::collections::HashSet::new();
     let mut payload_stems = std::collections::HashSet::new();
     let mut payload_files: Vec<(String, PathBuf)> = Vec::new();
     let mut corrupt_json = 0usize;
+    let mut total_bytes = 0u64;
 
     for entry in entries.filter_map(Result::ok) {
         let path = entry.path();
         let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
             continue;
         };
+        // One `stat` per entry, reused for both the corrupt check and the size
+        // total. `DirEntry::metadata` does not follow symlinks and on most
+        // platforms is served from the directory read itself.
+        let len = entry.metadata().map(|m| m.len()).unwrap_or_default();
+        total_bytes += len;
         if let Some(stem) = name.strip_suffix(".json") {
-            // Validate JSON is parseable.
-            if let Ok(text) = std::fs::read_to_string(&path) {
-                if serde_json::from_str::<serde_json::Value>(&text).is_err() {
-                    corrupt_json += 1;
-                    let _ = std::fs::remove_file(&path);
-                } else {
-                    jsons.insert(stem.to_string());
-                }
+            if len == 0 {
+                // An empty metadata file can never parse. Written atomically,
+                // so this should be unreachable; cheap to keep honest.
+                corrupt_json += 1;
+                let _ = std::fs::remove_file(&path);
+            } else {
+                jsons.insert(stem.to_string());
             }
         } else if let Some(stem) = payload_suffixes
             .iter()
@@ -123,7 +154,7 @@ fn check_paired_dir(
         warnings.push(format!("{label}: cleaned up {orphans} orphaned file(s)"));
     }
 
-    removed
+    (removed, total_bytes)
 }
 
 /// Check marks.toml — warn if it exists but can't be parsed.
@@ -168,17 +199,11 @@ fn check_sessions(dir: &Path, warnings: &mut Vec<String>) {
 }
 
 /// Warn if the graveyard is consuming significant disk space.
-fn check_graveyard_size(dir: &Path, warnings: &mut Vec<String>) {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-
-    let total_bytes: u64 = entries
-        .filter_map(Result::ok)
-        .filter_map(|e| e.metadata().ok())
-        .map(|m| m.len())
-        .sum();
-
+///
+/// Takes the total rather than deriving it, because [`check_paired_dir`] has
+/// already walked the directory and stat'd every entry — this used to be a
+/// second full walk for the same number.
+fn warn_on_graveyard_size(total_bytes: u64, warnings: &mut Vec<String>) {
     // Warn above 100 MB.
     if total_bytes > 100 * 1024 * 1024 {
         let mb = total_bytes / (1024 * 1024);
@@ -241,16 +266,80 @@ mod tests {
         assert!(!inv.join("abc123.json").exists());
     }
 
+    /// An empty metadata file is still cleaned. This is the reachable form of
+    /// "corrupt": the writers rename a complete temp file into place, so a
+    /// zero-length json is the only shape a broken write could leave, and the
+    /// size `read_dir` already reports is enough to spot it.
     #[test]
-    fn corrupt_json_removed() {
+    fn empty_json_removed() {
         let tmp = tempfile::tempdir().unwrap();
         let inv = tmp.path().join("inventory");
         std::fs::create_dir_all(&inv).unwrap();
-        std::fs::write(inv.join("bad.json"), "not json {{{").unwrap();
+        std::fs::write(inv.join("bad.json"), b"").unwrap();
         std::fs::write(inv.join("bad.dat"), b"data").unwrap();
         let report = check(tmp.path());
         assert!(report.cleaned > 0);
         assert!(report.warnings.iter().any(|w| w.contains("corrupt")));
+        assert!(!inv.join("bad.json").exists());
+    }
+
+    /// DELIBERATE NARROWING, recorded so it isn't mistaken for a regression.
+    ///
+    /// A non-empty but unparseable json is no longer removed. Detecting it meant
+    /// opening and parsing every metadata file on every launch — 526ms of a
+    /// 550ms startup check on a 5000-entry graveyard — to guard a state atomic
+    /// writes make impossible.
+    ///
+    /// The cost of tolerating it is a stale pair on disk, NOT a failure: the
+    /// readers skip an unparseable entry rather than choking on it, which this
+    /// test also pins.
+    #[test]
+    fn a_nonempty_unparseable_json_is_tolerated_not_removed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let grave = tmp.path().join("graveyard");
+        std::fs::create_dir_all(&grave).unwrap();
+        std::fs::write(grave.join("bad.json"), "not json {{{").unwrap();
+        std::fs::write(grave.join("bad.tar.zst"), b"payload").unwrap();
+
+        let report = check(tmp.path());
+        assert_eq!(report.cleaned, 0, "the pair is left alone");
+        assert!(grave.join("bad.json").exists());
+        assert!(
+            grave.join("bad.tar.zst").exists(),
+            "its payload is not an orphan while the json is present"
+        );
+
+        // And the reader tolerates it: the entry simply doesn't appear.
+        crate::state::with_state_root(tmp.path(), || {
+            assert!(
+                crate::state::graveyard::Graveyard::load()
+                    .entries
+                    .is_empty(),
+                "an unparseable entry must be skipped, not surfaced or fatal"
+            );
+        });
+    }
+
+    /// The size warning still fires — it now reads the total from the same walk
+    /// that does the pairing, instead of a second pass over the directory.
+    #[test]
+    fn size_warning_comes_from_the_pairing_walk() {
+        let tmp = tempfile::tempdir().unwrap();
+        let grave = tmp.path().join("graveyard");
+        std::fs::create_dir_all(&grave).unwrap();
+        // One valid pair, payload just over the 100 MB warn threshold.
+        std::fs::write(grave.join("big.json"), br#"{"id":"big"}"#).unwrap();
+        let f = std::fs::File::create(grave.join("big.tar.zst")).unwrap();
+        f.set_len(101 * 1024 * 1024).unwrap();
+        drop(f);
+
+        let report = check(tmp.path());
+        assert_eq!(report.cleaned, 0, "a valid pair is untouched");
+        assert!(
+            report.warnings.iter().any(|w| w.contains("MB")),
+            "expected a size warning, got {:?}",
+            report.warnings
+        );
     }
 
     #[test]


### PR DESCRIPTION
Third and last piece of Spencer's "graveyard filled up and broke my load times". #367 killed the O(N²) cascade, #370 moved it off the startup thread; this removes what was left — which turned out **not** to be what I predicted.

## I was wrong about where the time went

In #370 I proposed the win was merging the graveyard's two directory walks. Measured, that's worth **4%**:

| 5000 entries | |
|---|---|
| `check_paired_dir` | **473.8 ms (95%)** |
| `check_graveyard_size` | 22.2 ms (4%) |

The cost is `check_paired_dir` reading and JSON-parsing **every** `<stem>.json` on every launch. Splitting further shows it's the *opens*, not the parsing:

| step | 5000 entries |
|---|---|
| walk + metadata only | 23.7 ms |
| + `read_to_string` each json | **525.7 ms** ← 96% of cost |
| + parse to `Value` (as shipped) | 606.6 ms |
| read bytes + `IgnoredAny` | 596.6 ms ← swapping parsers buys ~2% |

So the only real lever is **not opening the files**.

## We never needed to

That read existed to prove the json parses. But both writers — `Graveyard::write_entry_as` and `state::inventory` — emit theirs through `fs::write_atomic`, which writes a temp file and **renames** it. A rename is atomic, so a `<stem>.json` in these directories is either **absent or complete**; never half-written. The validation was guarding a state that cannot occur.

Pairing needs only filenames. The one reachable form of corruption — a zero-length file — is visible in the size `read_dir` already reports, so it's still caught for free.

| entries | `check_paired_dir` | whole `health::check` |
|---|---|---|
| 1000 | 78.6 → **5.1 ms** | 45.9 → **3.7 ms** |
| 5000 | 473.8 → **27.3 ms** | 499.3 → **22.4 ms** — ~22× |

The size warning now takes its total from that same walk instead of a second pass (`check_graveyard_size` → `warn_on_graveyard_size`), so the 4% goes too.

## ⚠️ Deliberate narrowing — why this is `perf` and not a pure win

**A non-empty but unparseable json is no longer removed.** That's a real behavior change, and `corrupt_json_removed` asserted the old guarantee — so it did not simply get deleted:

- `empty_json_removed` — the reachable case, still cleaned, still warns
- `a_nonempty_unparseable_json_is_tolerated_not_removed` — pins what we now tolerate **and** that the reader survives it: `graveyard::read_entries` and the inventory loader both `.ok()?` the parse, so such an entry is skipped rather than fatal. The test asserts `Graveyard::load()` returns empty rather than erroring.
- `size_warning_comes_from_the_pairing_walk` — the merged walk still produces the >100 MB warning

The cost of tolerating a stale pair is disk, not correctness, and the size warning still counts its bytes so the user can `z`-purge.

If you'd rather keep strict validation, the alternative is a stamp file keyed on `(dir mtime, entry count)` that skips the pass when nothing changed — same speed on the common launch, full validation whenever the directory moves, at the price of new persistent state and a soundness argument about mtime granularity. I went with the simpler change because atomic writes already make the thing it was checking for impossible. Happy to switch if you disagree.

## Not moved off-thread

`health::check` still runs synchronously in `App::new`, and it has to: bootstrap cleans orphans *before* loading the state that depends on them. At 22 ms for 5000 entries it's no longer worth restructuring for.

`make check-ci` → `=== GATE: PASS ===`, 15 health tests green.

Generated with [Claude Code](https://claude.com/claude-code)