### PR TITLE
docs(features): agy's dot does report blocked — FEATURES said the opposite

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -262,10 +262,14 @@ spyc's workflow: browse files above, talk to Claude below.
     **codex** writes inline `[[hooks.*]]` into the same `.codex/config.toml` that
     already holds the MCP entry (read once at startup, so for an already-consented
     repo the hooks are written *before* codex spawns); **agy** (Antigravity)
-    writes a `spyc-status` set into `.agents/hooks.json` and is **partial** — agy
-    exposes no user-approval event, so its hooks cover `working` + `done` only
-    and the red `blocked` "needs me" square comes from spyc reading agy's
-    approval prompt off the pane instead.
+    writes a `spyc-status` set into `.agents/hooks.json` and is **partial** — it
+    covers `working`, `done`, and `blocked` for agy's own `ask_question` tool
+    (a `PreToolUse` hook sees that one exactly when it's called). The *other*
+    way agy waits on you — its tool-permission prompt — fires no event in any
+    agy version, so that half of the red square is read off the pane instead.
+    `done` needs **agy ≥ 1.1.10**, which is where `Stop` hooks became reachable
+    at all; on an older agy that half falls back to output timing. Full
+    mechanics: [`docs/AGENT_ORCHESTRATION.md`](docs/AGENT_ORCHESTRATION.md).
     **It asks first**, once per project: the first `claude`/`codex`/`agy` launch
     in a repo pops a `[Y/n]` ("let spyc show this agent's live status? writes
     hooks to `<config>`, removed on exit"), and the answer is **saved per repo** —


### PR DESCRIPTION
**M13** of the pre-2.1 review (`E-docs-comments.md`, F-E2) — `medium`, and the
one place in the delta where a doc states the *opposite* of HEAD rather than
merely lagging it.

`FEATURES.md:266` told the user:

> agy exposes no user-approval event, so its hooks cover `working` + `done` only
> and the red `blocked` "needs me" square comes from spyc reading agy's approval
> prompt off the pane instead.

`src/mcp/hooks.rs:493` says otherwise, and has since #287:

> PARTIAL — `working` + `done`, plus `blocked` for the `ask_question` tool. No
> event fires when agy asks the USER to approve a *tool call*, so that half of
> `blocked` comes from the screen scrape in `agent::AGY_DETECTION_RULES`.

agy waits on the user in **two** ways and they take different instruments: its
`ask_question` tool is a real tool, so a `PreToolUse` hook sees it exactly when
it's called; its tool-permission prompt fires no event in any agy version and is
the only half that's scraped. FEATURES collapsed both into "scraped".

`#287` updated `docs/AGENT_ORCHESTRATION.md` — which is correct and detailed —
and not FEATURES.md. This aligns FEATURES with it and points there for the
mechanics rather than restating them, so the pair can't drift the same way twice.

Two other corrections while the paragraph was open, both verified against the
tree rather than carried over:

- **`done` needs agy ≥ 1.1.10.** `src/mcp/hooks.rs:514` and
  `src/agent/mod.rs:733`: earlier versions left `Stop` unreachable behind agy's
  built-in handling, so that half falls back to output timing. FEATURES said
  nothing about it; `AGENT_ORCHESTRATION.md:62` and the release-notes draft both
  do.
- The `blocked` half that *is* scraped is now named as the tool-permission
  prompt specifically, rather than "agy's approval prompt", which read as
  covering both.

Doc-only; no test. A contradiction between prose and code isn't testable in the
usual sense — the verification is the code citation above, and I re-read
`hooks.rs:485-514` and `agent/mod.rs:733` on HEAD rather than trusting the
finding.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)