### PR TITLE
fix(archive): a member can't squat on the staging escape namespace

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -495,7 +495,8 @@ they land in a session-scoped staging dir that is cleaned up on exit.
   `[archive] extract_budget_mb` (default 512) is the ceiling; past it the mount
   is refused rather than filling the disk, and `:archive cancel` abandons one
   that is taking too long.
-- **It says what's odd** — unsafe member paths (`../…`), symlinks pointing out
+- **It says what's odd** — unsafe member paths (`../…`, or one claiming spyc's
+  own `.spyc` staging directory), symlinks pointing out
   of the archive, duplicate or case-colliding names, encrypted members and a
   capped index are all reported when the mount opens, in full under
   `:archive info`.

--- a/src/app/archive.rs
+++ b/src/app/archive.rs
@@ -499,17 +499,17 @@ impl App {
             .iter()
             .find(|m| real.starts_with(&m.staging_root))?;
         let rel = real.strip_prefix(&mount.staging_root).ok()?;
-        // A case-colliding member stages under its own prefix, so strip that
-        // before reading the path back as a member.
+        // A case-colliding member stages under the reserved directory
+        // (`<reserved>/case-N/<inner>`), so strip both of those components before
+        // reading the path back as a member. No member name can start with the
+        // reserved component — `index::normalize` refuses it — so a match here is
+        // spyc's own escape and never the archive's.
         let rel = rel
-            .components()
-            .next()
-            .and_then(|first| {
-                first
-                    .as_os_str()
-                    .to_str()
-                    .filter(|s| s.starts_with(".spyc-case-"))
-                    .and_then(|_| rel.strip_prefix(first).ok())
+            .strip_prefix(crate::archive::index::STAGING_RESERVED)
+            .ok()
+            .and_then(|after| {
+                let rank = after.components().next()?;
+                after.strip_prefix(rank).ok()
             })
             .unwrap_or(rel);
         Some(mount.archive().join(rel))
@@ -531,7 +531,7 @@ impl App {
         };
         // Keyed by **journal path**, which is what every reader of this map uses.
         // The staging-relative path is not the same string: a case-colliding member
-        // stages under a `.spyc-case-N/` prefix, so recording its location gave one
+        // stages under the reserved directory, so recording its location gave one
         // member two names and its edits were never noticed.
         let Some((archive, inner)) = self.staged_owner(real) else {
             return;
@@ -1462,6 +1462,65 @@ mod tests {
                 "the pid scopes it: {name}"
             );
             assert!(a.starts_with(tmp.path().join("archives")));
+        });
+    }
+
+    /// Every member's staged path maps back to the member it stands in for —
+    /// including a case-ranked one, whose bytes live under the reserved directory
+    /// rather than at its own name.
+    ///
+    /// This is the inverse of `ArchiveMount::staging_path`, and the two are
+    /// derived independently: the forward direction asks the entry, the reverse
+    /// direction strips a prefix. A round trip is the only thing that keeps them
+    /// agreeing, and getting it wrong hands one member another's journal path —
+    /// which is how edits stop being noticed.
+    #[test]
+    fn a_staged_path_maps_back_to_its_own_member_at_every_rank() {
+        use crate::archive::ArchiveFormat;
+        use crate::archive::index::{Draft, IndexBuilder, Locator};
+        use crate::archive::scan::Capability;
+
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let mut b = IndexBuilder::new(100);
+            for (i, name) in ["a/README", "a/readme"].iter().enumerate() {
+                b.push(name, Draft::file(1, Locator::Zip { index: i }));
+            }
+            let (index, _) = b.finish(PathBuf::from("/src/pkg.zip"), ArchiveFormat::Zip, 10);
+
+            let mut app = App::test_app(tmp.path().to_path_buf());
+            let staging_root = tmp.path().join("staging");
+            app.state.mounts.insert(
+                ArchiveMount {
+                    index: index.clone(),
+                    journal: Journal::default(),
+                    staged: StagedStats::new(),
+                    capability: Capability::ReadWrite,
+                    warnings: Vec::new(),
+                    staging_root: staging_root.clone(),
+                    last_used: 0,
+                    depth: 0,
+                    editing: Vec::new(),
+                },
+                &[],
+            );
+
+            let mut ranks = Vec::new();
+            for entry in &index.entries {
+                ranks.push(entry.case_rank);
+                let staged = staging_root.join(entry.staging_rel());
+                assert_eq!(
+                    app.mount_path_for_staged(&staged),
+                    Some(PathBuf::from("/src/pkg.zip").join(&entry.inner)),
+                    "{} staged at {}",
+                    entry.inner,
+                    entry.staging_rel().display()
+                );
+            }
+            assert!(
+                ranks.contains(&0) && ranks.iter().any(|r| *r > 0),
+                "the fixture must cover both an unranked and a ranked member: {ranks:?}"
+            );
         });
     }
 

