### PR TITLE
fix(archive): a streamed member's bytes go where its own entry says

### DIFF
--- a/src/archive/index.rs
+++ b/src/archive/index.rs
@@ -62,16 +62,27 @@ pub struct IndexEntry {
     pub readable: bool,
 }
 
+/// Where a member's bytes live under the mount's staging root, from its inner
+/// path and case rank.
+///
+/// The one definition, because a reader and a writer that each derive it are a
+/// reader and a writer that can disagree: the streaming extractor wrote raw
+/// inner paths while every reader looked under this, so on a case-insensitive
+/// volume one member's bytes silently answered for the other's.
+pub fn staging_rel_for(inner: &str, case_rank: u32) -> PathBuf {
+    if case_rank == 0 {
+        PathBuf::from(inner)
+    } else {
+        PathBuf::from(format!(".spyc-case-{case_rank}")).join(inner)
+    }
+}
+
 impl IndexEntry {
     /// Path relative to the mount's staging root where this entry's bytes live
     /// once materialized. Identity for all but case-colliding entries, which
     /// would otherwise overwrite each other on macOS.
     pub fn staging_rel(&self) -> PathBuf {
-        if self.case_rank == 0 {
-            PathBuf::from(&self.inner)
-        } else {
-            PathBuf::from(format!(".spyc-case-{}", self.case_rank)).join(&self.inner)
-        }
+        staging_rel_for(&self.inner, self.case_rank)
     }
 
     /// The last path component — the name a listing row shows.
@@ -190,13 +201,35 @@ pub fn normalize(raw: &str) -> Result<Normalized, Reject> {
     })
 }
 
+/// What [`IndexBuilder::push`] did with one member.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Pushed {
+    /// Admitted, and its bytes belong at this path under the mount's staging
+    /// root. Handed back rather than re-derived so a one-pass extractor cannot
+    /// write somewhere the finished index won't look.
+    Staged(PathBuf),
+    /// The name was rejected. Keep walking; the reason is in `facts`.
+    Skipped,
+    /// The entry cap is reached and the index is marked truncated. Stop walking.
+    Full,
+}
+
 /// Accumulates members into an [`ArchiveIndex`]: normalizes names, drops unsafe
