### PR TITLE
fix(git): the env-hygiene guard requires the one spawn site, not 1 of 9 variables

### DIFF
--- a/src/app/harness_tests/per_column.rs
+++ b/src/app/harness_tests/per_column.rs
@@ -205,20 +205,8 @@ fn dual_git_each_column_shows_its_own_repo() {
     use std::path::Path;
     let tmp = tempfile::tempdir().unwrap();
     let run_git = |dir: &Path, args: &[&str]| {
-        let ok = std::process::Command::new("git")
+        let ok = crate::git::test_support::git_command(dir)
             .args(args)
-            .current_dir(dir)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@x")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@x")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-            // retarget this at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git")
             .success();
@@ -278,22 +266,8 @@ fn worktree_column_markers_clear_after_a_commit() {
     use std::path::Path;
     let tmp = tempfile::tempdir().unwrap();
     let run_git = |dir: &Path, args: &[&str]| {
-        let ok = std::process::Command::new("git")
-            .arg("-C")
-            .arg(dir)
+        let ok = crate::git::test_support::git_command(dir)
             .args(args)
-            .current_dir(std::env::temp_dir())
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@x")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@x")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-            // retarget this at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git")
             .success();
@@ -369,22 +343,8 @@ fn why_git_dumps_per_column_refresh_state() {
     use std::path::Path;
     let tmp = tempfile::tempdir().unwrap();
     let run_git = |dir: &Path, args: &[&str]| {
-        std::process::Command::new("git")
-            .arg("-C")
-            .arg(dir)
+        crate::git::test_support::git_command(dir)
             .args(args)
-            .current_dir(std::env::temp_dir())
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@x")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@x")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-            // retarget this at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
     };

--- a/src/app/state/tests/mod.rs
+++ b/src/app/state/tests/mod.rs
@@ -681,22 +681,8 @@ fn refresh_listing_picks_up_edit_and_clears_after_commit() {
     let root = std::fs::canonicalize(tmp.path()).unwrap_or_else(|_| tmp.path().to_path_buf());
 
     let run_git = |args: &[&str]| {
-        let status = std::process::Command::new("git")
+        let status = crate::git::test_support::git_command(&root)
             .args(args)
-            .current_dir(&root)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@x")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@x")
-            // Suppress any user-level .gitconfig so the test is
-            // hermetic on machines with unusual defaults.
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-            // retarget this at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");
@@ -756,20 +742,8 @@ fn throttled_worktree_edit_converges_on_next_poll() {
     let tmp = tempfile::tempdir().unwrap();
     let root = std::fs::canonicalize(tmp.path()).unwrap_or_else(|_| tmp.path().to_path_buf());
     let run_git = |args: &[&str]| {
-        let status = std::process::Command::new("git")
+        let status = crate::git::test_support::git_command(&root)
             .args(args)
-            .current_dir(&root)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@x")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@x")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-            // retarget this at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");
@@ -844,20 +818,8 @@ fn git_worker_available_enqueues_request_instead_of_spawning() {
     let tmp = tempfile::tempdir().unwrap();
     let root = std::fs::canonicalize(tmp.path()).unwrap_or_else(|_| tmp.path().to_path_buf());
     let run_git = |args: &[&str]| {
-        let status = std::process::Command::new("git")
+        let status = crate::git::test_support::git_command(&root)
             .args(args)
-            .current_dir(&root)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@x")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@x")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-            // retarget this at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");
@@ -923,20 +885,8 @@ fn forced_rewalk_keeps_stale_markers_and_star_instead_of_blanking() {
     let tmp = tempfile::tempdir().unwrap();
     let root = std::fs::canonicalize(tmp.path()).unwrap_or_else(|_| tmp.path().to_path_buf());
     let run_git = |args: &[&str]| {
-        let status = std::process::Command::new("git")
+        let status = crate::git::test_support::git_command(&root)
             .args(args)
-            .current_dir(&root)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@x")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@x")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-            // retarget this at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");
@@ -1116,20 +1066,8 @@ fn compute_git_info_fast_memoizes_branch_by_head_mtime() {
     let tmp = tempfile::tempdir().unwrap();
     let root = std::fs::canonicalize(tmp.path()).unwrap_or_else(|_| tmp.path().to_path_buf());
     let run_git = |args: &[&str]| {
-        let status = std::process::Command::new("git")
+        let status = crate::git::test_support::git_command(&root)
             .args(args)
-            .current_dir(&root)
-            .env("GIT_AUTHOR_NAME", "t")
-            .env("GIT_AUTHOR_EMAIL", "t@x")
-            .env("GIT_COMMITTER_NAME", "t")
-            .env("GIT_COMMITTER_EMAIL", "t@x")
-            .env("GIT_CONFIG_GLOBAL", "/dev/null")
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-            // retarget this at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("spawn git");
         assert!(status.success(), "git {args:?} failed");

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -114,13 +114,20 @@ mod no_subprocess_git_in_production {
     /// index corrupted, 99 tests failed). Scans ALL source, tests included:
     /// unlike the guard above, test code is precisely the subject here.
     ///
-    /// A site satisfies this by stripping `GIT_DIR` in its own chain, or by
+    /// A site satisfies this by going through `test_support::git_command`, or by
     /// carrying `GIT-ENV-EXEMPT` with a reason.
+    ///
+    /// It used to accept a hand-rolled `env_remove("GIT_DIR")` instead, which is
+    /// **one of the nine** variables `GIT_REDIRECT_ENV` names. Ten sites took it
+    /// up on that and stripped three; the guard passed all ten while
+    /// `GIT_OBJECT_DIRECTORY` and `GIT_ALTERNATE_OBJECT_DIRECTORIES` — which
+    /// apply independently of `GIT_DIR` and would send a scratch repo's writes
+    /// into the developer's real object store — went through untouched. Naming
+    /// the list here would just be a tenth copy of it, so the requirement is now
+    /// the *function* that owns it.
     fn spawn_sites_missing_env_hygiene(src_root: &Path) -> Vec<String> {
-        const WINDOW: usize = 900;
         const BEHIND: usize = 300;
         const EXEMPT: &str = concat!("GIT-ENV", "-EXEMPT");
-        let strip = concat!("env_remove(", "\"GIT_DIR\")");
         let mut offenders = Vec::new();
         let mut stack = vec![src_root.to_path_buf()];
         while let Some(dir) = stack.pop() {
@@ -141,8 +148,8 @@ mod no_subprocess_git_in_production {
                     // written as a comment above the spawn, and the stripping
                     // calls come after it.
                     let start = at.saturating_sub(BEHIND);
-                    let window = &text[start..text.len().min(at + WINDOW)];
-                    if !window.contains(strip) && !window.contains(EXEMPT) {
+                    let window = &text[start..at];
+                    if !window.contains(EXEMPT) {
                         let line = text[..at].matches('\n').count() + 1;
                         offenders.push(format!("{}:{line}", path.display()));
                     }
@@ -160,9 +167,10 @@ mod no_subprocess_git_in_production {
         let offenders = spawn_sites_missing_env_hygiene(&src);
         assert!(
             offenders.is_empty(),
-            "these git spawns can be retargeted by an inherited GIT_DIR — build them \
-             with `git::test_support::git_command`, add `.env_remove(\"GIT_DIR\")`, or \
-             mark the site GIT-ENV-EXEMPT with a reason. Offenders: {offenders:?}"
+            "these git spawns can be retargeted by an inherited git environment — \
+             build them with `git::test_support::git_command`, which strips all of \
+             GIT_REDIRECT_ENV, or mark the site GIT-ENV-EXEMPT with a reason. \
+             Offenders: {offenders:?}"
         );
     }
 }

--- a/src/mcp/config.rs
+++ b/src/mcp/config.rs
@@ -1080,20 +1080,8 @@ mod tests {
     #[test]
     fn cleanup_skips_a_git_tracked_mcp_json() {
         let run_git = |dir: &std::path::Path, args: &[&str]| {
-            let ok = std::process::Command::new("git")
+            let ok = crate::git::test_support::git_command(dir)
                 .args(args)
-                .current_dir(dir)
-                .env("GIT_AUTHOR_NAME", "t")
-                .env("GIT_AUTHOR_EMAIL", "t@x")
-                .env("GIT_COMMITTER_NAME", "t")
-                .env("GIT_COMMITTER_EMAIL", "t@x")
-                .env("GIT_CONFIG_GLOBAL", "/dev/null")
-                .env("GIT_CONFIG_SYSTEM", "/dev/null")
-                // `GIT_DIR` overrides `-C`/cwd, so a hook-launched test run would
-                // retarget this at the real repo — see git::test_support.
-                .env_remove("GIT_DIR")
-                .env_remove("GIT_WORK_TREE")
-                .env_remove("GIT_INDEX_FILE")
                 .status()
                 .expect("spawn git")
                 .success();

--- a/src/merge_driver.rs
+++ b/src/merge_driver.rs
@@ -283,14 +283,8 @@ mod tests {
     #[test]
     fn ensure_installed_writes_once_and_is_idempotent() {
         let tmp = tempfile::tempdir().expect("tempdir");
-        let ok = std::process::Command::new("git")
+        let ok = crate::git::test_support::git_command(tmp.path())
             .args(["init", "-q"])
-            .current_dir(tmp.path())
-            // `GIT_DIR` overrides the cwd, so a hook-launched test run would
-            // init/redirect at the real repo — see git::test_support.
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
-            .env_remove("GIT_INDEX_FILE")
             .status()
             .expect("git init")
             .success();


### PR DESCRIPTION
**M3** of the pre-2.1 review (`C-mcp-state-security.md`, F3) — `medium`, and the
codebase's own stated anti-pattern: a guard that passes while checking a fraction
of what it claims.

`GIT_REDIRECT_ENV` names **nine** variables, and `scripts/git-hooks/pre-commit`
unsets the same nine. The guard enforcing this on test git spawns looked for
exactly one:

```rust
let strip = concat!("env_remove(", "\"GIT_DIR\")");
```

and its failure message offered a 1-variable strip as a sufficient remedy. Ten
hand-rolled spawn sites took it up on that and stripped three — `GIT_DIR`,
`GIT_WORK_TREE`, `GIT_INDEX_FILE` — instead of routing through
`git::test_support::git_command`. The guard passed all ten.

The remaining six inherit, and two of them matter on their own:
`GIT_OBJECT_DIRECTORY` and `GIT_ALTERNATE_OBJECT_DIRECTORIES` apply
**independently of `GIT_DIR`**, so a scratch repo's writes would land in the
developer's real object store. That is the same failure family as the 2026-08-07
incident this guard was written for — the one that wrote `core.bare = true` into
the checkout, corrupted the worktree index, and failed 99 tests.

## What changed

The requirement is now the **function that owns the list**, not a spelling of one
entry: a `Command::new("git")` anywhere under `src/` must either go through
`git_command` or carry `GIT-ENV-EXEMPT` with a reason. Naming the nine variables
in the guard would have made it a third copy of a list that already has to be
kept in sync in two places; requiring the one site that clears them in a loop
means there is nothing to drift.

All ten sites converted. Each loses its hand-rolled `-C`/`current_dir` and its
six hermetic-config `.env(...)` lines too — `git_command` already does all of
that, identically, which is most of why they were copies in the first place.

Three `Command::new("git")` sites remain, all in `test_support.rs`: the stripping
site itself and the two tests of it, each already exempt.

## Red before, and the bite-check is the finding

Tightening the guard first reported exactly the ten sites the review named
(`per_column.rs:208,281,372`, `state/tests/mod.rs:684,759,847,926,1119`,
`mcp/config.rs:1083`, `merge_driver.rs:286`), which is how I confirmed the
conversion list rather than trusting it.

Then, with the conversion done, reintroducing a **3-of-9 strip** at one site —
byte-for-byte what the old guard accepted at all ten — now reports it:

```
Offenders: [".../src/merge_driver.rs:287"]
```

The real regression check is the suite itself: every one of these ten is a
git-touching test, and they all still pass, so the conversion preserved what each
spawn actually did.

## A note on how this was nearly done wrong

The first attempt converted the sites with a regex over the Rust source. It
mangled two of them — one left a `git` spawn with **no directory at all**, which
would have run against the process cwd. Reverted and redone by hand against each
site's exact text. Regex-editing Rust source has burned this project before; it
is not a shortcut.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)