### PR TITLE
fix(mouse): invert_scroll reaches the agent pane too, not just spyc's own surfaces

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -326,9 +326,12 @@ and `less`. Set it to `true` if that reads backwards for you.
 It's named for the mechanism rather than for a convention on purpose: whether
 "down" *should* move the content or the cursor depends on your OS trackpad
 setting and your terminal, so a `natural_scroll`-style flag would be ambiguous
-in precisely the situation you'd reach for it. The flip is applied once, where
-the wheel delta is computed, so the file list, the pager, and an agent pane's
-synthesized scroll keys move together and never disagree with each other.
+in precisely the situation you'd reach for it. The flip is applied once, to the
+event itself, before anything branches on it — so the file list, the pager, an
+agent pane's synthesized scroll keys **and the wheel report forwarded to a
+mouse-aware child** (claude, vim, htop) all move together. Half-inverting spyc
+would be worse than either setting: the pane scrolling one way and the column
+beside it the other.
 
 > [!WARNING]
 > **Capture takes native click-drag text selection away from your terminal.**

--- a/src/app/mouse/forward.rs
+++ b/src/app/mouse/forward.rs
@@ -357,4 +357,51 @@ mod tests {
             );
         });
     }
+
+    /// **`[mouse] invert_scroll` reaches a mouse-aware child too.**
+    ///
+    /// The knob exists for one user: the wheel reads backwards on their
+    /// OS/terminal combination. Inverting spyc's own surfaces but not the report
+    /// forwarded to claude/vim/htop leaves that user with a *half*-inverted spyc
+    /// — the pane scrolling one way and the list beside it the other — which is
+    /// worse than either setting.
+    ///
+    /// Asserted as an equivalence rather than against a button number, so it
+    /// pins the contract ("an inverted tick reaches the child as the tick it
+    /// means") and not the xterm encoding.
+    #[test]
+    fn inverting_the_wheel_inverts_what_the_child_receives() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            crate::set_mouse_capture_for_test(true);
+            let (mut app, (col, row)) = app_with_a_mouse_pane(tmp.path());
+            let mut bytes_for = |invert: bool, kind| {
+                app.state.config.mouse.invert_scroll = invert;
+                let fx = app.handle_mouse(at(kind, col, row));
+                sent(&fx)
+                    .expect("a wheel tick over a mouse-aware pane reaches the child")
+                    .to_vec()
+            };
+
+            let plain_up = bytes_for(false, MouseEventKind::ScrollUp);
+            let plain_down = bytes_for(false, MouseEventKind::ScrollDown);
+            assert_ne!(
+                plain_up, plain_down,
+                "the two directions must differ, or this test proves nothing"
+            );
+
+            assert_eq!(
+                bytes_for(true, MouseEventKind::ScrollUp),
+                plain_down,
+                "an inverted wheel-up must reach the child as a wheel-down"
+            );
+            assert_eq!(
+                bytes_for(true, MouseEventKind::ScrollDown),
+                plain_up,
+                "and an inverted wheel-down as a wheel-up"
+            );
+            crate::set_mouse_capture_for_test(false);
+        });
+    }
 }

--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -31,19 +31,36 @@ pub(super) use route::{
     Gesture, MouseSink, MouseSnapshot, PendingViewIntent, region_at, route_mouse,
 };
 
-/// Resolve a raw mouse event kind to the gesture + wheel delta every downstream
+/// Apply `[mouse] invert_scroll` to a raw event, at the boundary, before anything
+/// branches on it.
+///
+/// The knob means "this machine reports the wheel the opposite way round from
+/// what I mean", which is a property of the *input* — so it is corrected once,
+/// here, and everything downstream reads a wheel that means what it says. That
+/// includes the report forwarded to a mouse-aware child, which a per-consumer
+/// flip could not reach: inverting the file list and the pagers but not the pane
+/// left the user who set the knob with a half-inverted spyc, the two halves of
+/// one window scrolling opposite ways.
+///
+/// Buttons and drags pass through untouched — there is no direction to invert.
+const fn with_wheel_direction_corrected(mut ev: MouseEvent, invert: bool) -> MouseEvent {
+    if invert {
+        ev.kind = match ev.kind {
+            MouseEventKind::ScrollUp => MouseEventKind::ScrollDown,
+            MouseEventKind::ScrollDown => MouseEventKind::ScrollUp,
+            other => other,
+        };
+    }
+    ev
+}
+
+/// Resolve a mouse event kind to the gesture + wheel delta every downstream
 /// consumer (`ListCursor`, `Pager`, `PaneScrollKeys`) shares. `None` for a kind
 /// with no behaviour (drags, motion, horizontal wheel — see the caller).
 ///
