### PR TITLE
docs(release): bring the 2.1 notes up to HEAD — archives, images, the review

### DIFF
--- a/docs/drafts/2.1-release-notes.md
+++ b/docs/drafts/2.1-release-notes.md
@@ -5,20 +5,74 @@
 > is the narrative layer on top of it — what a user would notice, in their
 > words. Numbers in `#nnn` are PRs unless marked "issue".
 >
-> **Verified against `git log v2.0.3..2eef3a7`** — 102 commits. Every item below
+> **Verified against `git log v2.0.3..6ee04b2`** — 177 commits. Every item below
 > is merged; there are no pending entries. All 15 issues in the 2.1 milestone are
 > closed.
 
 ## The short version
 
-Two big things, plus a launch-readiness pass.
+Three big things, plus a launch-readiness pass.
 
-**The mouse works, and it's on by default.** **Agents can read a spyc manual you
-install once.** Around those, a sweep through the papercuts a new user hits in
-the first fifteen minutes — with particular attention to Linux, where most of
-them were hiding.
+**You can walk into a zip or a tarball and change what's inside it.** **The mouse
+works, and it's on by default.** **Agents can read a spyc manual you install
+once.** Around those, a sweep through the papercuts a new user hits in the first
+fifteen minutes — with particular attention to Linux, where most of them were
+hiding.
 
 ## Added