-/// ones, resolves duplicates, and (at [`Self::finish`]) synthesizes the implied
-/// directories and ranks case collisions.
+/// ones, resolves duplicates, ranks case collisions, and (at [`Self::finish`])
+/// synthesizes the implied directories.
 pub struct IndexBuilder {
     entries: Vec<IndexEntry>,
     /// Inner path → position in `entries`, for last-wins duplicate handling.
     positions: HashMap<String, usize>,
+    /// Case-folded inner path → how many members have claimed it, which is the
+    /// next [`IndexEntry::case_rank`].
+    ///
+    /// Ranked **on arrival** rather than over the finished table, because a
+    /// compressed tar indexes and extracts in one pass: the writer has to know
+    /// where a member's bytes go before the group it collides with is fully
+    /// known. Arrival order is fixed for a given container, so the ranks are
+    /// still deterministic.
+    case_seen: HashMap<String, u32>,
     pub facts: IndexFacts,
     cap: usize,
     truncated: bool,
@@ -207,28 +240,42 @@ impl IndexBuilder {
         Self {
             entries: Vec::new(),
             positions: HashMap::new(),
+            case_seen: HashMap::new(),
             facts: IndexFacts::default(),
             cap,
             truncated: false,
         }
     }
 
-    /// Add one member. Returns `false` once the cap is reached, which is the
-    /// caller's signal to stop walking — the index is marked truncated.
+    /// Claim the next case rank for `inner`, or return the one an entry with
+    /// this exact name already holds — a duplicate replaces its predecessor, so
+    /// it inherits that entry's staging path rather than opening a new one.
+    fn claim_case_rank(&mut self, inner: &str) -> u32 {
+        if let Some(&pos) = self.positions.get(inner) {
+            return self.entries[pos].case_rank;
+        }
+        let slot = self.case_seen.entry(inner.to_lowercase()).or_insert(0);
+        let rank = *slot;
+        *slot += 1;
+        rank
+    }
+
+    /// Add one member, returning the case rank it was admitted under — which is
+    /// where a one-pass extractor must put its bytes ([`staging_rel_for`]).
     ///
     /// A later member with the same normalized name replaces the earlier one,
     /// matching what extractors do (last write wins) so the listing agrees with
     /// what a materialize would produce.
-    pub fn push(&mut self, raw_name: &str, draft: Draft) -> bool {
+    pub fn push(&mut self, raw_name: &str, draft: Draft) -> Pushed {
         if self.entries.len() >= self.cap {
             self.truncated = true;
-            return false;
+            return Pushed::Full;
         }
         let normalized = match normalize(raw_name) {
             Ok(n) => n,
             Err(reject) => {
                 self.facts.record_reject(reject);
-                return true;
+                return Pushed::Skipped;
             }
         };
         if normalized.had_backslash {
@@ -237,6 +284,7 @@ impl IndexBuilder {
         if normalized.was_absolute {
             self.facts.absolute_names += 1;
         }
+        let case_rank = self.claim_case_rank(&normalized.inner);
         let entry = IndexEntry {
             inner: normalized.inner,
             kind: draft.kind,
@@ -247,9 +295,10 @@ impl IndexBuilder {
             gid: draft.gid,
             link_target: draft.link_target,
             locator: draft.locator,
-            case_rank: 0,
+            case_rank,
             readable: draft.readable,
         };
+        let staged = staging_rel_for(&entry.inner, case_rank);
         if let Some(&pos) = self.positions.get(&entry.inner) {
             self.facts.duplicates += 1;
             self.entries[pos] = entry;
@@ -258,7 +307,7 @@ impl IndexBuilder {
                 .insert(entry.inner.clone(), self.entries.len());
             self.entries.push(entry);
         }
-        true
+        Pushed::Staged(staged)
     }
 
     pub fn finish(
@@ -269,7 +318,7 @@ impl IndexBuilder {
     ) -> (ArchiveIndex, IndexFacts) {
         self.synthesize_implied_dirs();
         self.entries.sort_unstable_by(|a, b| a.inner.cmp(&b.inner));
-        self.rank_case_collisions();
+        self.facts.case_collisions = self.entries.iter().filter(|e| e.case_rank > 0).count();
         let total_uncompressed = self
             .entries
             .iter()
@@ -309,6 +358,11 @@ impl IndexBuilder {
         implied.dedup();
         self.facts.implied_dirs = implied.len();
         for inner in implied {
+            // Through the same counter as a real member: a synthesized `a/`
+            // beside a stored `A/` is still a collision on a case-insensitive
+            // volume, and handing it rank 0 unconditionally would put two
+            // directories at one staging path.
+            let case_rank = self.claim_case_rank(&inner);
             self.positions.insert(inner.clone(), self.entries.len());
             self.entries.push(IndexEntry {
                 inner,
@@ -320,23 +374,10 @@ impl IndexBuilder {
                 gid: None,
                 link_target: None,
                 locator: Locator::Implied,
-                case_rank: 0,
+                case_rank,
                 readable: true,
             });
         }
-    }
-
-    /// Assign a nonzero `case_rank` to every entry after the first in a group of
-    /// names that differ only by case. Runs after the sort, so ranks are stable.
-    fn rank_case_collisions(&mut self) {
-        let mut seen: HashMap<String, u32> = HashMap::new();
-        for entry in &mut self.entries {
-            let key = entry.inner.to_lowercase();
-            let next = seen.entry(key).or_insert(0);
-            entry.case_rank = *next;
-            *next += 1;
-        }
-        self.facts.case_collisions = self.entries.iter().filter(|e| e.case_rank > 0).count();
     }
 }
 
@@ -486,7 +527,7 @@ mod tests {
                 size: *size,
                 ..Draft::file(*size, Locator::Zip { index: i })
             };
-            assert!(b.push(name, draft));
+            assert_ne!(b.push(name, draft), Pushed::Full);
         }
         b.finish(PathBuf::from("/src/a.zip"), ArchiveFormat::Zip, 100)
     }
@@ -545,8 +586,15 @@ mod tests {
     #[test]
     fn unsafe_names_are_dropped_and_counted_not_mounted() {
         let mut b = IndexBuilder::new(10);
-        assert!(b.push("../evil", Draft::file(1, Locator::Zip { index: 0 })));
-        assert!(b.push("ok.txt", Draft::file(2, Locator::Zip { index: 1 })));
+        assert_eq!(
+            b.push("../evil", Draft::file(1, Locator::Zip { index: 0 })),
+            Pushed::Skipped,
+            "an unsafe name is dropped, not indexed"
+        );
+        assert_ne!(
+            b.push("ok.txt", Draft::file(2, Locator::Zip { index: 1 })),
+            Pushed::Full
+        );
         let (index, facts) = b.finish(PathBuf::from("/a.zip"), ArchiveFormat::Zip, 10);
         assert_eq!(inners(&index), ["ok.txt"]);
         assert_eq!(facts.traversal_names, 1);
@@ -592,10 +640,10 @@ mod tests {
     #[test]
     fn the_entry_cap_truncates_and_stops_the_walk() {
         let mut b = IndexBuilder::new(2);
-        assert!(b.push("a", Draft::file(1, Locator::Staged)));
-        assert!(b.push("b", Draft::file(1, Locator::Staged)));
+        assert_ne!(b.push("a", Draft::file(1, Locator::Staged)), Pushed::Full);
+        assert_ne!(b.push("b", Draft::file(1, Locator::Staged)), Pushed::Full);
         assert!(
-            !b.push("c", Draft::file(1, Locator::Staged)),
+            b.push("c", Draft::file(1, Locator::Staged)) == Pushed::Full,
             "push reports the cap so the caller stops walking"
         );
         let (index, _) = b.finish(PathBuf::from("/a.zip"), ArchiveFormat::Zip, 10);

--- a/src/archive/read/mod.rs
+++ b/src/archive/read/mod.rs
@@ -14,7 +14,7 @@ use anyhow::{Context, Result, bail};
 
 use super::ArchiveFormat;
 use super::index::{
-    ArchiveEntryKind, ArchiveIndex, Draft, IndexBuilder, IndexEntry, Locator, normalize,
+    ArchiveEntryKind, ArchiveIndex, Draft, IndexBuilder, IndexEntry, Locator, Pushed, normalize,
 };
 use super::scan::IndexFacts;
 
@@ -89,7 +89,7 @@ fn index_zip(archive: &Path, cap: usize) -> Result<Indexed> {
         };
         let name = member.name().to_string();
         drop(member);
-        if !builder.push(&name, draft) {
+        if builder.push(&name, draft) == Pushed::Full {
             break;
         }
     }
@@ -110,7 +110,7 @@ fn index_tar(archive: &Path, cap: usize) -> Result<Indexed> {
         let offset = entry.raw_file_position();
         let (name, draft) = tar_draft(&entry, Locator::TarData { offset }, &mut builder.facts);
         let Some(draft) = draft else { continue };
-        if !builder.push(&name, draft) {
+        if builder.push(&name, draft) == Pushed::Full {
             break;
         }
     }
@@ -157,32 +157,38 @@ pub fn stream_mount(
         let mut entry = entry.with_context(|| format!("reading {}", archive.display()))?;
         let (name, draft) = tar_draft(&entry, Locator::Staged, &mut builder.facts);
         let Some(draft) = draft else { continue };
-        if let Ok(clean) = normalize(&name) {
-            // Budgeted on bytes that actually arrive, not on what the header
-            // claims. A tar header's size field is attacker input: declaring 0
-            // and then streaming gigabytes used to walk straight past this gate,
-            // because the gate added up the declarations. `write_member` reports
-            // what it really wrote and stops at the remaining allowance, so a
-            // member can overshoot by at most one byte before this fires.
-            let allowance = budget.saturating_sub(written);
-            let wrote = write_member(
-                &mut entry,
-                &draft,
-                &clean.inner,
-                staging_root,
-                allowance,
-                &mut builder.facts,
-            )?;
-            written = written.saturating_add(wrote);
-            if written > budget {
-                bail!(
-                    "over the {} extract budget — raise [archive] extract_budget_mb to mount it",
-                    crate::fs::ops::format_size(budget)
-                );
-            }
-        }
-        if !builder.push(&name, draft) {
-            break;
+        // Index BEFORE extracting, and take the destination from the index. A
+        // member's staging path depends on its case rank, which is the builder's
+        // to assign — deriving it here instead is how the streamed writer came
+        // to put bytes where no reader looks.
+        let staged = match builder.push(&name, draft.clone()) {
+            Pushed::Staged(rel) => rel,
+            // A refused name has no entry, so nothing would ever read what we
+            // wrote for it.
+            Pushed::Skipped => continue,
+            Pushed::Full => break,
+        };
+        // Budgeted on bytes that actually arrive, not on what the header
+        // claims. A tar header's size field is attacker input: declaring 0
+        // and then streaming gigabytes used to walk straight past this gate,
+        // because the gate added up the declarations. `write_member` reports
+        // what it really wrote and stops at the remaining allowance, so a
+        // member can overshoot by at most one byte before this fires.
+        let allowance = budget.saturating_sub(written);
+        let wrote = write_member(
+            &mut entry,
+            &draft,
+            &staged,
+            staging_root,
+            allowance,
+            &mut builder.facts,
+        )?;
+        written = written.saturating_add(wrote);
+        if written > budget {
+            bail!(
+                "over the {} extract budget — raise [archive] extract_budget_mb to mount it",
+                crate::fs::ops::format_size(budget)
+            );
         }
     }
     let (index, facts) = builder.finish(archive.to_path_buf(), format, compressed_size);
@@ -202,10 +208,11 @@ pub fn stream_mount(
 /// how many members were restored.
 pub fn restage_missing(
     archive: &Path,
-    format: ArchiveFormat,
+    index: &super::ArchiveIndex,
     staging_root: &Path,
     cap: usize,
 ) -> Result<usize> {
+    let format = index.format;
     let file = File::open(archive).with_context(|| format!("opening {}", archive.display()))?;
     let reader: Box<dyn Read> = match format {
         ArchiveFormat::TarGz => Box::new(flate2::read::GzDecoder::new(BufReader::new(file))),
@@ -230,9 +237,14 @@ pub fn restage_missing(
         let Ok(clean) = normalize(&name) else {
             continue;
         };
-        // `staging_rel` is what a reader looks under, so a case-colliding member is
-        // restored where its own reader expects it.
-        if staging_root.join(&clean.inner).exists() {
+        // Asked of the index rather than derived from the name: `staging_rel` is
+        // what a reader looks under, and only the entry knows its case rank. A
+        // member the index doesn't hold has no reader to satisfy.
+        let Some(entry_in_index) = index.get(&clean.inner) else {
+            continue;
+        };
+        let staged = entry_in_index.staging_rel();
+        if staging_root.join(&staged).exists() {
             continue;
         }
         // Refilling a member that was already admitted at mount time — the
@@ -241,7 +253,7 @@ pub fn restage_missing(
         write_member(
             &mut entry,
             &draft,
-            &clean.inner,
+            &staged,
             staging_root,
             u64::MAX,
             &mut facts,
@@ -264,12 +276,12 @@ pub fn restage_missing(
 fn write_member<R: Read>(
     entry: &mut tar::Entry<'_, R>,
     draft: &Draft,
-    inner: &str,
+    staging_rel: &Path,
     staging_root: &Path,
     allowance: u64,
     facts: &mut IndexFacts,
 ) -> Result<u64> {
-    let Ok(dest) = contained_dest(staging_root, inner) else {
+    let Ok(dest) = contained_dest(staging_root, staging_rel) else {
         facts.link_traversals += 1;
         return Ok(0);
     };

--- a/src/archive/read/tests.rs
+++ b/src/archive/read/tests.rs
@@ -1036,3 +1036,105 @@ fn an_honest_archive_still_extracts_completely() {
         "an in-budget member must arrive intact"
     );
 }
+
+/// Two members differing only by case must each read back their OWN bytes.
+///
+/// `staging_rel()` exists so they don't collide on a case-insensitive volume —
+/// every default macOS volume. Every reader used it; the streaming writer used
+/// the raw member path instead, so on macOS the second member's bytes landed on
+/// top of the first's and the reader for rank 1 looked under a prefix nothing had
+/// ever written. Reading `a/README` returned the *other* member's content, and
+/// `a/readme` was unreadable and — because the repack reads the same path —
+/// unwritable.
+///
+/// Asserted through the index rather than against fixed paths, so it tests the
+/// contract ("a member's bytes are where its own entry says") rather than the
+/// current spelling of the escape prefix.
+#[test]
+fn a_streamed_case_collision_stages_each_member_where_its_own_entry_says() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("case.tar.gz");
+    let staging = tmp.path().join("staging");
+    tar_gz_at(
+        &archive,
+        &[("a/README", b"UPPER", 0o644), ("a/readme", b"lower", 0o644)],
+    );
+
+    let indexed = stream_mount(
+        &archive,
+        ArchiveFormat::TarGz,
+        &staging,
+        1 << 20,
+        1000,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
+
+    // The premise: the two really are ranked as a collision. Without this the
+    // test could pass on a hypothetical index that never ranked them.
+    assert_eq!(
+        indexed.facts.case_collisions, 1,
+        "the two names differ only by case, so exactly one is ranked above 0"
+    );
+
+    for (inner, want) in [("a/README", &b"UPPER"[..]), ("a/readme", &b"lower"[..])] {
+        let entry = indexed
+            .index
+            .get(inner)
+            .unwrap_or_else(|| panic!("{inner} is in the index"));
+        let at = staging.join(entry.staging_rel());
+        let got = std::fs::read(&at)
+            .unwrap_or_else(|e| panic!("{inner} staged at {}: {e}", at.display()));
+        assert_eq!(
+            got, want,
+            "{inner} must read its own bytes, not the other member's"
+        );
+    }
+}
+
+/// A refill puts a member back where its own entry says too — the same contract,
+/// on the path that repairs staging when something outside spyc empties it.
+///
+/// This is the half a comment used to claim and the code didn't: `restage_missing`
+/// walked the container deriving paths from member names, so a case-ranked member
+/// was checked for (and rewritten) at a path no reader consults. For a streamed
+/// archive the staged bytes are the only copy outside the container, so the
+/// archive became permanently unwritable.
+#[test]
+fn a_refill_puts_a_case_ranked_member_back_where_its_reader_looks() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("case.tar.gz");
+    let staging = tmp.path().join("staging");
+    tar_gz_at(
+        &archive,
+        &[("a/README", b"UPPER", 0o644), ("a/readme", b"lower", 0o644)],
+    );
+    let indexed = stream_mount(
+        &archive,
+        ArchiveFormat::TarGz,
+        &staging,
+        1 << 20,
+        1000,
+        &AtomicBool::new(false),
+    )
+    .unwrap();
+
+    let ranked = indexed
+        .index
+        .entries
+        .iter()
+        .find(|e| e.case_rank > 0)
+        .expect("one of the pair is ranked");
+    let at = staging.join(ranked.staging_rel());
+    let want = std::fs::read(&at).expect("it was staged");
+    std::fs::remove_file(&at).expect("something outside spyc reaps it");
+
+    let restored = restage_missing(&archive, &indexed.index, &staging, 1000).unwrap();
+
+    assert_eq!(restored, 1, "the one missing member is refilled");
+    assert_eq!(
+        std::fs::read(&at).expect("back where its reader looks"),
+        want,
+        "and with its own bytes"
+    );
+}

--- a/src/archive/write.rs
+++ b/src/archive/write.rs
@@ -86,7 +86,7 @@ pub fn repack(
         if missing {
             read::restage_missing(
                 archive,
-                index.format,
+                index,
                 staging_root,
                 index.entries.len().saturating_add(1024),
             )


### PR DESCRIPTION
**M5** of the pre-2.1 review (`A-archive.md`, MEDIUM-1) — `medium`.

`IndexEntry::staging_rel()` exists so two members differing only by case don't
clobber each other on a case-insensitive volume — every default macOS volume,
which is the platform this is developed on. Every *reader* used it
(`materialize`, `mount.staging_path`, `write_tar`, `write.rs`'s
missing-member probe). Both *writers* derived the path from the member name
instead:

```rust
write_member(&mut entry, &draft, &clean.inner, staging_root, …)   // stream_mount
if staging_root.join(&clean.inner).exists() { continue; }         // restage_missing
```

So for a `.tar.gz` holding `a/README` and `a/readme`, on macOS:

- both members were written to one file, so **`a/README` read back the other
  member's bytes** — silent content substitution, no error anywhere;
- `a/readme` was unreadable ("staged bytes are missing") **and unwritable**, since
  the repack reads the same path;
- on a case-sensitive volume the first symptom disappears and the second remains.

The user's only warning was "1 member(s) differ only by case", which doesn't
describe any of that.

`restage_missing`'s comment claimed the opposite of what its code did — and it
was asserting a property the function was structurally unable to have, having no
index in hand to ask for a rank.

## Why the rank moved to arrival time

Ranks were assigned in `IndexBuilder::finish`, over the sorted table. A
compressed tar indexes and extracts in **one pass**, so at the moment the writer
needs a destination the group a member collides with isn't known yet — the
writer could not have asked, whatever it wanted to do.

`claim_case_rank` now runs in `push`. Arrival order is fixed for a given
container, so ranks stay deterministic; what changes is that they're knowable
*during* the walk. Two details it has to get right, both covered:

- a **duplicate** (same normalized name) inherits the rank of the entry it
  replaces, rather than claiming a new one and orphaning the staged bytes;
- a **synthesized implied directory** goes through the same counter, so an
  implied `a/` beside a stored `A/` can't be handed rank 0 twice.

## Why `push` returns the path rather than the rank

`Pushed::Staged(PathBuf)`. A rank would still leave the writer deriving the path
itself, which is exactly the shape that failed — a reader and a writer that each
derive it are a reader and a writer that can disagree. Now there is one
definition (`staging_rel_for`), the builder applies it, and the writer is handed
the answer. `Pushed`'s other two variants make the previously-implicit outcomes
explicit: `Skipped` (name refused — nothing would ever read what we wrote for it,
so don't write) and `Full` (cap reached, stop walking).

`restage_missing` takes the index and asks the entry. The comment is now true.

## Tests

Two, both red before:

- `a_streamed_case_collision_stages_each_member_where_its_own_entry_says` — the
  finding's own fixture, asserted **through the index** (`entry.staging_rel()`)
  rather than against fixed paths, so it pins the contract and not the spelling
  of the escape prefix. It also asserts the premise — that the pair really is
  ranked as a collision — so it can't pass on an index that never ranked them.
  Before: `a/README` returns `lower`.
- `a_refill_puts_a_case_ranked_member_back_where_its_reader_looks` — the same
  contract on the repair path, which for a streamed archive is what stands
  between a reaped staging file and an archive that can never be written again.

Bite-checked three ways, because the two halves can mask each other: both
defects reintroduced (both tests red), and the refill defect alone (`the one
missing member is refilled` — `restored` was 0, since it kept checking a path
nothing writes).

`make check-ci` → `=== GATE: PASS ===` (253 archive tests).

Generated with [Claude Code](https://claude.com/claude-code)