-/// `invert_scroll` (`[mouse] invert_scroll`) flips the sign here, in this ONE
-/// place, so the file list, the pager, and an agent pane's synthesized scroll
-/// keys always agree with each other under either setting — none of them
-/// re-check the config themselves.
-fn gesture_and_delta(
-    kind: MouseEventKind,
-    lines: usize,
-    invert_scroll: bool,
-) -> Option<(Gesture, i32)> {
+/// Direction-agnostic: the kind reaching here has already been through
+/// [`with_wheel_direction_corrected`].
+fn gesture_and_delta(kind: MouseEventKind, lines: usize) -> Option<(Gesture, i32)> {
     let magnitude = i32::try_from(lines).unwrap_or(i32::MAX);
     let (gesture, delta) = match kind {
         MouseEventKind::ScrollUp => (Gesture::Wheel, -magnitude),
@@ -63,7 +80,7 @@ fn gesture_and_delta(
         | MouseEventKind::ScrollLeft
         | MouseEventKind::ScrollRight => return None,
     };
-    Some((gesture, if invert_scroll { -delta } else { delta }))
+    Some((gesture, delta))
 }
 
 /// The surface an in-flight mouse drag belongs to. See
@@ -174,6 +191,10 @@ impl super::App {
         if !crate::mouse_capture_is_on() {
             return Vec::new();
         }
+        // Before anything branches on it — see
+        // [`with_wheel_direction_corrected`]. Every path below, including the one
+        // that hands a report to the child, reads the corrected event.
+        let ev = with_wheel_direction_corrected(ev, self.state.config.mouse.invert_scroll);
         let (cols, rows) = self.view.term_size;
         let frame = ratatui::layout::Rect::new(0, 0, cols, rows);
 
@@ -234,9 +255,8 @@ impl super::App {
         }
 
         let lines = self.state.config.mouse.scroll_lines.max(1);
-        let invert_scroll = self.state.config.mouse.invert_scroll;
         // `delta` is only meaningful for a wheel gesture; buttons ignore it.
-        let Some((gesture, delta)) = gesture_and_delta(ev.kind, lines, invert_scroll) else {
+        let Some((gesture, delta)) = gesture_and_delta(ev.kind, lines) else {
             // Drags, motion, horizontal wheel: no behaviour. spyc asks the terminal
             // only for 1000 (press/release), so `Moved`/`Drag` shouldn't arrive at
             // all — `proc.rs` filters them for the terminals that send them anyway.
@@ -385,54 +405,86 @@ mod tests {
     #[test]
     fn uninverted_keeps_the_documented_sign() {
         assert_eq!(
-            gesture_and_delta(MouseEventKind::ScrollDown, 3, false),
+            gesture_and_delta(MouseEventKind::ScrollDown, 3),
             Some((Gesture::Wheel, 3))
         );
         assert_eq!(
-            gesture_and_delta(MouseEventKind::ScrollUp, 3, false),
+            gesture_and_delta(MouseEventKind::ScrollUp, 3),
             Some((Gesture::Wheel, -3))
         );
     }
 
     /// `invert_scroll = true` flips both directions — the escape hatch for a
-    /// terminal/OS combination that reads backwards from spyc's default.
+    /// terminal/OS combination that reads backwards from spyc's default. Applied
+    /// to the EVENT, at the boundary, so every consumer inherits it including the
+    /// report forwarded to a mouse-aware child.
     #[test]
     fn invert_scroll_flips_both_directions() {
+        let at = |kind| MouseEvent {
+            kind,
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        };
         assert_eq!(
-            gesture_and_delta(MouseEventKind::ScrollDown, 3, true),
+            with_wheel_direction_corrected(at(MouseEventKind::ScrollDown), true).kind,
+            MouseEventKind::ScrollUp
+        );
+        assert_eq!(
+            with_wheel_direction_corrected(at(MouseEventKind::ScrollUp), true).kind,
+            MouseEventKind::ScrollDown
+        );
+        // …and reaches the shared delta through the ordinary path.
+        assert_eq!(
+            gesture_and_delta(
+                with_wheel_direction_corrected(at(MouseEventKind::ScrollDown), true).kind,
+                3
+            ),
             Some((Gesture::Wheel, -3))
         );
+    }
+
+    /// Every consumer (`ListCursor`, `Pager`, `PaneScrollKeys`, and the report
+    /// `PaneForward` hands the child) reads one already-corrected event — the
+    /// toggle is applied at the boundary, once, specifically so they can never
+    /// disagree with each other. This test is the guard against a future edit
+    /// re-introducing a per-consumer flip.
+    #[test]
+    fn the_sign_is_decided_once_for_every_consumer() {
+        let (_, down) = gesture_and_delta(MouseEventKind::ScrollDown, 1).unwrap();
+        let (_, up) = gesture_and_delta(MouseEventKind::ScrollUp, 1).unwrap();
+        assert_eq!(down, -up, "up and down must be exact opposites");
         assert_eq!(
-            gesture_and_delta(MouseEventKind::ScrollUp, 3, true),
-            Some((Gesture::Wheel, 3))
+            gesture_and_delta(MouseEventKind::ScrollUp, 1),
+            gesture_and_delta(MouseEventKind::ScrollUp, 1),
+            "and the function must not consult the config itself"
         );
     }
 
-    /// Every consumer (`ListCursor`, `Pager`, `PaneScrollKeys` in `handle_mouse`)
-    /// reads the SAME delta this function returns — the toggle lives here, once,
-    /// specifically so those three can never disagree with each other. This test
-    /// is the guard against a future edit re-introducing a per-consumer flip.
-    #[test]
-    fn the_sign_is_decided_once_for_every_consumer() {
-        for invert in [false, true] {
-            let (_, down) = gesture_and_delta(MouseEventKind::ScrollDown, 1, invert).unwrap();
-            let (_, up) = gesture_and_delta(MouseEventKind::ScrollUp, 1, invert).unwrap();
-            assert_eq!(
-                down, -up,
-                "invert_scroll={invert}: up and down must be exact opposites"
-            );
-        }
-    }
-
-    /// Buttons carry no delta and are unaffected by the toggle.
+    /// Buttons and drags carry no direction, so the toggle leaves them alone.
     #[test]
     fn button_presses_carry_no_delta_either_way() {
-        for invert in [false, true] {
+        let at = |kind| MouseEvent {
+            kind,
+            column: 0,
+            row: 0,
+            modifiers: crossterm::event::KeyModifiers::NONE,
+        };
+        for kind in [
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Up(MouseButton::Left),
+            MouseEventKind::Drag(MouseButton::Left),
+        ] {
             assert_eq!(
-                gesture_and_delta(MouseEventKind::Down(MouseButton::Left), 5, invert),
-                Some((Gesture::Left, 0))
+                with_wheel_direction_corrected(at(kind), true).kind,
+                kind,
+                "{kind:?} has no direction to invert"
             );
         }
+        assert_eq!(
+            gesture_and_delta(MouseEventKind::Down(MouseButton::Left), 5),
+            Some((Gesture::Left, 0))
+        );
     }
 
     /// Drags, motion, and horizontal wheel have no behaviour — matches the
@@ -446,7 +498,7 @@ mod tests {
             MouseEventKind::ScrollRight,
             MouseEventKind::Up(MouseButton::Left),
         ] {
-            assert_eq!(gesture_and_delta(kind, 1, false), None, "{kind:?}");
+            assert_eq!(gesture_and_delta(kind, 1), None, "{kind:?}");
         }
     }
 
@@ -455,7 +507,7 @@ mod tests {
     #[test]
     fn lines_scales_the_magnitude() {
         assert_eq!(
-            gesture_and_delta(MouseEventKind::ScrollDown, 7, false),
+            gesture_and_delta(MouseEventKind::ScrollDown, 7),
             Some((Gesture::Wheel, 7))
         );
     }

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -151,8 +151,8 @@
 # further into the content — the "scroll down = toward the end" mapping
 # shared by browsers and `less`. Set true if that reads backwards on your
 # OS/terminal combination (which direction is "natural" depends on both).
-# Applies uniformly to the file list, the pager, and an agent pane's
-# synthesized scroll keys — they always agree with each other either way.
+# Applies uniformly: the file list, the pager, an agent pane's synthesized
+# scroll keys, and the wheel report forwarded to a mouse-aware child.
 # invert_scroll = false
 
 # ── markdown ──────────────────────────────────────────────────────────

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -380,9 +380,10 @@ pub struct MouseConfig {
     /// Named for the mechanism, not for a convention: which direction counts
     /// as "natural" depends on the OS trackpad setting and the terminal, so a
     /// `natural_scroll` flag would be ambiguous in exactly the cases a user
-    /// reaches for it. Applied once, where the wheel delta is computed
-    /// (`src/app/mouse/mod.rs`), so the file list, the pager, and an agent
-    /// pane's synthesized scroll keys always agree with each other.
+    /// reaches for it. Applied once, to the event itself, at `handle_mouse`'s
+    /// boundary (`src/app/mouse/mod.rs`) — so the file list, the pager, an agent
+    /// pane's synthesized scroll keys and the report forwarded to a mouse-aware
+    /// child all agree with each other.
     pub invert_scroll: bool,
 }
 


### PR DESCRIPTION
**M9** of the pre-2.1 review (`B-app-interaction.md`, finding 3) — `medium`.

`[mouse] invert_scroll` was applied inside `gesture_and_delta`, which
`MouseSink::PaneForward` / `FocusAndForward` never call — they go through
`mouse_report`, which maps the raw event kind:

```rust
MouseEventKind::ScrollUp   => (64, false, false),
MouseEventKind::ScrollDown => (65, false, false),
```

So with the knob set, the file list, the pagers and agy's synthesized keys
inverted while claude / vim / htop scrolled the original direction. The user who
reaches for this setting is by definition the one whose wheel reads backwards,
and what they got was a spyc inverted on one half of the window and not the
other — worse than either setting, and on the primary dog-fooding surface.

`CONFIGURATION.md:295` — the inline TOML comment people copy — already claimed
`# true flips the wheel direction everywhere`.

## Which of the two contracts

The finding offered either: make the claim true, or narrow the doc to the prose
(which honestly named three surfaces). Making it true, because the knob is not a
per-surface preference — it says *this machine reports the wheel the opposite way
round from what I mean*, which is a fact about the input. A window that scrolls
two ways at once isn't a defensible setting.

## Where the flip moved

To the event, at `handle_mouse`'s boundary, before anything branches on it —
`with_wheel_direction_corrected`. Not a second flip inside `mouse_report`:
`gesture_and_delta`'s own doc comment already warned that the toggle lives in ONE
place so consumers can't disagree, and adding a second config-reading site would
have been the same mistake one consumer further along. Correcting the input
instead means `gesture_and_delta` loses the parameter entirely and every
downstream reader — including the one that hands bytes to the child — sees a
wheel that means what it says.

Buttons and drags pass through untouched; there is no direction to invert.

## Test

`inverting_the_wheel_inverts_what_the_child_receives` drives `handle_mouse`
against a pane made mouse-aware the real way (the DEC mode written to `cat`'s
stdin, echoed back through the pty) and asserts an **equivalence** rather than a
button number: an inverted wheel-up must reach the child as the bytes an
uninverted wheel-*down* produces, and vice versa. It first asserts the two
directions differ at all, so it can't pass on a build where forwarding is broken
in both.

Before: `left: [27, 91, 77, 96, …]` (button 64, wheel up) against
`right: [27, 91, 77, 97, …]` (65, wheel down).

**Bite-checked by restoring the shipped design** — the per-consumer flip back
inside the delta, no boundary correction — which is the point of the finding
rather than a detail of it: **106 of 107 mouse tests still pass**, every existing
list/pager/delta assertion among them, and only this one reports. Same shape as
H9.

Docs in the same commit: the `CONFIGURATION.md` prose, the `default.spycrc.toml`
comment and the `MouseConfig::invert_scroll` field doc all named three surfaces;
they now name four and say where the flip happens. The inline TOML comment
claiming "everywhere" needed no change — it is now true.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)