--- a/src/archive/index.rs
+++ b/src/archive/index.rs
@@ -62,6 +62,16 @@ pub struct IndexEntry {
     pub readable: bool,
 }
 
+/// The one staging directory that is spyc's rather than the archive's.
+///
+/// Reserved in [`normalize`], which is what makes it unreachable: a member
+/// *named* into the escape namespace would otherwise resolve to the same staging
+/// path as a case-ranked member, and `materialize` returns early on an existing
+/// destination — so whichever landed first served both. Reserving one component
+/// beats matching the escape spelling, because it also leaves room for anything
+/// else spyc needs to keep beside a mount's member tree.
+pub const STAGING_RESERVED: &str = ".spyc";
+
 /// Where a member's bytes live under the mount's staging root, from its inner
 /// path and case rank.
 ///
@@ -73,7 +83,9 @@ pub fn staging_rel_for(inner: &str, case_rank: u32) -> PathBuf {
     if case_rank == 0 {
         PathBuf::from(inner)
     } else {
-        PathBuf::from(format!(".spyc-case-{case_rank}")).join(inner)
+        Path::new(STAGING_RESERVED)
+            .join(format!("case-{case_rank}"))
+            .join(inner)
     }
 }
 
@@ -144,6 +156,9 @@ pub enum Reject {
     Traversal,
     /// An interior NUL, which no filesystem accepts.
     Nul,
+    /// The name claims [`STAGING_RESERVED`], the staging directory spyc uses for
+    /// its own bookkeeping.
+    Reserved,
 }
 
 impl Reject {
@@ -152,6 +167,7 @@ impl Reject {
             Self::Empty => "empty name",
             Self::Traversal => "`..` path traversal",
             Self::Nul => "NUL in name",
+            Self::Reserved => "claims spyc's reserved staging directory",
         }
     }
 }
