### PR TITLE
fix(mouse): copying part of a flash keeps the message, instead of eating it

### DIFF
--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -405,7 +405,14 @@ pub enum ClipMsg {
     /// identical to the one it replaced — `copied: <path>: not a regular file` reads
     /// as a copy that failed, not as a successful copy of an error message. Trailing
     /// it leaves the echo starting where the user's eye already is.
-    StatusLine,
+    ///
+    /// `whole_row` is the row's full text, set when the row copied from is the one
+    /// the echo lands on — the flash row. Echoing the fragment there would replace
+    /// the message with a piece of itself, so the message the user copied *from*
+    /// disappears and the surviving text looks left-shifted under the highlight,
+    /// which is how this was reported. The status bar and divider pass `None`: they
+    /// live on other rows and survive their own echo.
+    StatusLine { whole_row: Option<String> },
     /// `"copied {count} name(s)"` / `"copied {count} path(s)"` — a file-list row
     /// selection. `count` is carried because a name may contain a newline, so it
     /// can't be recovered from `text`; `paths` distinguishes the modifier-held copy.
@@ -424,9 +431,16 @@ impl ClipMsg {
                 format!("yanked path: {preview}{ellipsis}")
             }
             Self::MultiPath { count } => format!("yanked {count} paths"),
-            Self::StatusLine => {
-                let preview: String = text.chars().take(60).collect();
-                let ellipsis = if text.chars().count() > 60 { "…" } else { "" };
+            Self::StatusLine { whole_row } => {
+                // Show the whole row when the echo would otherwise eat it; the
+                // drag highlight still marks which part went to the clipboard.
+                let shown = whole_row.as_deref().unwrap_or(text);
+                let preview: String = shown.chars().take(60).collect();
+                let ellipsis = if shown.chars().count() > 60 {
+                    "…"
+                } else {
+                    ""
+                };
                 format!("{preview}{ellipsis} (copied)")
             }
             Self::ListNames { count, paths } => {
@@ -1284,12 +1298,13 @@ mod tests {
     #[test]
     fn clip_status_line_echo_trails_the_confirmation() {
         assert_eq!(
-            ClipMsg::StatusLine.success("/Users/me/src/spyc/docs: not a regular file"),
+            ClipMsg::StatusLine { whole_row: None }
+                .success("/Users/me/src/spyc/docs: not a regular file"),
             "/Users/me/src/spyc/docs: not a regular file (copied)"
         );
         // The echo is not prefixed, so it still begins with the selected text.
         assert!(
-            !ClipMsg::StatusLine
+            !ClipMsg::StatusLine { whole_row: None }
                 .success("anything")
                 .starts_with("copied"),
             "the marker trails"
@@ -1303,8 +1318,33 @@ mod tests {
         let long = "z".repeat(75);
         let preview: String = long.chars().take(60).collect();
         assert_eq!(
-            ClipMsg::StatusLine.success(&long),
+            ClipMsg::StatusLine { whole_row: None }.success(&long),
             format!("{preview}… (copied)")
+        );
+    }
+
+    /// Copying part of a FLASH echoes the whole message, not the fragment. The
+    /// echo lands on the flash row, so echoing the fragment replaces the message
+    /// with a piece of itself — reported as the line jumping left, because the
+    /// drag highlight kept its columns while the text under it got shorter.
+    #[test]
+    fn clip_status_line_echo_keeps_the_message_it_was_taken_from() {
+        let whole = "directory not found, returning to project home";
+        // Columns 14..41 of that message — the reported drag.
+        let fragment = "found, returning to project";
+        assert_eq!(
+            ClipMsg::StatusLine {
+                whole_row: Some(whole.to_string())
+            }
+            .success(fragment),
+            format!("{whole} (copied)"),
+            "the message survives its own copy"
+        );
+        // The status bar and divider are other rows: they still echo the fragment,
+        // which is the point of substring selection.
+        assert_eq!(
+            ClipMsg::StatusLine { whole_row: None }.success(fragment),
+            format!("{fragment} (copied)")
         );
     }
 

--- a/src/app/mouse/selection.rs
+++ b/src/app/mouse/selection.rs
@@ -176,16 +176,23 @@ impl super::super::App {
             return Vec::new();
         }
         let (lo, hi) = sel.range();
-        let text = {
+        let (text, whole_row) = {
             let rows = self.view.chrome_rows.borrow();
             let Some(row) = rows.iter().find(|r| r.y == sel.y) else {
                 return Vec::new();
             };
-            crate::ui::line_select::text_between_columns(
+            let selected = crate::ui::line_select::text_between_columns(
                 &row.line,
                 usize::from(lo),
                 usize::from(hi),
-            )
+            );
+            // The echo lands on the flash row. If that's the row just copied
+            // from, carry its full text so the confirmation appends to the
+            // message instead of replacing it with a fragment of itself.
+            let whole_row = self
+                .selection_row_is_the_flash_row(sel.y)
+                .then(|| crate::ui::line_select::text_between_columns(&row.line, 0, usize::MAX));
+            (selected, whole_row)
         };
         let text = text.trim().to_string();
         if text.is_empty() {
@@ -193,8 +200,20 @@ impl super::super::App {
         }
         vec![Effect::CopyToClipboard {
             text,
-            ok: super::super::effect::ClipMsg::StatusLine,
+            ok: super::super::effect::ClipMsg::StatusLine { whole_row },
         }]
+    }
+
+    /// Is `y` the row a flash echo will be drawn on? True only while a flash is
+    /// actually up: that's the case where copying from the row and echoing to it
+    /// collide. `render_prompt_line` owns this row, so its rect is the authority
+    /// on where it is (in a vsplit it is narrowed, never moved sideways).
+    fn selection_row_is_the_flash_row(&self, y: u16) -> bool {
+        if self.state.flash.is_none() {
+            return false;
+        }
+        let (cols, rows) = self.view.term_size;
+        self.frame_layout(Rect::new(0, 0, cols, rows)).prompt.y == y
     }
 
     /// Translate the pointer into the pane's own grid coordinates, clamped into it.
@@ -798,6 +817,130 @@ mod tests {
             assert!(
                 app.view.chrome_selection.is_some(),
                 "the highlight stays up after the copy, like the other surfaces"
+            );
+        });
+    }
+
+    /// Dragging part of a live FLASH copies the fragment but echoes the whole
+    /// message, so the message survives being copied from. Reported from a real
+    /// drag over `directory not found, returning to project home`: the echo
+    /// replaced the line with the fragment, and because the highlight holds
+    /// COLUMNS the surviving text appeared to jump left under it.
+    ///
+    /// Drawn through a real frame rather than a hand-pushed `ChromeRow`, because
+    /// the bug is in which row the echo lands on relative to the row copied from —
+    /// a fabricated row can't tell those apart.
+    #[test]
+    fn copying_part_of_a_flash_echoes_the_whole_flash() {
+        use crossterm::event::KeyModifiers;
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        crate::state::with_state_root(&tmp, || {
+            let mut app = App::test_app(tmp.clone());
+            let whole = "directory not found, returning to project home";
+            app.state.flash_info(whole);
+            // Hit-testing resolves the layout from `term_size` (the resize handler
+            // keeps it current in production), so it must match the frame drawn.
+            app.view.term_size = (100, 24);
+
+            // One real frame, so the flash row records itself where it is drawn.
+            let mut terminal = Terminal::new(TestBackend::new(100, 24)).expect("backend");
+            terminal.draw(|f| app.render(f)).expect("draw");
+            let flash_y = {
+                let rows = app.view.chrome_rows.borrow();
+                rows.iter()
+                    .find(|r| {
+                        crate::ui::line_select::text_between_columns(&r.line, 0, usize::MAX)
+                            .contains("returning to project")
+                    })
+                    .map(|r| r.y)
+                    .expect("the flash row was recorded")
+            };
+
+            let at = |kind, col| MouseEvent {
+                kind,
+                column: col,
+                row: flash_y,
+                modifiers: KeyModifiers::NONE,
+            };
+            // The reported drag: from "found" (col 14) to just past "project".
+            app.begin_chrome_selection(at(MouseEventKind::Down(MouseButton::Left), 14));
+            app.extend_chrome_selection(at(MouseEventKind::Drag(MouseButton::Left), 41));
+            let effects =
+                app.finish_chrome_selection(at(MouseEventKind::Up(MouseButton::Left), 41));
+
+            let [Effect::CopyToClipboard { text, ok }] = effects.as_slice() else {
+                panic!("expected one clipboard copy, got {effects:?}");
+            };
+            assert_eq!(
+                text, "found, returning to project",
+                "the clipboard still gets exactly the dragged columns"
+            );
+            let crate::app::effect::ClipMsg::StatusLine { whole_row } = ok else {
+                panic!("a chrome copy must echo as a status line, got {ok:?}");
+            };
+            assert_eq!(
+                whole_row.as_deref(),
+                Some(whole),
+                "the echo carries the whole message, so copying from it doesn't erase it"
+            );
+        });
+    }
+
+    /// The same drag on the STATUS BAR carries no whole-row echo: that row is not
+    /// the one the flash lands on, so it survives its own echo and showing the
+    /// fragment is the point of substring selection.
+    #[test]
+    fn copying_the_status_bar_still_echoes_only_the_fragment() {
+        use crossterm::event::KeyModifiers;
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        crate::state::with_state_root(&tmp, || {
+            let mut app = App::test_app(tmp.clone());
+            app.state
+                .flash_info("directory not found, returning to project home");
+            app.view.term_size = (100, 24);
+
+            let mut terminal = Terminal::new(TestBackend::new(100, 24)).expect("backend");
+            terminal.draw(|f| app.render(f)).expect("draw");
+            // The status bar owns the top row (`status_position` defaults to top);
+            // the flash owns the bottom one. Located by position, because a fixture's
+            // status bar is all temp paths with no stable word to search for.
+            let status_y = 0;
+            {
+                let rows = app.view.chrome_rows.borrow();
+                assert!(
+                    rows.iter().any(|r| r.y == status_y),
+                    "the status row was recorded"
+                );
+                assert!(
+                    rows.iter().any(|r| r.y != status_y),
+                    "the flash row is a different row, or this test proves nothing"
+                );
+            }
+
+            let at = |kind, col| MouseEvent {
+                kind,
+                column: col,
+                row: status_y,
+                modifiers: KeyModifiers::NONE,
+            };
+            app.begin_chrome_selection(at(MouseEventKind::Down(MouseButton::Left), 0));
+            app.extend_chrome_selection(at(MouseEventKind::Drag(MouseButton::Left), 40));
+            let effects =
+                app.finish_chrome_selection(at(MouseEventKind::Up(MouseButton::Left), 40));
+
+            let [Effect::CopyToClipboard { ok, .. }] = effects.as_slice() else {
+                panic!("expected one clipboard copy, got {effects:?}");
+            };
+            let crate::app::effect::ClipMsg::StatusLine { whole_row } = ok else {
+                panic!("a chrome copy must echo as a status line, got {ok:?}");
+            };
+            assert!(
+                whole_row.is_none(),
+                "the status bar is not the flash row: {whole_row:?}"
             );
         });
     }


### PR DESCRIPTION
Reported from a live drag over `directory not found, returning to project home`: the line appeared to jump left with its beginning cut off.

**What happened.** A chrome drag echoes `<fragment> (copied)` — and for a flash, that echo lands on the row the fragment came from. So the message replaced itself with a piece of itself. Because a chrome selection holds **columns**, not content, the highlight stayed where the drag put it while the text underneath got shorter — the fragment `found, returning to project` sitting under a highlight that starts at column 14, which reads as a left shift rather than a replacement.

The columns were exactly right: 14..41 of that message *is* `found, returning to project`, and the clipboard got precisely that.

**The fix.** `ClipMsg::StatusLine` now carries the row's full text when the row copied from is the row the echo lands on, and the confirmation appends to the message rather than replacing it. The status bar and divider pass `None` and still echo the fragment — they live on other rows, survive their own echo, and showing which item you picked out of the line is the point of substring selection.

## Test plan

- `make check-ci` green, 2400 tests.
- Two end-to-end tests drive a **real frame** rather than a hand-pushed `ChromeRow`: the bug is about which row the echo lands on relative to the row copied from, which a fabricated row can't distinguish. One covers the reported flash drag, one pins that a status-bar drag still echoes only the fragment.
- **Bite-checked**: with the row check forced to `false`, the flash test fails with exactly the reported `None`, then passes again restored.
- Setting up those tests turned up that hit-testing resolves layout from `view.term_size` (the resize handler keeps it current in production), so a test must pin it to the frame it draws — otherwise the lookup compares against the real terminal's geometry.

Generated with [Claude Code](https://claude.com/claude-code)