### PR TITLE
fix(clipboard): a yank stops waiting out the helper on the event loop

### DIFF
--- a/src/app/bootstrap.rs
+++ b/src/app/bootstrap.rs
@@ -324,6 +324,7 @@ impl App {
                 archive_mount_then: None,
                 file_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 clipboard_paste_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                clipboard_copy_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 listing_refresh_inflight: false,
                 listing_refresh_dirty: false,
                 inventory_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),

--- a/src/app/clipboard.rs
+++ b/src/app/clipboard.rs
@@ -432,12 +432,26 @@ impl super::App {
     /// `[clipboard].command` / `$SPYC_CLIPBOARD` is an exclusive top-priority tier,
     /// not one more mechanism to also try: when set, it's the ONLY thing run —
     /// `via`/OSC-52 are skipped entirely rather than layered underneath.
+    ///
+    /// **Anything that spawns a helper is dispatched, not awaited.** `xclip` and
+    /// `xsel` legitimately stay alive after a successful copy — that is how they
+    /// serve the X11 selection — so `try_wait` never answers and the reap poll
+    /// spends its entire budget. Awaiting that put 150 ms of fully blocked event
+    /// loop on *every single yank* on the platform where most non-macOS users
+    /// are. So the helper runs on a worker (`spawn_clipboard_write`) and this
+    /// returns as soon as the payload is on its way; a failure arrives later and
+    /// `apply_clipboard_writes` flashes it, replacing the confirmation.
+    ///
+    /// OSC 52 stays inline — it is a write to spyc's own stdout, not a spawn.
     pub(super) fn deliver_clipboard(&self, text: &str) -> Result<(), String> {
         if let Some(cmd) =
             crate::clipboard::resolve_override(self.state.config.clipboard.command.as_deref())
         {
-            return crate::clipboard::copy_via_user_command(&cmd, text)
-                .map_err(|e| format!("{e:#}"));
+            let text = text.to_string();
+            self.spawn_clipboard_write(move || {
+                crate::clipboard::copy_via_user_command(&cmd, &text).map_err(|e| format!("{e:#}"))
+            });
+            return Ok(());
         }
         let (local, osc52) = clipboard_delivery(self.state.config.clipboard.via, self.view.is_ssh);
         let mut errs: Vec<String> = Vec::new();
@@ -449,10 +463,17 @@ impl super::App {
             }
         }
         if local {
-            match crate::clipboard::copy(text) {
-                Ok(()) => ok = true,
-                Err(e) => errs.push(format!("{e:#}")),
-            }
+            // Whether OSC 52 already delivered it decides whether a later helper
+            // failure is worth interrupting the user for: with `Both`, the text
+            // IS on their clipboard, and the local helper failing is spyc's
+            // problem rather than theirs.
+            let already = ok;
+            let text = text.to_string();
+            self.spawn_clipboard_write(move || match crate::clipboard::copy(&text) {
+                Err(e) if !already => Err(format!("{e:#}")),
+                _ => Ok(()),
+            });
+            ok = true;
         }
         if ok {
             return Ok(());
@@ -462,6 +483,50 @@ impl super::App {
         } else {
             errs.join("; ")
         })
+    }
+
+    /// Run a clipboard write on a detached worker (the `graveyard_ops`
+    /// template), landing its outcome on `runtime.clipboard_copy_results` and
+    /// waking the loop.
+    ///
+    /// `pane_wake_tx` is `None` only before `run()` / in the test harness, where
+    /// there is no loop to wake — the outcome still lands in the slot.
+    fn spawn_clipboard_write(&self, write: impl FnOnce() -> Result<(), String> + Send + 'static) {
+        let results = std::sync::Arc::clone(&self.runtime.clipboard_copy_results);
+        let wake = self.runtime.pane_wake_tx.clone();
+        std::thread::spawn(move || {
+            let outcome = write().err();
+            results
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(outcome);
+            if let Some(tx) = wake {
+                let _ = tx.send(Message::ClipboardCopyDone);
+            }
+        });
+    }
+
+    /// Drain every landed clipboard write and flash whichever failed. Called
+    /// each pre-recv scan, so the slot is always emptied whichever wake survived
+    /// coalescing. Returns whether the frame is dirty.
+    ///
+    /// A failure arrives *after* the verb already flashed its confirmation, so it
+    /// replaces one — which is the right way round: the last thing on screen is
+    /// what actually happened.
+    pub(crate) fn apply_clipboard_writes(&mut self) -> bool {
+        let landed: Vec<Option<String>> = std::mem::take(
+            &mut *self
+                .runtime
+                .clipboard_copy_results
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
+        let mut dirty = false;
+        for err in landed.into_iter().flatten() {
+            self.state.flash_error(format!("clipboard: {err}"));
+            dirty = true;
+        }
+        dirty
     }
 
     /// Kick the middle-click clipboard read onto a detached worker
@@ -669,6 +734,128 @@ mod paste_tests {
                     std::thread::sleep(Duration::from_millis(10));
                 }
                 assert!(app.apply_clipboard_pastes().0);
+            });
+        });
+    }
+}
+
+#[cfg(test)]
+mod copy_tests {
+    use super::App;
+    use std::time::{Duration, Instant};
+
+    /// A helper that reads the payload and then keeps running, the way
+    /// `xclip`/`xsel` do to serve the X11 selection until another app claims it.
+    #[cfg(unix)]
+    fn persisting_helper(dir: &std::path::Path) -> std::path::PathBuf {
+        use std::os::unix::fs::PermissionsExt;
+        let stub = dir.join("stub-persist.sh");
+        std::fs::write(&stub, "#!/bin/sh\ncat > /dev/null\nsleep 10\n").expect("write stub");
+        let mut perms = std::fs::metadata(&stub).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&stub, perms).unwrap();
+        stub
+    }
+
+    /// **A write that fails still reaches the user, after the fact.**
+    ///
+    /// Dispatching instead of awaiting means the verb's "yanked" flash goes up
+    /// before the outcome is known. That is only honest if a failure arrives and
+    /// **replaces** it — otherwise this trades a 150 ms hitch for a silent
+    /// wrong answer, which is the defect #350 closed.
+    #[cfg(unix)]
+    #[test]
+    fn a_failed_write_flashes_its_reason_after_the_confirmation() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        crate::state::with_state_root(tmp.path(), || {
+            let stub = tmp.path().join("stub-fail.sh");
+            std::fs::write(&stub, "#!/bin/sh\ncat > /dev/null\nexit 3\n").expect("write stub");
+            let mut perms = std::fs::metadata(&stub).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&stub, perms).unwrap();
+
+            let mut app = App::test_app(tmp.path().to_path_buf());
+            crate::clipboard::with_reap_budget(Duration::from_secs(10), || {
+                crate::clipboard::with_clipboard_override(&stub, || {
+                    app.deliver_clipboard("hello")
+                        .expect("dispatch reports no error of its own");
+                    // The verb's own confirmation is already on screen at this
+                    // point; production flashes it from `run_effects`.
+                    app.state.flash_info("yanked 1 line");
+
+                    let deadline = Instant::now() + Duration::from_secs(20);
+                    while Instant::now() < deadline {
+                        if app.apply_clipboard_writes() {
+                            let flash = app.flash_text().unwrap_or_default().to_string();
+                            assert!(
+                                flash.contains("clipboard:") && flash.contains("exited"),
+                                "the failure must replace the confirmation, got {flash:?}"
+                            );
+                            return;
+                        }
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                    panic!("a failed clipboard write never surfaced");
+                });
+            });
+        });
+    }
+
+    /// **A yank must not stall the loop while a helper persists.**
+    ///
+    /// `xclip`/`xsel` legitimately stay alive after a successful copy, so
+    /// `try_wait` never answers and the reap poll runs its whole budget — 150 ms
+    /// of fully blocked event loop on *every single yank*, which on Linux is the
+    /// common case rather than an edge one. `HELPER_REAP_BUDGET`'s own comment
+    /// says the fix is moving the write off-thread.
+    ///
+    /// Measured, not structural: what matters is that dispatching a yank returns
+    /// promptly, wherever the waiting ends up living.
+    #[cfg(unix)]
+    #[test]
+    fn a_yank_does_not_wait_out_a_persisting_helper_on_the_loop() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        crate::state::with_state_root(tmp.path(), || {
+            let stub = persisting_helper(tmp.path());
+            let app = App::test_app(tmp.path().to_path_buf());
+
+            crate::clipboard::with_reap_budget(Duration::from_millis(150), || {
+                crate::clipboard::with_clipboard_override(&stub, || {
+                    let start = Instant::now();
+                    app.deliver_clipboard("hello")
+                        .expect("the yank is accepted");
+                    let spent = start.elapsed();
+                    assert!(
+                        spent < Duration::from_millis(50),
+                        "the yank blocked the loop for {spent:?}"
+                    );
+
+                    // …and the write still really happens, reported from wherever
+                    // it ran. A dispatch that returns fast by doing nothing would
+                    // pass the assertion above.
+                    let deadline = Instant::now() + Duration::from_secs(20);
+                    loop {
+                        let landed = app
+                            .runtime
+                            .clipboard_copy_results
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .pop();
+                        if let Some(outcome) = landed {
+                            assert_eq!(
+                                outcome, None,
+                                "a helper that read the payload and persisted is a success"
+                            );
+                            return;
+                        }
+                        assert!(
+                            Instant::now() < deadline,
+                            "the clipboard write never reported back"
+                        );
+                        std::thread::sleep(Duration::from_millis(10));
+                    }
+                });
             });
         });
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -145,6 +145,11 @@ enum Message {
     /// wake of the same shape as `GraveyardDone`; `apply_clipboard_pastes`
     /// drains the slot in the pre-recv scan and feeds the text to `handle_paste`.
     ClipboardPasteDone,
+    /// An off-thread clipboard *write* finished and pushed its outcome onto
+    /// `runtime.clipboard_copy_results`. Payloadless, same shape as
+    /// `ClipboardPasteDone`; `apply_clipboard_writes` drains the slot in the
+    /// pre-recv scan and flashes anything that failed.
+    ClipboardCopyDone,
     /// An off-thread inventory op (`Effect::Inventory`) finished.
     InventoryDone,
     /// An off-thread MCP worktree op (create/remove/clean) finished and pushed
@@ -655,6 +660,13 @@ struct Runtime {
     /// drains it each pre-recv scan. A `Vec`, like `graveyard_results`: a middle
     /// click is cheap to repeat, so reads can overlap and must not clobber.
     clipboard_paste_results: std::sync::Arc<std::sync::Mutex<Vec<std::io::Result<String>>>>,
+    /// Landing slot for off-thread clipboard *writes*. One entry per dispatched
+    /// write: `None` succeeded, `Some(msg)` is what to flash.
+    ///
+    /// The write runs off the loop because the helpers legitimately outlive it —
+    /// `xclip`/`xsel` keep running to serve the X11 selection, so the reap poll
+    /// spends its whole budget on every yank. A `Vec` because yanks can overlap.
+    clipboard_copy_results: std::sync::Arc<std::sync::Mutex<Vec<Option<String>>>>,
     /// The watcher-driven listing refresh (`FileOp::RefreshListing`) reads the
     /// dir off-thread; `inflight` keeps a single read in flight at a time, and
     /// `dirty` records a refresh requested while one was running so the result

--- a/src/app/run.rs
+++ b/src/app/run.rs
@@ -267,6 +267,7 @@ impl App {
                 | Message::ArchiveDone
                 | Message::FileOpDone
                 | Message::ClipboardPasteDone
+                | Message::ClipboardCopyDone
                 | Message::InventoryDone
                 | Message::PreviewReloadDone
                 | Message::WorktreeJobDone
@@ -596,6 +597,12 @@ impl App {
             // A middle-click clipboard read that landed (woke us via
             // `Message::ClipboardPasteDone`). Routing runs here, against the
             // focus of *now* — see `apply_clipboard_pastes`.
+            // A clipboard write that landed (woke us via
+            // `Message::ClipboardCopyDone`). Only failures have anything to say.
+            if self.apply_clipboard_writes() {
+                ctx.draw.mark(3);
+            }
+
             let (paste_draw, paste_fx) = self.apply_clipboard_pastes();
             if paste_draw {
                 ctx.draw.mark(3);

--- a/src/app/sources.rs
+++ b/src/app/sources.rs
@@ -91,6 +91,9 @@ pub fn coalesce_pending(
             // rides `runtime.clipboard_paste_results`, drained by
             // `apply_clipboard_pastes` in the pre-recv scan.
             | Message::ClipboardPasteDone
+            // Clipboard write done — the outcome rides
+            // `runtime.clipboard_copy_results`, drained by `apply_clipboard_writes`.
+            | Message::ClipboardCopyDone
             | Message::InventoryDone
             | Message::Tick(_) => {}
             Message::Input(ev) => return Some(ev),

--- a/src/app/test_harness.rs
+++ b/src/app/test_harness.rs
@@ -75,6 +75,7 @@ impl App {
                 preview_results: std::sync::Arc::new(std::sync::Mutex::new(None)),
                 file_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 clipboard_paste_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+                clipboard_copy_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
                 listing_refresh_inflight: false,
                 listing_refresh_dirty: false,
                 inventory_results: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -17,15 +17,20 @@ use std::io::{self, Read, Write};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
+/// Test-only override: when set, `copy` spawns this binary instead of resolving
+/// a platform clipboard helper, so unit tests can inject a stub without mutating
+/// process-global env vars.
+///
+/// Process-global rather than a thread-local, and for the same reason
+/// [`PASTE_STUB`] is: the write it stands in for runs on a **worker thread**,
+/// which is exactly the property under test. A thread-local cannot reach there.
 #[cfg(test)]
-thread_local! {
-    /// Test-only override: when set, `copy` spawns this binary
-    /// instead of resolving a platform clipboard helper. Lets unit
-    /// tests inject a stub without mutating process-global env vars
-    /// (the same trick `with_state_root` uses in `src/state/mod.rs`).
-    static CLIPBOARD_OVERRIDE: std::cell::RefCell<Option<std::path::PathBuf>> =
-        const { std::cell::RefCell::new(None) };
-}
+static CLIPBOARD_OVERRIDE: std::sync::RwLock<Option<std::path::PathBuf>> =
+    std::sync::RwLock::new(None);
+
+/// Serializes clipboard-stub installation, so two tests can't read each other's.
+#[cfg(test)]
+static CLIPBOARD_OVERRIDE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Test-only stand-in for the clipboard: `paste` sleeps `delay`, then returns
 /// `text` instead of spawning a helper. `delay` is what lets a test watch the
@@ -81,27 +86,41 @@ pub fn with_paste_override<R>(text: &str, body: impl FnOnce() -> R) -> R {
 }
 
 #[cfg(test)]
-thread_local! {
-    /// Test-only override for [`HELPER_REAP_BUDGET`]. Production's budget is
-    /// deliberately far too short to wait out a `/bin/sh` stub's fork+exec,
-    /// which is right for a yank and useless for a test that has to observe the
-    /// helper's exit status or the file it wrote. Third seam in this file's
-    /// existing thread-local pattern.
-    static REAP_BUDGET_OVERRIDE: std::cell::RefCell<Option<std::time::Duration>> =
-        const { std::cell::RefCell::new(None) };
-}
+/// Test-only override for [`HELPER_REAP_BUDGET`]. Production's budget is
+/// deliberately far too short to wait out a `/bin/sh` stub's fork+exec, which is
+/// right for a yank and useless for a test that has to observe the helper's exit
+/// status or the file it wrote.
+///
+/// Process-global for the same reason [`CLIPBOARD_OVERRIDE`] is — the budget is
+/// consumed on the worker thread that runs the write.
+static REAP_BUDGET_OVERRIDE: std::sync::RwLock<Option<std::time::Duration>> =
+    std::sync::RwLock::new(None);
+
+/// Serializes reap-budget installation.
+#[cfg(test)]
+static REAP_BUDGET_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 /// Test-only: run `body` with the reap budget pinned to `budget`.
 #[cfg(test)]
 pub fn with_reap_budget<R>(budget: std::time::Duration, body: impl FnOnce() -> R) -> R {
-    struct Guard;
+    struct Guard(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
     impl Drop for Guard {
         fn drop(&mut self) {
-            REAP_BUDGET_OVERRIDE.with(|c| *c.borrow_mut() = None);
+            *REAP_BUDGET_OVERRIDE
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
         }
     }
-    REAP_BUDGET_OVERRIDE.with(|c| *c.borrow_mut() = Some(budget));
-    let _g = Guard;
+    // The guard takes the lock BEFORE the override is installed and holds it for
+    // the whole body, so a concurrent test can neither see nor replace it.
+    let _g = Guard(
+        REAP_BUDGET_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+    );
+    *REAP_BUDGET_OVERRIDE
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(budget);
     body()
 }
 
@@ -115,7 +134,8 @@ const fn reap_budget() -> Duration {
 #[cfg(test)]
 fn reap_budget() -> Duration {
     REAP_BUDGET_OVERRIDE
-        .with(|c| *c.borrow())
+        .read()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
         .unwrap_or(HELPER_REAP_BUDGET)
 }
 
@@ -123,14 +143,22 @@ fn reap_budget() -> Duration {
 /// The override is unwound when `body` returns *or panics* (RAII).
 #[cfg(test)]
 pub fn with_clipboard_override<R>(bin: &std::path::Path, body: impl FnOnce() -> R) -> R {
-    struct Guard;
+    struct Guard(#[allow(dead_code)] std::sync::MutexGuard<'static, ()>);
     impl Drop for Guard {
         fn drop(&mut self) {
-            CLIPBOARD_OVERRIDE.with(|c| *c.borrow_mut() = None);
+            *CLIPBOARD_OVERRIDE
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
         }
     }
-    CLIPBOARD_OVERRIDE.with(|c| *c.borrow_mut() = Some(bin.to_path_buf()));
-    let _g = Guard;
+    let _g = Guard(
+        CLIPBOARD_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+    );
+    *CLIPBOARD_OVERRIDE
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(bin.to_path_buf());
     body()
 }
 
@@ -458,7 +486,11 @@ pub fn copy_via_user_command(cmd: &str, text: &str) -> io::Result<()> {
 pub fn copy(text: &str) -> io::Result<()> {
     #[cfg(test)]
     {
-        if let Some(p) = CLIPBOARD_OVERRIDE.with(|c| c.borrow().clone()) {
+        let stub = CLIPBOARD_OVERRIDE
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        if let Some(p) = stub {
             // Route the override through `/bin/sh <script>` rather
             // than execve'ing the script directly. Direct exec of a
             // just-written file intermittently trips


### PR DESCRIPTION
**M22** of the pre-2.1 review (`D-clipboard-pane-agent.md`, D4) — `medium`, and
the fix `HELPER_REAP_BUDGET`'s own comment has been naming since it was written.

`xclip`/`xsel` legitimately stay alive after a successful copy — that is how they
serve the X11 selection until another app claims it — so `try_wait()` never
returns `Some` and the reap poll runs its **entire** budget. 150 ms of fully
blocked event loop on every single `yf`, on the platform where most non-macOS
users are. Not an edge case: the common one.

Measured, with the write back on the loop: **156.77 ms**.

## What changed

Anything that spawns a helper is now dispatched rather than awaited — the
`graveyard_ops` template, the same one the paste side moved to in #362. The
worker's outcome lands on `runtime.clipboard_copy_results` and wakes with
`Message::ClipboardCopyDone`; `apply_clipboard_writes` drains it in the pre-recv
scan.

OSC 52 stays inline. It is a write to spyc's own stdout, not a spawn, and it can
fail *knowably* (payload over the size limit) — so it keeps answering
synchronously and `deliver_clipboard` keeps its signature and its five call sites.

## The flash moves ahead of the outcome, deliberately

The verb's "yanked" confirmation now goes up before the helper has answered. That
is the point — the whole defect is that yanking feels slow — but it is only
honest because a failure **replaces** the confirmation when it arrives, rather
than being dropped. Trading a hitch for a silent wrong answer would be
re-introducing the defect #350 closed.

One case deliberately does not flash: under `[clipboard] via = "both"`, if OSC 52
already succeeded then the text *is* on the user's clipboard and a local helper
failing is spyc's problem, not theirs. The worker is told whether anything
already delivered.

(If you'd rather the confirmation waited for the truth, it is one branch: flash
from `apply_clipboard_writes` instead of from the verb. The loop is unblocked
either way; the cost is a ~150 ms-late confirmation on Linux.)

## Test seams had to become process-global

`CLIPBOARD_OVERRIDE` and `REAP_BUDGET_OVERRIDE` were thread-locals, and a
thread-local cannot reach the worker — which is precisely the property under
test. Both are now `RwLock` + a serializing `Mutex`, exactly as `PASTE_STUB`
already was for the same reason on the read side. `with_clipboard_override` /
`with_reap_budget` keep their signatures, so no existing test changed.

## Tests

- `a_yank_does_not_wait_out_a_persisting_helper_on_the_loop` — a stub that reads
  the payload then sleeps 10 s (what `xclip` looks like from outside). Asserts
  the dispatch returns in under 50 ms **and then** that the write really lands,
  because a dispatch that returns fast by doing nothing would pass the first
  half alone. Bite-checked with the inline `copy` restored: `the yank blocked the
  loop for 156.772958ms`.
- `a_failed_write_flashes_its_reason_after_the_confirmation` — the half that
  makes an optimistic flash defensible: a helper exiting non-zero surfaces
  `clipboard: … exited unsuccessfully`, over the top of a "yanked" already on
  screen.

`make check-ci` → `=== GATE: PASS ===` (30 clipboard tests).

Generated with [Claude Code](https://claude.com/claude-code)