+
+### Archives are directories now
+
+`Enter` on a `.zip` / `.tar` / `.tar.gz` / `.tar.zst` — or any of the
+zip-derived formats, `.jar`, `.whl`, `.epub`, `.apk` — walks *into* it, and `h`
+climbs back out. Inside, it's a normal listing: real sizes, mtimes and
+permission bits, and sorting, `=` filters, picks, `/` search and the cursor all
+work the way they do in a directory. Nested containers too, up to
+`[archive] max_depth`.
+
+**Entering a multi-gigabyte zip extracts nothing.** A mount is the archive's
+*index*, not a copy of it — a member's bytes are read only when you open one, and
+they land in a session-scoped staging dir that's cleaned up on exit. A
+`.tar.gz`/`.tar.zst` is the exception, since it can't be listed without
+decompressing the stream: those extract as they mount, under
+`[archive] extract_budget_mb` (default 512), and `:archive cancel` abandons one
+that's taking too long.
+
+**And you can change what's inside.** `R` marks a member for removal, `M` renames
+one, `p` / `c` put files in, `e` / `V` edit a member in your editor — all pending
+until `:archive write`, with a `+2 ~1 -3` badge on the suffix and a per-member
+marker in the listing's own status gutter meanwhile. Delete and rename are edits
+to the index, so dropping a 500 MB member never extracts it. The archive file
+itself is marked `~` in the directory it lives in, so a container holding
+unwritten changes is visible from outside it.
+
+**A failed write can't damage the original.** `:archive write` repacks to a temp
+file beside it, carrying untouched members across without recompressing them,
+reads the result back to verify it, and only then renames over the original —
+which is also snapshotted into the graveyard first (up to
+`[archive] snapshot_max_mb`) so `:undo` can bring the old one back. `:archive
+discard` throws the pending changes away instead; unmounting a changed archive
+offers to write it first, and quitting warns before dropping unwritten changes.
+
+Taking things out works the way it does anywhere else: `y` yanks a member into
+the inventory contents-and-all — remembered by its path *inside* the archive, so
+the row reads as taken — `c` copies out, `^a p` pipes to the pane, `f` / `L`
+report. A mark, a harpoon slot and the session you quit from can all point inside
+an archive and mount it again on the way, so `spyc -r` puts you back several
+directories deep in a tarball. **Agents can read in here too:** MCP
+`get_file_content` resolves a path inside a mount, reading the container in
+memory (or your not-yet-written edit, if there is one).
+
+It tells you what's odd rather than guessing: unsafe member paths, symlinks
+pointing out of the archive, duplicate or case-colliding names, encrypted members
+and a capped index are all reported when the mount opens, in full under
+`:archive info`, and the suffix shows `ro` when an archive can't be written back.
+The things that would have to half-work are refused with a message instead —
+creating an empty dir or a new file, copying a whole *directory* in, moving across
+the archive boundary in one step, `:grep`, `F`, and shell commands. `:archive
+info|list|write|discard|unmount|cancel` manages it all. (issue #149, #298,
+#301, #305, #307, #310–#312, #314, #317, #319–#321, #328–#330, #333–#339,
+#341, #343, #347, #348)
 
 ### The mouse works
 
@@ -75,6 +129,29 @@ you. Worth knowing: the "turn finished" half of agy's dot needs **agy ≥ 1.1.10
 which is where agy made `Stop` hooks reachable at all — on an older agy that half
 quietly falls back to guessing from output timing. (#285, #287)
 
+### You can see the images you pasted
+
+An agent renders a pasted image as an opaque token — `[Image #3]` — so you can't
+check what you actually attached, and neither can you a day later. **`^a g`** (or
+`:images`) lists them, read back out of the agent's own transcript, so the list
+survives a spyc restart and a `claude --resume`. Images you've pasted but not sent
+yet lead it, marked 📎: spyc keeps its own copy at the moment your paste key goes
+through, because that keystroke is the only signal it gets — the agent reads the
+system clipboard itself, the terminal never carries the bytes — and that moment is
+the only one where the same image is still there.
+
+It's a popup over whatever you were doing rather than a view the file list
+switches into, since checking an attachment is a glance and not a destination.
+`j`/`k` move, `1`-`9` jump, `Enter` shows one full-screen with the usual image
+verbs, and `q` closes. (#302, #304, #308)
+
+**Image files open full-screen from the list too.** `Enter` on a PNG / JPEG / GIF /
+WebP draws the picture at the size your terminal can take, on the same image path
+the mermaid preview already used — `s` saves, `y` copies the image, `Y` the path,
+`o` hands it to your OS viewer. Detection is by magic bytes, so an extensionless
+screenshot previews and a misnamed `.png` full of text still hex-dumps. Needs a
+terminal with a graphics protocol; without one, `o` still works. (#300)
+
 ### Smaller additions
 
 - **`:about`** (`Space a`) — build identity and environment from inside the TUI,
@@ -92,11 +169,37 @@ quietly falls back to guessing from output timing. (#285, #287)
   build from source can be identified precisely. This matters more than it used
   to: `main` now carries a static `N.M.0-CURRENT` instead of bumping every PR, so
   the SHA is the only thing distinguishing two dev builds. (#222, #283)
+- **`^` and `$` anchor `/` and `=`** — `/^env` finds `environment.toml` but not
+  `.envrc`, `/env$` the other way round, `/^env$` is exact. They compose with
+  globs (`/^a?c$`), and a `$` that isn't at the end stays literal, so `/$RECYCLE`
+  still finds `$RECYCLE.BIN`. (#296)
+- **`W l` marks which worktree is the main checkout** and collapses `$HOME` to
+  `~` in the paths, so the picker fits and you can tell the main repo from its
+  linked worktrees at a glance. (#340)
+- **`[diff] intraline`** — choose per-character (default) or per-word intra-line
+  highlighting; see *Changed*. (#364)
 
 ## Changed
 
 **`L`'s long listing leads with the name instead of trailing it.** The column you
 scan for is now the one your eye lands on first. (#293)
+
+**The vertical split opens full-height, and `^s` owns the whole family.** A fresh
+`^s |` preview now runs the divider the full frame height, with the pane confined
+under the left column, instead of splitting only the list —
+`[layout] vsplit_mode = "top_only"` restores the old shape, and `^s f` still flips
+an open split either way. The split keys moved onto one prefix (`^s |` open/close,
+`^s f` flip, `^s n` second commander, `^s x` close it), with the `^a` forms kept as
+aliases because the pane intercepts only `^a`-family keys — `^s` alone would be
+unreachable while you're typing to an agent. (#352)
+
+**Intra-line diff highlighting marks the characters that changed, not a blob.** In
+`gd` / `gD` / a commit from `gl`, `value` → `values` now brightens the `s` rather
+than washing the whole token, and **every** changed region on the line is marked,
+so an unchanged token sitting between two changed ones is no longer swept in. If
+per-character marking on dense code reads as confetti to you,
+`[diff] intraline = "word"` gives you the `git --word-diff` granularity back.
+(#351, #364)
 
 **Mouse capture is on by default, and while it's on you lose your terminal's own
 click-drag text selection.** That's inherent — the terminal can't both report the
@@ -107,6 +210,23 @@ false` turns it off permanently. `^a u` quick-select and `y` in the pager are th
 mouse-free yank paths.
 
 ## Fixed
+
+### Clipboard
+
+**Every yank goes out the way you configured it.** Four verbs — the pane yanks
+`yp` / `ya`, `^a u` quick select, and the image overlay's `Y` — called the *local*
+clipboard helper directly instead of the delivery seam, so they ignored
+`[clipboard] via`, the `command` / `$SPYC_CLIPBOARD` override, and OSC 52. Over
+SSH that wrote the **server's** clipboard, which you can never paste from, and the
+call succeeded, so the yank flashed "yanked" either way. Half the yank chord
+behaved and half didn't, with nothing to tell you which. (#350)
+
+**A middle-click paste can't freeze spyc.** The clipboard read ran inline on the
+event loop with no deadline, so a wedged X selection owner, a stalled compositor
+or a hung macOS pasteboard server took the whole interface down — no frame, no
+key out of it — and mouse capture defaults on, so an accidental middle click was
+enough. The read now runs off the loop *and* gives the helper a deadline; past it
+the helper is killed and you get an error instead of a silent empty paste. (#362)
 
 ### Clipboard, on Linux
 
@@ -158,6 +278,46 @@ banner on screen for a moment after it closes and spyc read that as "still open"
 One flick past the bottom left a run of `q`s in the prompt. It now sends the key
 once and waits to actually see the view go. (#292)
 
+**`spyc -r` puts a codex tab back in its own conversation.** A codex tab that was
+still working when you quit saved no session id at all, so restore fell back to
+`codex resume --last` — which attaches to whichever rollout in that directory was
+written most recently, including one belonging to a *different* spyc. The tab
+already knew which conversation it was pinned to; the save path was the one place
+that didn't ask. (#363)
+
+**Another spyc exiting no longer blinds your activity dots.** The status hooks a
+pane reports through live in the project's own `.claude/settings.json` and are
+shared by every spyc on the machine — but teardown deleted them unconditionally,
+so a short-lived second instance quitting in the same directory silently
+un-hooked a 13-hour-old session's three live tabs, which then fell back to
+guessing from output timing. They're refcounted now, only the last instance out
+removes them, and a live pane re-installs them if something else takes them away.
+(#315)
+
+**A restarted pane tab drops its `[exited 0]` label,** and **`^z` suspends any
+non-shell tab, not just an agent one.** Both reported off one screenshot: a
+restarted `rmatrix` still labelled `[exited 0]` while it animated — the tag
+survived `^a R` and leaked into the `^a R` / `^a x` confirm prompts for the rest
+of the session — and `^z` did nothing on that tab, because the suspend was gated
+on the tab being a *known agent* rather than on it not being a shell. A shell tab
+still forwards `^z`, so its own job control keeps working. (#306)
+
+### Mouse
+
+**Copying off a chrome row confirms without eating what you copied.** Dragging
+text off the status bar flashed `copied: {selection}` — which, since what's on
+that line is usually a message spyc just put there, replaced the message with
+something nearly identical to it, and copying an *error* read as a copy that had
+failed. The marker trails now: `…: not a regular file (copied)`. (#342)
+
+**And copying *part* of a flash keeps the whole message.** A chrome selection
+holds columns, not content, so when the echo landed back on the row it came from,
+the highlight stayed put while the text under it got shorter — a fragment sitting
+at column 14 of a row that now starts there, which reads as the line jumping left
+with its beginning cut off. Reported live from a drag over `directory not found,
+returning to project home`. The confirmation now appends to the message instead of
+replacing it. (#372)
+
 ### Pager
 
 **Pager action messages appear in the pager,** instead of flashing in the status
@@ -174,11 +334,47 @@ place the end-of-file signal used to go missing. (#251, #286)
 box to the line *count* mis-measured anything that wrapped, so a view could open
 too short or too tall. (#290)
 
+### Images
+
+**The full-screen image overlay can be dismissed.** It's the last surface drawn,
+so there's nothing visible beneath it to aim a key at — but it was consulted only
+from inside the pager, which was fine while a mermaid block was the only way to
+raise one. Opening it from the file list or the gallery left `q` and `Esc` doing
+nothing, and with the pane focused they went to the agent instead: an overlay with
+no way out. It's on the modal routing axis now, so it gets keys wherever it was
+opened from. (#313)
+
+**`o` (open externally) writes somewhere only you can read.** The temp file went to
+a fully predictable path under the system temp dir — `spyc-agent-image-1.png`,
+`spyc-mermaid-<hash>.png` — and the write follows symlinks, so anything able to
+plant one there first could have spyc overwrite a file of its choosing with image
+bytes. Both call sites now build their path inside a per-process directory with an
+unguessable name, mode `0700` — which matters twice over, because the pictures
+going through here are often screenshots. (#316)
+
+**A corrupt transcript can't be read into memory whole.** The image index streamed
+the entire conversation file a line at a time, and a "line" grows until it finds a
+newline — so a multi-gigabyte file with none in it was a multi-gigabyte
+allocation. The reader is bounded now, like every other transcript reader already
+was. (#318)
+
 ### File list
 
 **A background refresh keeps your sort order.** A watcher-driven refresh — a file
 changing under you, not anything you did — silently reset the listing to sort by
 name, undoing a `:sort mtime` or `:sort size` while you were reading it. (#289)
+
+**The status bar describes the column you're in.** It took the git half from the
+focused column but everything else — path, picks, filter, sort, hidden count —
+from column *a*, so with a second commander focused it showed a's path beside b's
+branch. It surfaced as an archive browsed in `b` never showing its format or its
+pending-change badge at all. (#322)
+
+**Text is measured and cut by grapheme cluster, not by character.** Every width
+helper summed per-char widths, which diverges from what a terminal actually draws
+in both directions: `❤️` measured 1 column and renders 2, a family emoji measured
+6 and renders 2. Live consequences were an emoji overflowing the cell it was
+truncated into, and a truncation that sliced a ZWJ sequence in half. (#354)
 
 ### Prompts
 
@@ -212,12 +408,26 @@ combining marks don't push it around. (#205, #215)
 `HEAD` file's mtime while the status layer resolved `HEAD` to the ref it points
 at — so on any normal branch the two disagreed permanently and the walk re-ran
 every tick. Both now read the same resolved mtime, and the shared config's mtime
-is part of the cache key too. (#193, #255)
+is part of the cache key too. (#193, #255, #303)
 
 **A failed worktree removal tells you what actually went wrong.** All three causes
 — the path doesn't exist, it exists but isn't a worktree, or its status couldn't
 be read — collapsed into one message that blamed the target path. Each now says
 which, and the third carries git's own cause chain. (#278)
+
+### Startup
+
+**A full graveyard no longer stops spyc booting.** Reported by a user whose
+graveyard filled up: launch degraded until it was unusable and they had to empty
+the directory from outside spyc. Three separate causes, all on the startup path
+before anything is on screen — the size cap's cascade re-derived the total from
+disk on *every* iteration (quadratic in the number of entries), then ran its
+decompress-extract-and-trash work synchronously in the launch thread, and the
+health check opened and JSON-parsed every metadata file in the graveyard just to
+count them. Un-nesting the cascade's walk took it from **25.2 s to 235 ms** at 800
+entries, moving what remained off the launch thread got it out of your way
+entirely, and the scan now reads the directory rather than its contents —
+**499 ms to 22 ms** at 5,000. (#367, #370, #371)
 
 ### Errors and lifecycle
 
@@ -250,6 +460,10 @@ writer. (#217, #237, #238)
   (issue #232, #272)
 - **`docs/KEYBINDINGS.md`** — the missing bindings filled in, so the reference
   matches `?`. (#276)
+- **`README.md`** — reworked twice: a four-loop tour of what the commander
+  actually does rather than only the agent bridge, and a hero frame showing one
+  real session instead of a feature list. It's the repo's front door and it was
+  selling the narrower half of the tool. (#323, #355)
 - **`SECURITY.md`** was rewritten to describe the distribution and signing chain
   that 2.0 actually shipped (#236). The realistic threats are named —
   release-pipeline compromise as the highest-consequence one, plus local misuse
@@ -287,6 +501,40 @@ Not user-visible, but this is where the release's risk actually lived:
   free to change without breaking the next release's automated bump. (#280)
 - The **harpoon menu and find picker got pure key decisions** with tests, closing
   the last of the old coverage chores. (#297, issue #178)
+- The release got a **six-area quality review before the tag** — archive,
+  app-interaction, MCP/state/security, clipboard/pane/agent, docs/comments,
+  tests/guards — over the whole `v2.0.0..HEAD` diff. It found one blocker and nine
+  highs; all ten are fixed, in the twelve PRs below.
+- **The blocker was an archive escape,** and it never reached a released build.
+  Extraction decided containment by looking at the *name* it was about to write,
+  which two symlink members can defeat by composition: `d/link1 -> ..` and then
+  `d/link1/link2 -> ..` each pass on their own, and a later file member written
+  through the pair lands outside the staging dir entirely. Automatic on `Enter`
+  for a compressed tar — no confirmation in the path. **Extraction never traverses
+  a symlink now**, and containment is decided against the filesystem per path
+  component, so it's a property of every step rather than of the final string.
+  Alongside it, a member's *declared* size is treated as a claim rather than a
+  fact, so a lying header can't make spyc spend on it. (#346, #347, #348)
+- The other highs: every yank onto one delivery seam, the middle-click paste off
+  the loop and bounded, a live codex tab saving its own conversation, and four
+  guards or test suites that were checking less than they claimed — the mouse
+  capture guard blind to the file that sets the terminal up, the module-index
+  guard blind to subdirectories, the flash guard unable to see a wrapped call, and
+  the render purity guard unable to see the draw pass mutate. Plus the archive
+  write-back's safety properties and the mouse dispatch entry pinned by tests that
+  a mutation actually breaks. (#349, #350, #353, #357, #359, #362, #363, #365,
+  #368)
+- A sweep replaced **seven hand-rolled utilities with library code**, across six
+  PRs: grapheme-aware measurement, `~`/`$VAR` expansion, shell quoting, per-word
+  diff regions, a macOS pane's cwd read in-process rather than by spawning
+  `lsof`, and one config-root resolver in place of three (which also retired a
+  `hostname` shell-out). Two of them are the user-visible entries under *Changed*
+  and *Fixed*; the rest changed nothing you can see, which was the point.
+  (#351, #354, #356, #358, #360, #361)
+- `make` now **asks cargo where `target/` is** instead of assuming, so a shared
+  build directory works — and `AGENTS.md` says plainly that with one shared,
+  `cargo clean` deletes every worktree's cache and not just yours. (#369, #366,
+  #373)
 
 ## Housekeeping
 
@@ -305,6 +553,7 @@ than carried forward:
 | #26 `cw` in the `!` prompt | mostly correct; the one real defect split out as #267, now fixed in this release |
 | #35 human-friendly release notes | closed — this document is the answer |
 | #148 WSL support | WSL2 works; the one live symptom matches a fix already shipped in v2.0.1 (#169) |
+| #149 archive browsing | shipped — the largest feature in the release (#298–#348) |
 | #153 rate-limit git status re-walk | a proposed optimization, never implemented; closed because its justification had largely evaporated, stated plainly rather than as a fix |
 | #179 word-diff highlight bleed | stale duplicate of #205 / #215 |
 | #206 `:about` | shipped (#254) |
@@ -312,6 +561,16 @@ than carried forward:
 Left open deliberately: #20 (waiting on an upstream codex bug) and #140 (waiting
 on an upstream GitHub Action to ship a Node-24 runtime — spyc's floating `v2` pin
 means it needs no change on our side when it does).
+
+**Two known defects were found during this cycle and are still open,** both from
+hand-driving the archive work rather than from a test: **#326** — the first
+keystrokes into a freshly spawned pane can be dropped before the child is ready to
+read them; and **#327** — a `remove_worktree` that fails part-way leaves a
+worktree neither spyc nor `git` will finish removing. #326 is on the dog-fooding
+path and reproducible on demand — someone who types straight after `^a c` loses
+the head of their first message to the agent with no indication anything was
+dropped — so it's worth deciding whether it holds the tag rather than letting the
+tag decide.
 
 **Milestones:** 2.1 is empty (15 closed). 2.0 is empty. 2.2 carries 6 — the
 remaining coverage and refactor chores (#174–#177) that were the old milestone's
@@ -328,7 +587,15 @@ post-release regressions get backported and announced under this heading.)
 
 ### Notes for the owner, delete before publishing
 
-- **The mouse default-on flip is the biggest behavioral change in 2.1** and the
+- **Archive browsing is now the largest thing in the release** and it landed
+  *after* this document's first two drafts, which is why the framing above moved
+  from two big things to three. It's around thirty PRs and a whole new
+  `src/archive/` module, and unlike the mouse campaign it has been hand-driven
+  hard: fifteen of them are fixes that came out of using it rather than out of a
+  test, which is the kind of coverage a test suite doesn't buy you. If the
+  announcement leads with one thing, this is the candidate — "walk into a zip and
+  change what's inside it" is the sentence a file-manager user reacts to.
+- **The mouse default-on flip is still the biggest behavioral change** and the
   thing most likely to generate a "2.1 broke my terminal" report — losing
   click-drag selection is surprising if you don't know about Shift. Consider
   leading the announcement with it, and mentioning `:mouse off` in the same
@@ -341,20 +608,32 @@ post-release regressions get backported and announced under this heading.)
 - **Most of this release is other sessions' work** — the mouse campaign, the
   agent skill, agy, `:about`. Those descriptions are written from the PRs and
   from `FEATURES.md`, not from having reviewed the code. Worth a read before
-  publishing.
+  publishing. The exception is the archive material and everything under *Under
+  the hood* from the review onward: that comes from the six-area review of
+  `v2.0.0..HEAD` and from fixing what it found, so it's written from the code.
+- **Decide how much of the blocker to publish.** It was found by our own review
+  and fixed before any release carried it, so there's no advisory to file and no
+  user action to request — 2.0.x can't be exploited through it because 2.0.x
+  can't open an archive at all. Naming it in the notes is a credibility choice,
+  not an obligation. The *Under the hood* entry is written to be publishable as
+  it stands; cut it to one line, or to nothing, if you'd rather the release read
+  as a feature release.
 - **One thing never tested on real hardware:** the Linux clipboard path (#261).
   The 150ms helper-reap budget is a reasoned number, not a measured one — if it's
   wrong, the symptom is a visible stall on every yank on X11.
 - **Dispatch `audit.yml` before tagging.** Supply-chain checks moved off the PR
   path in #273, so a dependency change since then hasn't been license/ban
   checked. `gh workflow run audit.yml`.
-- 102 commits is a lot for a minor. If the announcement wants a shorter spine:
-  mouse, agent skill, agy, Linux clipboard, and "a lot of papercuts" covers it.
-- **Re-check the range at tag time.** Verified at `2eef3a7`. The range has moved
-  under this document twice now — `#279`/`#281`/`#283` during the first refresh,
-  and a dozen more since — so assume it moves again before the tag. The mouse
-  section is deliberately written around *surfaces* rather than PRs so it
-  survives that churn; the PR lists are the part that goes stale.
+- 177 commits is a lot for a minor. If the announcement wants a shorter spine:
+  archives, mouse, agent skill, agy, Linux clipboard, and "a lot of papercuts"
+  covers it.
+- **Re-check the range at tag time.** Verified at `6ee04b2`. The range has moved
+  under this document three times now — `#279`/`#281`/`#283` during the first
+  refresh, then 75 more commits including the entire archive campaign — so assume
+  it moves again before the tag. The mouse and archive sections are deliberately
+  written around *surfaces* rather than PRs so they survive that churn; the PR
+  lists are the part that goes stale. To find what's new since this pass:
+  `git log --oneline 6ee04b2..HEAD`.
 - **#285 is cited alongside #287 for agy's dot, but on its own it fixed
   nothing.** It removed a scrape phrase on the theory agy never printed it; agy
   does print it, built at runtime from a format string, which is why it was


### PR DESCRIPTION
**M12** of the pre-2.1 review (`docs/drafts/review-2.1/E-docs-comments.md`) — `medium`, and reviewer E's "most serious single item" in that report.

## The finding

`docs/drafts/2.1-release-notes.md` was verified against `2eef3a7` and opened with "Two big things, plus a launch-readiness pass". HEAD is **75 commits** past that sha — the finding recorded 47; it has moved again since — and the largest of them is the **entire archive-browsing campaign**: a new `src/archive/` module, three `src/app/archive*.rs` files, a `:archive` command family, issue #149.

The release's biggest feature was missing from its own release notes. So were the image gallery, `^`/`$` anchors, the `^s` split family, per-character diffs, the graveyard startup fixes, a security fix, and the review that found the blocker.

## What changed

**Three big things, not two.** Archives lead, then the mouse, then the skill.

| section | added |
|---|---|
| **Added** | `### Archives are directories now`; `### You can see the images you pasted`; `^`/`$` anchors, `W l`'s main-worktree marker, `[diff] intraline` |
| **Changed** | the split opens full-height and `^s` owns the family; intra-line diff per-character by default |
| **Fixed** | new `Mouse`, `Images` and `Startup` subsections; the clipboard seam + bounded middle-click paste; codex tabs restoring their own conversation; a sibling spyc no longer un-hooking your dots; the status bar following the focused column; grapheme measurement; the graveyard startup trio with its measured numbers |
| **Docs** | the two README reworks |
| **Under the hood** | the six-area review, the blocker, the nine highs, the hand-rolled-utility sweep, the shared-build-dir work |
| **Housekeeping** | #149 in the triage table; #326 and #327 named as found-and-still-open |

The archive and image sections are written around **surfaces rather than PRs**, the same way the mouse section is, so the next dozen commits don't stale them.

## Owner notes

Updated rather than appended to: the range note reads `6ee04b2` and carries the command to diff forward from it, the commit count is 177, and the "most of this release is other sessions' work" caveat now says which parts are written from the code instead. One note is new — **how much of the blocker to publish is the owner's call**. It was found in-house and fixed before any release carried it (`git ls-tree v2.0.3 src/` has no `archive`), so there's no advisory to file and no user action to request; naming it is a credibility choice.

## Verification

Every claim re-derived at `6ee04b2` rather than carried across: `git log` subjects and bodies for the behaviour, `FEATURES.md` / `CONFIGURATION.md` for key and config names, `gh` for milestone and issue state (2.1 still 15/15 closed; #20 and #140 still open; #326/#327 filed 2026-08-10), and the two performance figures read out of #367 and #371 *with* their entry counts, since both are size-dependent.

Four claims in my own first pass were wrong on checking and were fixed before commit: the four verbs in #350 (the pager's `y` was never one of them — it already went through the seam), `^z`'s widening being a fix rather than an addition, the archive PR count, and the shape of the temp-dir fix.

`make check-ci` → `=== GATE: PASS ===`.

Docs-only, no behaviour change.

Generated with [Claude Code](https://claude.com/claude-code)
