### PR TITLE
fix(pane): the scrollback snapshot settles on the loop, not in a 30 ms sleep

### DIFF
--- a/docs/drafts/native_scroll_plan.md
+++ b/docs/drafts/native_scroll_plan.md
@@ -507,6 +507,15 @@ branch (a 4 MB tail-read + per-line parse + markdown render), and the vt100 bran
 stalls the loop `3 × 10 ms` per mount — at ~30 ticks/s that's a hang. The wheel
 must never mount anything.
 
+> **Amended (2026-08-11).** Both stalls this paragraph names are gone, and the
+> wheel does mount — under `[mouse] pane_scroll_view = "spyc_history"`, gated on
+> three consecutive up-ticks. The transcript branch reads and renders off-thread
+> (`spawn_pager_stream`); the vt100 branch's settle is a `Deadline`, waited out
+> on the loop instead of slept through. What the paragraph was really asserting
+> — *the wheel must not block the loop* — still holds, and is now pinned by
+> `opening_the_scrollback_pager_does_not_sleep_on_the_loop`. The rejection of
+> mounting *itself* was a consequence of the stalls, not a separate rule.
+
 ### Deferred: wheel-burst coalescing
 
 Summing same-direction wheel events before applying them. Two reasons this is no

--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -289,6 +289,7 @@ impl App {
                 next_sink_id: 0,
                 autosave_last_saved_fp: None,
                 autosave_due: None,
+                pane_scroll_settle: None,
                 hook_recheck_at: None,
                 scope_waiters: Vec::new(),
                 lua: None,

--- a/src/app/harness_tests/pane.rs
+++ b/src/app/harness_tests/pane.rs
@@ -247,6 +247,14 @@ fn empty_scrollback_flashes_hint_and_stays_live() {
         let mut app = App::test_app(dir);
         app.open_pane_tab("cat"); // fresh cat: no output → empty scrollback
         app.open_pane_scroll_pager();
+        // The snapshot is deferred by `SCROLL_SETTLE` so the wait happens on the
+        // event loop rather than in a sleep; `settle_pane_scroll` is what calls
+        // this when the window elapses.
+        assert!(
+            app.runtime.pane_scroll_settle.is_some(),
+            "opening arms the settle rather than snapshotting inline"
+        );
+        app.mount_vt100_scrollback();
         assert_eq!(
             app.flash_text(),
             Some("no terminal scrollback captured"),
@@ -279,6 +287,7 @@ fn empty_scrollback_agent_pane_points_to_transcript() {
             crate::pane::tabs::TabEntry::new(pane, crate::pane::tabs::TabInfo::new("claude", dir));
         app.runtime.pane_tabs = Some(crate::pane::tabs::PaneTabs::new(entry));
         app.open_pane_scroll_pager();
+        app.mount_vt100_scrollback();
         assert_eq!(
             app.flash_text(),
             Some(
@@ -1022,6 +1031,38 @@ fn closing_help_over_a_v_editor_keeps_the_editor_column_pinned() {
             app.view.overlay_column,
             Some(state::Side::Left),
             "the still-open V editor must stay pinned to its column after help closes",
+        );
+    });
+}
+
+/// **A wheel tick must not stall the event loop.**
+///
+/// With `[mouse] pane_scroll_view = "spyc_history"` a qualifying wheel gesture
+/// mounts spyc's own scrollback pager. The vt100 branch used to settle the pty
+/// by sleeping — `3 × 10 ms` inline — so an input event cost 30 ms of dead loop,
+/// re-paid on the next qualifying tick whenever scrollback turned out empty and
+/// nothing mounted. `docs/drafts/native_scroll_plan.md` ruled exactly this out
+/// ("the wheel must never mount anything ... at ~30 ticks/s that's a hang").
+///
+/// Measured rather than asserted structurally: a test that checked for the
+/// absence of a `sleep` call would pass the moment the sleep moved one function
+/// along. What matters is that the call returns promptly.
+#[test]
+fn opening_the_scrollback_pager_does_not_sleep_on_the_loop() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        let dir = tmp.path().join("work");
+        std::fs::create_dir(&dir).unwrap();
+        let mut app = App::test_app(dir);
+        app.open_pane_tab("cat");
+
+        let started = std::time::Instant::now();
+        app.open_pane_scroll_pager();
+        let spent = started.elapsed();
+
+        assert!(
+            spent < std::time::Duration::from_millis(10),
+            "the input path must not block: {spent:?}"
         );
     });
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -518,6 +518,14 @@ struct Runtime {
     /// only while a change awaits its save; cleared on save / when clean. An
     /// OS-ish clock value, correctly in `Runtime` (never the pure Model).
     autosave_due: Option<std::time::Instant>,
+    /// A deferred vt100 scrollback snapshot: when to take it, and which tab
+    /// asked for it. `Some` only between `open_pane_scroll_pager` arming the
+    /// settle and `settle_pane_scroll` taking the shot, so idle stays 0 dps.
+    ///
+    /// The tab index is part of it because the settle window is real time the
+    /// user can act in — switching tabs mid-window must abandon the snapshot
+    /// rather than mount a different pane's history.
+    pane_scroll_settle: Option<(std::time::Instant, usize)>,
     /// When the agent status-hook drift check may next run
     /// (`settle_status_hooks`). A throttle, not a deadline — nothing wakes the
     /// loop for it, so idle stays 0 dps. `None` = due now (startup).

--- a/src/app/pane_scroll.rs
+++ b/src/app/pane_scroll.rs
@@ -12,6 +12,16 @@ use super::pager_stream::{DrainOutcome, PagerStream, PagerStreamMount, RenderCtx
 use super::{App, Effect, PaneTextKind, PaneTextSink, state};
 use crate::ui::pager::PagerView;
 
+/// How long the vt100 scrollback snapshot waits for in-flight pty bytes to
+/// land before taking it.
+///
+/// Spent on the event loop (a `Deadline`), never in a sleep: this is reachable
+/// from a wheel tick, and `docs/drafts/native_scroll_plan.md` rules out
+/// blocking the loop from one ("at ~30 ticks/s that's a hang"). The loop drains
+/// pane output every iteration anyway, so waiting *on* it is also the more
+/// thorough settle — the old sleep only yielded the thread.
+pub(super) const SCROLL_SETTLE: std::time::Duration = std::time::Duration::from_millis(30);
+
 /// Inputs to the pure `^a v` scrollback-source decision.
 #[derive(Clone, Copy)]
 struct ScrollSnapshot {
@@ -46,6 +56,42 @@ const fn decide_scroll_source(s: ScrollSnapshot) -> ScrollSource {
         ScrollSource::AltScreenDeadEnd
     } else {
         ScrollSource::Vt100
+    }
+}
+
+/// What to do with a pending deferred scrollback snapshot this loop pass.
+#[derive(Debug, PartialEq, Eq)]
+enum ScrollSettle {
+    /// Nothing pending — stay disarmed.
+    Idle,
+    /// The settle window hasn't elapsed; keep the deadline armed at this instant.
+    Wait(std::time::Instant),
+    /// Take the snapshot now.
+    Take,
+    /// The tab that asked is no longer active — drop it. The window is real time
+    /// the user can act in, and mounting a different pane's history would answer
+    /// a question they didn't ask.
+    Abandon,
+}
+
+/// Pure decision for [`App::settle_pane_scroll`] (the `route.rs` / `focus.rs`
+/// template). `active_tab` is `None` when the pane closed under the pending
+/// snapshot, which is an abandon for the same reason a tab switch is.
+fn decide_scroll_settle(
+    pending: Option<(std::time::Instant, usize)>,
+    now: std::time::Instant,
+    active_tab: Option<usize>,
+) -> ScrollSettle {
+    let Some((due, tab)) = pending else {
+        return ScrollSettle::Idle;
+    };
+    if now < due {
+        return ScrollSettle::Wait(due);
+    }
+    if active_tab == Some(tab) {
+        ScrollSettle::Take
+    } else {
+        ScrollSettle::Abandon
     }
 }
 
@@ -258,22 +304,80 @@ impl App {
         }
 
         // vt100 terminal-scrollback path: not an alt-screen app and no engaged
-        // transcript, so snapshot the pane's own scrollback buffer.
+        // transcript, so snapshot the pane's own scrollback buffer — but not
+        // yet. Bytes that reached the OS pipe just before this event may still
+        // be in flight on the reader/parser threads, and the snapshot should
+        // include the most-recent paint. That settle used to be three inline
+        // 10 ms sleeps: 30 ms of dead event loop per invocation, and this is
+        // reachable from a WHEEL TICK (`[mouse] pane_scroll_view =
+        // "spyc_history"`) — re-paid on the next tick whenever scrollback turns
+        // out empty and nothing mounts. So arm a deadline instead and let the
+        // loop keep running; its own per-iteration drain does the flushing,
+        // and `settle_pane_scroll` snapshots when the window elapses.
         let tabs = self
             .runtime
             .pane_tabs
-            .as_mut()
+            .as_ref()
             .expect("pane_tabs presence checked above");
-        let active = tabs.active_mut();
-        // Drain pending bytes before snapshotting. Bytes that hit
-        // the OS pipe between the last render tick and this keypress
-        // may still be in flight on the reader/parser threads; a few
-        // short yields let them flush so the snapshot includes the
-        // most-recent paint.
-        for _ in 0..3 {
-            active.drain_output();
-            std::thread::sleep(std::time::Duration::from_millis(10));
+        self.runtime.pane_scroll_settle = Some((
+            std::time::Instant::now() + SCROLL_SETTLE,
+            tabs.active_index(),
+        ));
+    }
+
+    /// PRE-recv settle for a deferred vt100 scrollback snapshot.
+    ///
+    /// Takes the shot once `SCROLL_SETTLE` has elapsed, then disarms — and
+    /// abandons it if the user switched tabs in the meantime, since the window
+    /// is real time they can act in and mounting another pane's history would
+    /// answer a question they didn't ask. Returns whether the frame changed.
+    pub(crate) fn settle_pane_scroll(
+        &mut self,
+        now: std::time::Instant,
+        ctx: &mut super::RunCtx,
+    ) -> bool {
+        use super::scheduler::Deadline;
+        let active_tab = self
+            .runtime
+            .pane_tabs
+            .as_ref()
+            .map(crate::pane::tabs::PaneTabs::active_index);
+        match decide_scroll_settle(self.runtime.pane_scroll_settle, now, active_tab) {
+            ScrollSettle::Idle => {
+                ctx.scheduler.disarm(Deadline::PaneScrollSettle);
+                false
+            }
+            ScrollSettle::Wait(due) => {
+                ctx.scheduler.arm(Deadline::PaneScrollSettle, due);
+                false
+            }
+            ScrollSettle::Abandon => {
+                self.runtime.pane_scroll_settle = None;
+                ctx.scheduler.disarm(Deadline::PaneScrollSettle);
+                false
+            }
+            ScrollSettle::Take => {
+                self.runtime.pane_scroll_settle = None;
+                ctx.scheduler.disarm(Deadline::PaneScrollSettle);
+                self.mount_vt100_scrollback();
+                true
+            }
         }
+    }
+
+    /// Snapshot the active pane's vt100 scrollback and mount it, or say why it
+    /// can't be. The tail of [`Self::open_pane_scroll_pager`]'s vt100 branch,
+    /// split off so the settle window can elapse on the loop rather than in a
+    /// sleep. Callable on its own — that is what the harness drives.
+    pub(crate) fn mount_vt100_scrollback(&mut self) {
+        let Some(tabs) = self.runtime.pane_tabs.as_mut() else {
+            return;
+        };
+        let label = tabs.active_info().label.clone();
+        let command = tabs.active_info().command.clone();
+        let profile = crate::agent::detect(&command);
+        let spec = profile.transcript();
+        let active = tabs.active_mut();
         active.drain_output();
         // Empty scrollback ⇒ a fresh/short process, or an inline agent whose
         // structured transcript is toggled off (an agent with its transcript
@@ -618,5 +722,46 @@ mod tests {
             decide_scroll_source(snap(false, false, false)),
             ScrollSource::Vt100
         );
+    }
+}
+
+#[cfg(test)]
+mod settle_tests {
+    use super::{ScrollSettle, decide_scroll_settle};
+    use std::time::{Duration, Instant};
+
+    /// The window is real time the user can act in, so the decision has to hold
+    /// the tab that asked — not just an instant.
+    #[test]
+    fn a_snapshot_waits_then_fires_for_the_tab_that_asked() {
+        let now = Instant::now();
+        let due = now + Duration::from_millis(30);
+
+        assert_eq!(decide_scroll_settle(None, now, Some(0)), ScrollSettle::Idle);
+        assert_eq!(
+            decide_scroll_settle(Some((due, 0)), now, Some(0)),
+            ScrollSettle::Wait(due),
+            "before the window elapses, keep waiting on the loop"
+        );
+        assert_eq!(
+            decide_scroll_settle(Some((due, 0)), due, Some(0)),
+            ScrollSettle::Take
+        );
+    }
+
+    /// Switching tabs — or closing the pane — inside the settle window drops the
+    /// snapshot. Mounting tab 0's history into tab 1 would answer a question the
+    /// user didn't ask, and they had 30 ms of real time in which to move.
+    #[test]
+    fn moving_away_inside_the_window_abandons_the_snapshot() {
+        let now = Instant::now();
+        let due = now + Duration::from_millis(30);
+        for active in [Some(1), None] {
+            assert_eq!(
+                decide_scroll_settle(Some((due, 0)), due, active),
+                ScrollSettle::Abandon,
+                "active tab {active:?}"
+            );
+        }
     }
 }

--- a/src/app/run.rs
+++ b/src/app/run.rs
@@ -738,6 +738,15 @@ impl App {
                 ctx.draw.mark(3);
             }
 
+            // A deferred vt100 scrollback snapshot: take it once the settle
+            // window has elapsed. Armed only between `^a v` (or a
+            // `spyc_history` wheel gesture) and the shot, so idle stays 0 dps —
+            // and the wait happens on the loop instead of in a sleep, which is
+            // what keeps a wheel tick from stalling it.
+            if self.settle_pane_scroll(now_pre, &mut ctx) {
+                ctx.draw.mark(3);
+            }
+
             // P3-2 crash-sufficient autosave: debounce a session save after any
             // session-relevant change (tab/cwd/vsplit/project-home/geometry),
             // firing ~AUTOSAVE_DEBOUNCE after the last change so a SIGKILL loses

--- a/src/app/scheduler.rs
+++ b/src/app/scheduler.rs
@@ -80,6 +80,12 @@ pub enum Deadline {
     /// Re-armed on output; disarmed when scan fires or no dirty tab remains.
     /// PRE-recv (`settle_scrape_quiet`).
     ScrapeQuiet,
+    /// Deferred vt100 scrollback snapshot: wake `SCROLL_SETTLE` after `^a v`
+    /// (or a `spyc_history` wheel gesture) so in-flight pty bytes land before
+    /// the snapshot. Replaces three inline 10 ms sleeps that stalled the loop
+    /// from an input event. Armed only while a snapshot is pending. PRE-recv
+    /// (`settle_pane_scroll`).
+    PaneScrollSettle,
     /// P2 `wait_for_scope_clear`: wake at the earliest parked scope-waiter's
     /// deadline so a timeout fires with no other activity. Armed only while a
     /// waiter is parked, disarmed when none remain — idle stays 0 dps. PRE-recv

--- a/src/app/test_harness.rs
+++ b/src/app/test_harness.rs
@@ -38,6 +38,7 @@ impl App {
                 next_sink_id: 0,
                 autosave_last_saved_fp: None,
                 autosave_due: None,
+                pane_scroll_settle: None,
                 hook_recheck_at: None,
                 scope_waiters: Vec::new(),
                 lua: None,


### PR DESCRIPTION
**M10** of the pre-2.1 review (`B-app-interaction.md`, finding 4) — `medium`.

`open_pane_scroll_pager`'s vt100 branch settled the pty by sleeping, inline:

```rust
for _ in 0..3 { active.drain_output(); std::thread::sleep(Duration::from_millis(10)); }
```

30 ms of dead event loop per call — and this is reachable from a **wheel tick**.
With `[mouse] pane_scroll_view = "spyc_history"` a qualifying gesture returns
`AgentViewAction::UseSpycHistory`, which calls it straight from the wheel
handler. If scrollback turns out empty it flashes and mounts nothing, so the
next qualifying tick pays it again — and the `!is_open` gate doesn't help, since
`is_open` scrapes for the *agent's* marker, which mounting spyc's own pager never
sets.

`docs/drafts/native_scroll_plan.md:504-508` ruled this out in writing: *"the
vt100 branch stalls the loop 3 × 10 ms per mount — at ~30 ticks/s that's a hang.
The wheel must never mount anything."*

## What changed

The settle became a `Deadline`. `open_pane_scroll_pager` arms
`runtime.pane_scroll_settle` and returns; `settle_pane_scroll` (PRE-recv) takes
the snapshot when `SCROLL_SETTLE` elapses.

This preserves the settle's purpose rather than dropping it. The 30 ms is still
real time before the snapshot — but spent on a loop that keeps running, and
the loop drains pane output every iteration, so waiting *on* it is a more
thorough flush than the sleep's thread yields ever were.

Not the alternative the finding also offered (gate `UseSpycHistory` on the
transcript branch only): that would make `pane_scroll_view = "spyc_history"` a
setting that silently doesn't apply to the case it names.

## The window is time the user can act in

30 ms is enough to switch tabs, and mounting tab 0's history into tab 1 answers a
question nobody asked — so the pending snapshot carries the tab that asked for
it, and a switch (or the pane closing) abandons it. That's the pure decision
`decide_scroll_settle`, extracted and unit-tested per the `route.rs` template,
because `RunCtx` isn't constructible from a test and the guard is worth pinning
on its own.

## Tests

- `opening_the_scrollback_pager_does_not_sleep_on_the_loop` — **measured**, not
  structural: a test asserting the absence of a `sleep` call would pass the
  moment the sleep moved one function along. Before: `35.48 ms`. Bite-checked by
  putting the sleep back: `36.04 ms`.
- `a_snapshot_waits_then_fires_for_the_tab_that_asked` and
  `moving_away_inside_the_window_abandons_the_snapshot` cover the decision,
  including the pane closing under a pending snapshot.
- The two existing empty-scrollback tests now assert the deferral happened
  (`pane_scroll_settle.is_some()`) before driving `mount_vt100_scrollback`, so
  they document the new shape instead of merely tolerating it.

Left alone deliberately: `:dump-scrollback` (`pane_tabs.rs`) has the same three
sleeps. It is a one-shot diagnostic command, not an input-rate path, and the
finding doesn't name it — 30 ms on an explicit `:` command is not the same
defect.

## Plan amended

`native_scroll_plan.md` gets the note it never got (finding 5's shape, though
that finding is about the button bindings and stays open): both stalls the
paragraph names are gone — the transcript branch reads off-thread, the vt100
branch's settle is now a deadline — and what it was really asserting, *the wheel
must not block the loop*, is now pinned by a test rather than by a prohibition.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)