### PR TITLE
docs(security): SECURITY.md claims two things HEAD doesn't do

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,13 +47,24 @@ is what `fuzz/fuzz_targets/` exists for — see the fuzzing caveat.
 
 The MCP read tools take an optional `root` argument to scope a query to
 a worktree. That argument is **validated against a set of roots spyc
-knows about**, so an agent cannot point a read tool at an arbitrary
-directory. The rationale is recorded in ROADMAP.md's decisions log:
-agent harnesses commonly auto-approve MCP tool calls while gating shell
-execution behind per-command permission prompts, so an unvalidated
+knows about**: the trusted context root, its worktrees, and the focused
+column's own chain. The rationale is recorded in ROADMAP.md's decisions
+log: agent harnesses commonly auto-approve MCP tool calls while gating
+shell execution behind per-command permission prompts, so an unvalidated
 `root` would bypass a boundary the *user* believes exists.
 
-That validation is a guardrail, not a sandbox. An agent with shell
+**That set is not fixed, and the agent can widen it.** Two of its
+entries come from the cursor (`cwd`, `search_root`), and `navigate_to`
+sets `cwd` to any path the agent names — so `navigate_to("/etc")`
+followed by `search_content(…, root="/etc")` is allowed. `open_worktree`
+is a quieter second path to the same widening. This is deliberate:
+freezing the set at launch would break the ordinary case of a user
+navigating somewhere and then asking the agent about it. Navigation is
+visible (a `[mcp] navigated to …` flash), and it grants no reach the
+agent didn't already have.
+
+So the validation is a guardrail, not a sandbox — it keeps an agent from
+*wandering*, not from *going somewhere on purpose*. An agent with shell
 access can read anything you can read, and spyc does not try to prevent
 it. Do not treat the MCP tool surface as a containment mechanism for an
 untrusted agent.
@@ -66,14 +77,26 @@ untrusted agent.
   builds pass `--locked` to cargo, so a CI-time `Cargo.lock` drift
   fails loudly. The Makefile and the GitHub Actions CI
   (`.github/workflows/ci.yml`) both enforce this.
-- **`cargo deny check`** runs on every CI build (advisories,
-  licenses, sources, bans). Configuration is checked in at `deny.toml`
-  with documented reasons for every advisory ignore — none are silent.
+- **`cargo deny check`** (advisories, licenses, sources, bans) runs
+  **weekly and on demand**, in `.github/workflows/audit.yml` — not on
+  every CI build. It re-fetches the RUSTSEC database on every
+  invocation, which is what makes the weekly run worth having (it
+  surfaces new advisories against unchanged deps) and what made it
+  unfit for the per-commit path, where it is network-dependent and has
+  segfaulted mid-run, failing PRs that touched no dependencies.
+  **The gap that buys:** a PR introducing a banned, wrongly-licensed or
+  duplicate dependency is not caught at PR time. It surfaces on the next
+  scheduled run, or from `make deny` locally. Dispatch it (`gh workflow
+  run audit.yml`) after merging anything that moves `Cargo.toml` /
+  `Cargo.lock`, and before cutting a release. Configuration is checked
+  in at `deny.toml` with documented reasons for every advisory ignore —
+  none are silent.
 - **License allow-list.** Only the licenses present in our actual
   dep graph are allowed; the list is reviewed against
   `cargo deny list` when deps change. Adding a dep with a license
-  outside that set fails CI; you read it, decide, and either add to
-  the allow-list (with a reason) or pick a different dep. Several deps
+  outside that set fails the audit run above (not the PR — same gap);
+  you read it, decide, and either add to the allow-list (with a reason)
+  or pick a different dep. Several deps
   are multi-licensed and offer a copyleft option (`self_cell`,
   `r-efi`, the `Unlicense OR MIT` BurntSushi crates); cargo-deny
   selects an allowed alternative, so no copyleft obligation attaches.


### PR DESCRIPTION
**M1 and M2** of the pre-2.1 review (`C-mcp-state-security.md`, F1 and F2) —
both `medium`. Taken together deliberately: they are the same defect (a security
document asserting a property the code doesn't have), one paragraph apart, and
correcting one while leaving the other would still hand a reader a file that
misleads them.

## M1 — "an agent cannot point a read tool at an arbitrary directory"

`allowed_roots` (`src/mcp/readers.rs:78-88`) is built from three sources, and the
third is the context file's own cursor-tracking fields:

```rust
for key in ["search_root", "project_home", "cwd"] { … push(PathBuf::from(s)); }
```

`navigate_to` sets that `cwd` to any path the agent names — `AppState::jump_to`
canonicalizes and chdirs, nothing more — and `execute_mcp_command` then calls
`write_context()` **synchronously on the same turn**, deliberately, so a
follow-up read isn't stale. So:

1. `navigate_to("/etc")` → context `cwd` becomes `/etc`
2. `search_content(pattern, root="/etc")` → `is_within_allowed` matches

Both are the kind of call agent harnesses auto-approve, which is exactly the
"bypass a boundary the *user* believes in" that the paragraph invokes to justify
the validation in the first place. `open_worktree` is a quieter second path.

**Not fixed in code, and the doc now says why.** Freezing the allowed set at
launch would break the ordinary case — the user navigates somewhere and then
asks the agent about it — and this is not a privilege escalation: the same agent
has shell reach, and navigation is visible (a `[mcp] navigated to …` flash). The
paragraph's *next* sentence was already the honest framing ("a guardrail, not a
sandbox"); the one before it overstated. It now names what widens the set, and
sharpens the guardrail line to what it actually buys — an agent is kept from
**wandering**, not from **going somewhere on purpose**.

## M2 — "`cargo deny check` runs on every CI build"

Untrue since `ba874c2` (#273) moved it to `audit.yml`. `ci.yml:57` says so in a
comment; SECURITY.md never caught up.

Rewritten to say weekly-and-on-demand, and — because this is the file where a
reader goes to find out what is *not* covered — to state the gap `audit.yml`
already admits in its own header: a PR introducing a banned, wrongly-licensed or
duplicate dependency is not caught at PR time, so dispatch the workflow after
anything that moves `Cargo.toml`/`Cargo.lock` and before cutting a release.

The **License allow-list** bullet carried the same stale claim one bullet down
("fails CI"); corrected in the same pass rather than left as a second instance of
the finding.

## Verification

Both claims re-derived on HEAD rather than taken from the review:
`readers.rs:52-91` for the root set, `app/mcp.rs`'s synchronous `write_context`,
`state/navigation.rs`'s unscoped `jump_to`, and `audit.yml`'s
`schedule`/`workflow_dispatch` triggers against `ci.yml`'s `make fmt-check lint`.

Doc-only; no test. The verification is the citations above.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)