### PR TITLE
test(git): a stale pre-commit hook fails the gate instead of hiding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,23 @@ workflow, standards, and conventions for the project.
 # Use single-branch to avoid downloading the heavy gh-pages branch
 git clone --single-branch --branch main git@github.com:Tripstack-Corp/spyc.git
 cd spyc
-make doctor    # check prerequisites (rustc, cargo, zig, etc.)
-cargo build    # dev build
-cargo test     # run all tests
+make doctor         # check prerequisites (rustc, cargo, zig, etc.)
+make install-hooks  # pre-commit hook — see below
+cargo build         # dev build
+cargo test          # run all tests
 ```
+
+**Install the pre-commit hook.** It runs `make check` before each commit, and
+it does one thing nothing else can: it `unset`s git's redirect environment
+(`GIT_DIR` and friends) before the gate runs, so every tool the gate invokes is
+covered — not just spyc's own git calls. Skipping that once cost a multi-day
+investigation, after `cargo-deny`'s advisory-db refresh inherited `GIT_DIR` from
+the hook and hard-reset the branch under it.
+
+Re-run `make install-hooks` whenever the template changes; the installed copy is
+a snapshot, not a link. You don't have to track that yourself — `make check`
+fails if the two have drifted (`git::commit_hook_is_current`). Bypass a single
+commit with `git commit --no-verify`; don't make a habit of it.
 
 See [BUILD.md](BUILD.md) for the full toolchain, build, and
 cross-compilation reference, and [INSTALL.md](INSTALL.md) for terminal

--- a/Makefile
+++ b/Makefile
@@ -443,10 +443,17 @@ uninstall-debug: ## Remove spyc.debug from $(PREFIX)/bin
 
 # ---------- Git hooks --------------------------------------------------------
 
+# Ask git where the hooks live rather than assuming `.git/hooks`: from a linked
+# worktree `.git` is a FILE, so the literal path doesn't exist and the install
+# fails — in the layout this project actually works in. There is one hooks dir
+# per repository (the common dir), which is also what
+# `git::commit_hook_is_current` compares against.
+HOOKS_DIR = $(shell git rev-parse --git-common-dir 2>/dev/null)/hooks
+
 .PHONY: install-hooks
 install-hooks: ## Install pre-commit hook (runs `make check` before each commit)
-	@install -m 755 scripts/git-hooks/pre-commit .git/hooks/pre-commit
-	@echo "✓ installed .git/hooks/pre-commit — runs 'make check' on each commit"
+	@install -m 755 scripts/git-hooks/pre-commit $(HOOKS_DIR)/pre-commit
+	@echo "✓ installed $(HOOKS_DIR)/pre-commit — runs 'make check' on each commit"
 	@echo "  bypass with 'git commit --no-verify' (don't make a habit)"
 
 # ---------- Doctor (preflight checks) ----------------------------------------

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -47,6 +47,58 @@ pub fn error_chain(e: &dyn std::error::Error) -> String {
 }
 
 #[cfg(test)]
+mod commit_hook_is_current {
+    //! The other half of the 2026-08-07 defenses (see
+    //! [`super::no_subprocess_git_in_production`]): the installed pre-commit
+    //! hook is what `unset`s `GIT_REDIRECT_ENV` before `exec make check`, so
+    //! *every* tool the gate invokes is covered — not just spyc's own git
+    //! spawns. A checkout whose installed copy predates that line has no
+    //! protection and no way to tell.
+    //!
+    //! Nothing compared the two: `make install-hooks` is a bare `install -m
+    //! 755` with no stamp, `make check` didn't look, and the only instruction
+    //! was a sentence of prose in AGENTS.md. The drift was live in this
+    //! repository's own checkout when this test was written — comment-only, and
+    //! therefore harmless, but a missing `unset` would have looked identical.
+    use std::path::{Path, PathBuf};
+
+    /// Where git keeps this repository's hooks, or `None` when that can't be
+    /// answered — an unpacked source tree with no `.git`, or a `core.hooksPath`
+    /// pointing somewhere else. Resolved through the **common** dir so the test
+    /// finds the one installed hook from a linked worktree too.
+    fn hooks_dir() -> Option<PathBuf> {
+        let repo = gix::discover(Path::new(env!("CARGO_MANIFEST_DIR"))).ok()?;
+        Some(repo.common_dir().join("hooks"))
+    }
+
+    /// A hook is installed and is **byte-identical** to the tracked template.
+    ///
+    /// Skipped when none is installed: a fresh clone and CI are both legitimate
+    /// states, and failing there would make `make check` unrunnable before the
+    /// first `make install-hooks`. What it catches is the state that has no
+    /// other signal — an installed hook that has since fallen behind.
+    #[test]
+    fn the_installed_hook_matches_its_template() {
+        let template = Path::new(env!("CARGO_MANIFEST_DIR")).join("scripts/git-hooks/pre-commit");
+        let Some(installed) = hooks_dir().map(|d| d.join("pre-commit")) else {
+            return;
+        };
+        let Ok(have) = std::fs::read(&installed) else {
+            return; // no hook installed — see the doc comment
+        };
+        let want = std::fs::read(&template).expect("the tracked hook template");
+        assert!(
+            have == want,
+            "{} has drifted from scripts/git-hooks/pre-commit — re-run \
+             `make install-hooks` (from the main checkout or any worktree). \
+             The hook is what strips the ambient git environment before the \
+             gate runs; a stale copy silently removes that protection.",
+            installed.display()
+        );
+    }
+}
+
+#[cfg(test)]
 mod no_subprocess_git_in_production {
     //! Strangler-fig closing guard: production code must never spawn the `git`
     //! binary — every git operation runs in-process via gix. Test fixtures may


### PR DESCRIPTION
**M4** of the pre-2.1 review (`C-mcp-state-security.md`, F4) — `medium`.

The pre-commit hook is what `unset`s `GIT_REDIRECT_ENV` before `exec make check`,
so **every** tool the gate invokes is covered rather than just spyc's own git
spawns. That line exists because of the 2026-08-07 incident, where `cargo-deny`'s
advisory-db refresh inherited `GIT_DIR` from the hook's environment and hard-reset
whatever branch was checked out.

Nothing told a contributor their *installed* copy predated it:

- `make install-hooks` is a bare `install -m 755` — no stamp, no comparison.
- `make check` didn't look.
- No test did.
- `CONTRIBUTING.md` didn't mention the hook at all.
- The only instruction was a sentence of prose in AGENTS.md — advice a human has
  to read and act on, in a file whose whole point is that it is long.

**The drift was live here.** Running the new test for the first time failed
against this repository's own installed hook, which had fallen ten lines behind
the template. Comment-only, so this machine was safe — but a missing `unset`
would have looked exactly the same from outside.

## The signal

`git::commit_hook_is_current` compares the installed hook to the tracked
template, byte for byte. It sits beside `no_subprocess_git_in_production`, which
is the *other* half of the same incident's defenses — spyc's own spawns there,
everything else the gate runs here.

It runs on the commit path (hook → `make check` → this test) and lives in the
tracked tree, so unlike a check written into the hook it can't go stale with the
thing it's checking.

**Skipped when no hook is installed.** A fresh clone and CI are both legitimate
states, and failing there would make `make check` unrunnable before the first
`make install-hooks`. The state that had no other signal is an installed hook
that has since fallen behind, and that is what this catches. (CI passing on this
PR is the skip branch's own test.)

Resolved through git's **common** dir, so it finds the one installed hook from a
linked worktree too — the layout this project actually works in.

## `make install-hooks` had to work from a worktree

It wrote to the literal `.git/hooks/pre-commit`. From a linked worktree `.git` is
a *file*, so that path doesn't exist and the install fails — which would have
made the new failure message name a fix that didn't work where the reader was
standing. It now asks `git rev-parse --git-common-dir`, the same
ask-don't-assume shape `TARGET_DIR` already uses two dozen lines up.

## Docs

`CONTRIBUTING.md` gains `make install-hooks` in its getting-started block plus
what the hook is actually for and why the snapshot needs re-installing — with the
note that you don't have to track that yourself, because the gate now does.

## Evidence

- **Red before, on real drift** — not a synthetic fixture: the first run failed
  against the live installed hook.
- **Bite-checked**: appending one comment line to the installed hook reports it;
  `make install-hooks` restores it, verified byte-identical to both the template
  and the pre-test backup.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)