@@ -171,7 +187,8 @@ pub struct Normalized {
 /// written by Windows tools do use `\`, and reading them as one long filename
 /// would flatten the tree. A leading `/` is stripped rather than refused (it's
 /// merely sloppy), while `..` is refused outright — that one is how an archive
-/// escapes its mount.
+/// escapes its mount. [`STAGING_RESERVED`] is refused for a related reason: a
+/// member may not name the directory spyc stages its own copies under.
 pub fn normalize(raw: &str) -> Result<Normalized, Reject> {
     if raw.contains('\0') {
         return Err(Reject::Nul);
@@ -193,6 +210,11 @@ pub fn normalize(raw: &str) -> Result<Normalized, Reject> {
     }
     if parts.is_empty() {
         return Err(Reject::Empty);
+    }
+    // The FIRST component only: `a/.spyc/b` stages harmlessly under the member
+    // tree, and refusing it would drop a legal name for nothing.
+    if parts[0] == STAGING_RESERVED {
+        return Err(Reject::Reserved);
     }
     Ok(Normalized {
         inner: parts.join("/"),
@@ -666,10 +688,21 @@ mod tests {
         assert_eq!(first.case_rank, 0);
         assert_eq!(first.staging_rel(), PathBuf::from("a/README"));
         assert_eq!(second.case_rank, 1);
-        assert_eq!(
+        assert_ne!(
             second.staging_rel(),
-            PathBuf::from(".spyc-case-1/a/readme"),
+            first.staging_rel(),
             "the colliding entry stages somewhere it cannot clobber the first"
+        );
+        // Under the reserved directory specifically, which is what makes the
+        // escape unreachable from a member name (`normalize` refuses it).
+        assert!(
+            second.staging_rel().starts_with(STAGING_RESERVED),
+            "{}",
+            second.staging_rel().display()
+        );
+        assert!(
+            normalize(&format!("{STAGING_RESERVED}/anything")).is_err(),
+            "a member may not name the escape namespace"
         );
     }
 

--- a/src/archive/journal.rs
+++ b/src/archive/journal.rs
@@ -733,7 +733,10 @@ mod repack_tests {
         assert_eq!(
             staged.source,
             StepSource::Staging {
-                rel: PathBuf::from(".spyc-case-1/readme")
+                rel: index
+                    .get("readme")
+                    .expect("the colliding member is indexed")
+                    .staging_rel()
             }
         );
     }

--- a/src/archive/read/tests.rs
+++ b/src/archive/read/tests.rs
@@ -1138,3 +1138,63 @@ fn a_refill_puts_a_case_ranked_member_back_where_its_reader_looks() {
         "and with its own bytes"
     );
 }
+
+/// A member can't reach the namespace spyc escapes case collisions into.
+///
+/// Ranked copies stage under a reserved prefix. Nothing stopped an archive from
+/// containing a member *named* that prefix: its own (rank 0) staging path was
+/// then the same path the ranked member's reader consults, `materialize` returns
+/// early on `dest.exists()`, and whichever landed first served both. Contrived to
+/// build, but it is content substitution under the archive's control.
+///
+/// The demonstrated fixture: `a/README`, `a/readme`, and a decoy sitting where
+/// `a/readme` escapes to.
+#[test]
+fn a_member_cannot_squat_on_the_case_escape_namespace() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("decoy.zip");
+    let staging = tmp.path().join("staging");
+    // Aimed by asking where a rank-1 member escapes to, rather than by spelling
+    // the prefix out — so this keeps aiming at the escape namespace if the
+    // namespace is ever renamed, instead of quietly passing.
+    let decoy = crate::archive::index::staging_rel_for("a/readme", 1)
+        .to_str()
+        .expect("the escape path is utf-8")
+        .to_string();
+    zip_at(
+        &archive,
+        &[
+            (&decoy, b"DECOY", 0o644),
+            ("a/README", b"RANK0", 0o644),
+            ("a/readme", b"RANK1", 0o644),
+        ],
+    );
+
+    let indexed = index_seekable(&archive, ArchiveFormat::Zip, 1000).unwrap();
+
+    // Every indexed member must own its staging path — no two entries may
+    // resolve to the same one, whatever the archive named them.
+    let mut seen = std::collections::HashMap::new();
+    for entry in &indexed.index.entries {
+        if let Some(other) = seen.insert(entry.staging_rel(), entry.inner.clone()) {
+            panic!(
+                "{} and {} both stage at {}",
+                other,
+                entry.inner,
+                entry.staging_rel().display()
+            );
+        }
+    }
+
+    // And the member that would have been shadowed reads its own bytes.
+    let ranked = indexed
+        .index
+        .get("a/readme")
+        .expect("the ranked member is indexed");
+    let at = materialize(&archive, ranked, &staging).unwrap();
+    assert_eq!(
+        std::fs::read(&at).unwrap(),
+        b"RANK1",
+        "a/readme must not be served the decoy's bytes"
+    );
+}

--- a/src/archive/scan.rs
+++ b/src/archive/scan.rs
@@ -20,6 +20,9 @@ pub struct IndexFacts {
     pub absolute_names: usize,
     /// Members whose `\` separators were reinterpreted as `/`.
     pub backslash_names: usize,
+    /// Members whose name claimed [`crate::archive::index::STAGING_RESERVED`],
+    /// the staging directory spyc keeps its own copies under.
+    pub reserved_names: usize,
     /// Members whose name collided with an earlier one (last won).
     pub duplicates: usize,
     /// Directories the archive omitted and we synthesized.
@@ -50,12 +53,13 @@ impl IndexFacts {
             Reject::Traversal => self.traversal_names += 1,
             Reject::Empty => self.empty_names += 1,
             Reject::Nul => self.nul_names += 1,
+            Reject::Reserved => self.reserved_names += 1,
         }
     }
 
     /// Members that never made it into the index at all.
     pub const fn skipped(&self) -> usize {
-        self.traversal_names + self.empty_names + self.nul_names
+        self.traversal_names + self.empty_names + self.nul_names + self.reserved_names
     }
 
     /// tar members whose shape a rebuilt header can't reproduce.
@@ -143,6 +147,13 @@ pub fn warnings(facts: &IndexFacts, index: &ArchiveIndex) -> Vec<String> {
         out.push(format!(
             "{} member(s) skipped: unusable name",
             facts.empty_names + facts.nul_names
+        ));
+    }
+    if facts.reserved_names > 0 {
+        out.push(format!(
+            "{} member(s) skipped: named spyc's reserved `{}` staging directory",
+            facts.reserved_names,
+            crate::archive::index::STAGING_RESERVED
         ));
     }
     if facts.absolute_names > 0 {
@@ -309,6 +320,7 @@ mod tests {
             traversal_names: 1,
             empty_names: 1,
             nul_names: 1,
+            reserved_names: 1,
             absolute_names: 1,
             backslash_names: 1,
             duplicates: 1,
@@ -323,9 +335,10 @@ mod tests {
         };
         let notes = warnings(&facts, &index);
         // Empty + NUL names share a line; implied dirs are normal and silent.
-        assert_eq!(notes.len(), 11, "{notes:#?}");
+        assert_eq!(notes.len(), 12, "{notes:#?}");
         assert!(notes.iter().any(|n| n.contains("traversal")));
         assert!(notes.iter().any(|n| n.contains("unusable name")));
+        assert!(notes.iter().any(|n| n.contains("reserved")));
         assert!(notes.iter().any(|n| n.contains("only by case")));
         assert!(notes.iter().any(|n| n.contains("encrypted")));
         assert!(


### PR DESCRIPTION
**M6** of the pre-2.1 review (`A-archive.md`, MEDIUM-2) — `medium`.

A case-colliding member stages under an escape prefix so it doesn't clobber its
twin on a case-insensitive volume. Nothing stopped an archive from containing a
member *literally named* into that prefix: `.spyc-case-1/a/readme` normalized to
itself, took rank 0, and resolved to the same staging path as `a/readme` at rank
1. `materialize` returns early on an existing destination, so whichever landed
first served both — content substitution under the archive's control.

Demonstrated with a zip holding `a/README`, `a/readme` and the decoy: reading
`a/readme` yields the decoy's bytes.

## The fix

The escape namespace becomes a directory a member cannot name.
`index::normalize` — the one place a name enters, and already where `..`, a
leading `/` and a NUL are refused — now refuses a **first component** equal to
`STAGING_RESERVED` (`.spyc`), and ranked copies stage at
`.spyc/case-<rank>/<inner>`.

Reserving one component rather than matching the escape's spelling, because the
spelling is an implementation detail that can change (it just did) while the
reservation is the property; it also leaves room for anything else spyc needs
beside a mount's member tree. Only the first component: `a/.spyc/b` stages
harmlessly under the member tree, and refusing it would drop a legal name for
nothing.

A refused member is counted (`IndexFacts::reserved_names`), named in the mount's
warnings, and — like every other skipped name — makes the mount read-only, since
a repack couldn't reproduce what spyc declined to represent.

## The reverse map went with it

`mount_path_for_staged` is the inverse of `ArchiveMount::staging_path`, and the
two derive their answer independently: the forward direction asks the entry, the
reverse strips a prefix. It was sniffing `.spyc-case-`, so on its own it would
have kept "working" — mapping a ranked member's staged file to
`pkg.zip/.spyc/case-1/a/readme`, a path that is not a member. That hands one
member another's journal identity, which is how an edit stops being noticed.

## Tests

- `a_member_cannot_squat_on_the_case_escape_namespace` — the finding's fixture,
  but the decoy's name is **computed from `staging_rel_for`** rather than spelled
  out, so it keeps aiming at the escape namespace if the namespace is renamed
  again instead of quietly passing. It asserts the general property (no two
  entries share a staging path) and then that the shadowed member reads its own
  bytes. Before: `.spyc-case-1/a/readme and a/readme both stage at
  .spyc-case-1/a/readme`.
- `a_staged_path_maps_back_to_its_own_member_at_every_rank` — the round trip,
  which is the only thing keeping the two derivations in agreement. Its fixture
  asserts it covers both an unranked and a ranked member, so it can't pass by
  testing rank 0 twice.
- Two existing tests hardcoded the old prefix; both now ask the entry (or assert
  the property — "differs from its twin, and lives under the reserved
  directory") instead of a literal, which is what let this one drift.

Bite-checked with both halves reintroduced: the squat test reports the shared
path, and the round trip reports `/src/pkg.zip/.spyc/case-1/a/readme` where
`/src/pkg.zip/a/readme` was expected.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)