### PR TITLE
docs: close the 2.1 doc-contract cluster — five findings, one pass

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -135,8 +135,11 @@ Locally it stays helper-first deliberately — OSC 52 is write-only with no repl
 spyc can't confirm the terminal honored it, and some terminals disable it on purpose
 (a remote host writing your clipboard is a real risk). Inside tmux it needs
 `set -g set-clipboard on`; spyc DCS-wraps the escape so tmux forwards it to the outer
-terminal. A selection too large for the escape falls back to the helper rather than
-risk a terminal truncating it silently.
+terminal. A selection too large for the escape (~75 KB of base64) is **refused with a
+message** rather than risking a terminal truncating it silently — it does not fall
+back to the helper, because under `auto` over SSH the helper isn't enabled and writing
+the server's clipboard wouldn't help you anyway. Only `via = "both"` has a second
+mechanism to reach.
 
 ```toml
 [clipboard]

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -712,10 +712,14 @@ end).
   **Ctrl** while pressing to copy absolute paths instead. The highlight stays up
   after the copy. Distinct from picks: a drag never changes what the next file
   operation acts on.
-  **Drag across the status line or the divider/tab line to select part of it** —
-  release copies exactly those columns, so you can take just a branch name, an
-  agent session id, or a custom tab name without the rest of the line. A click
-  that doesn't move copies nothing.
+  **Click a pane tab to switch to it** — the tab bar looked clickable and wasn't,
+  so the one part of that row meaning "go here" behaved like static text.
+  **Drag across any chrome row to select part of it** — the status line, the
+  divider/tab line, the prompt row (a flash, the `:` command line, an armed
+  chord) and the activity HUD. Release copies exactly those columns, so you can
+  take just a branch name, an agent session id, a custom tab name or an error
+  message without the rest of the line. A click that doesn't move copies nothing,
+  and copying part of a flash leaves the message intact.
   **Drag in a pager to select text; release copies it** and the pager title
   reports the line count. Works the same full-screen or popped-up, and copies the
   content only — never the line-number gutter, the whitespace/line-break markers,
@@ -1227,17 +1231,18 @@ spyc auto-saves your workspace on quit and can restore it on startup.
 
 ```sh
 spyc --install-skill
-#  → ~/.claude/skills/spyc/     (Claude Code)
-#  → ~/.codex/skills/spyc/      (codex; honors $CODEX_HOME)
+#  → ~/.claude/skills/spyc/          (Claude Code)
+#  → ~/.codex/skills/spyc/           (codex; honors $CODEX_HOME)
+#  → ~/.gemini/config/skills/spyc/   (agy / Antigravity)
 ```
 
 Writes an embedded usage guide into each agent's **personal** skills directory,
 so it applies in every project without touching any repo.
 
-Claude Code and codex independently converged on the same format —
-`<skills-dir>/<name>/SKILL.md` with YAML frontmatter plus optional `references/`
-sub-files — so one embedded copy serves both **verbatim**; only the directory
-differs. Adding another host is one `Host` variant and its directory.
+All three hosts converged on the same format — `<skills-dir>/<name>/SKILL.md`
+with YAML frontmatter plus optional `references/` sub-files — so one embedded
+copy serves them **verbatim**; only the directory differs. Adding another host is
+one `Host` variant and its directory.
 
 Contents:
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -6,7 +6,8 @@ overlay; this file is the browsable version. The survival subset lives in the
 
 Binding tiers (see [DESIGN.md](../DESIGN.md) → "Binding taxonomy"): **frame**
 keys drive the file view (letters / `g` / `H` / `[`/`]`); **pane** keys use the
-`^a` prefix; **global** workspace ops are on the `Space` leader.
+`^a` prefix; **global** workspace ops are on the `Space` leader. The mouse is
+bound too, and on by default — see [Mouse](#mouse).
 
 ## Navigation
 
@@ -301,3 +302,40 @@ to open them in the current listing dir.
 | `:lua` | Lua engine: `status` / `on` / `off` / `reload` |
 | `:notify test` | Fire every notification channel to verify setup |
 | `:date` | Show date/time (UTC) |
+
+## Mouse
+
+Real mouse reporting, **on by default** (`[mouse] capture`). Not keys, but part
+of the keymap in the sense that matters: these are bindings you can hit without
+meaning to.
+
+The wheel scrolls **whatever is under the pointer**, not whatever has keyboard
+focus.
+
+| Gesture | Action |
+|-----|--------|
+| Wheel | Scroll the region under the pointer — file list, pager, or pane |
+| Wheel over a pane | Whatever that agent can receive: forwarded to a mouse-aware child, else its own scroll keys; over codex it drives the `^T` transcript |
+| Left click | Focus that region — and click *through* to a mouse-aware child |
+| Left click on a pane tab | Switch to that tab |
+| Left drag | Select text: pager content, a non-mouse pane's grid, any chrome row, or file-list rows. Release copies |
+| `Ctrl` + left drag (list) | Copy absolute paths instead of names |
+| Middle click | Paste the clipboard |
+| Right click | Open the leader menu |
+| `Shift` + drag | Your terminal's own selection, bypassing spyc (Option/Fn on iTerm2) |
+
+**Capture costs your terminal's native click-drag selection while it's on** —
+inherent, not a spyc choice: the terminal can't both report the drag and handle
+it. `Shift` is the per-drag bypass; `:mouse off` gives it back immediately with
+no restart and survives a config reload; `:mouse auto` returns to following the
+config; `capture = false` turns it off permanently. `^a u` quick-select and `y`
+in the pager are the mouse-free yank paths.
+
+| Command | Does |
+|-----|--------|
+| `:mouse on` / `off` | Turn reporting on/off for this session |
+| `:mouse auto` | Follow `[mouse] capture` again |
+
+Config: `[mouse] capture`, `scroll_lines`, `pane_scroll_lines`,
+`pane_scroll_view`, `invert_scroll` — see
+[CONFIGURATION.md](../CONFIGURATION.md#mouse--mouse).

--- a/src/app/render/mod.rs
+++ b/src/app/render/mod.rs
@@ -447,13 +447,6 @@ impl App {
         self.render_image_overlay(frame, frame_area);
     }
 
-    /// Pre-draw pass: compute the frame layout and settle the derived list
-    /// state (rows cache + the `view_top`↔grid stabilization) before any
-    /// drawing, so `render_inner` draws from already-settled state. Returns
-    /// the layout the draw reuses (computed once). The list settle runs only
-    /// on the file-list path — when a top-overlay owns the screen the list
-    /// isn't drawn and its derived state isn't consulted, matching
-    /// `render_inner`'s overlay early-return.
     /// The frame's geometry for `area` — **the single source of truth**.
     ///
     /// `&self` and side-effect-free, so anything that needs to know where a rect
@@ -498,6 +491,13 @@ impl App {
         layout
     }
 
+    /// Pre-draw pass: compute the frame layout and settle the derived list
+    /// state (rows cache + the `view_top`↔grid stabilization) before any
+    /// drawing, so `render_inner` draws from already-settled state. Returns
+    /// the layout the draw reuses (computed once). The list settle runs only
+    /// on the file-list path — when a top-overlay owns the screen the list
+    /// isn't drawn and its derived state isn't consulted, matching
+    /// `render_inner`'s overlay early-return.
     fn prepare_frame(&mut self, area: ratatui::layout::Rect) -> FrameLayout {
         let layout = self.frame_layout(area);
         if self.runtime.top_overlay.is_none() {

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -390,8 +390,13 @@ pub fn read_image() -> Result<Option<ClipboardImage>, String> {
 /// xterm's own limit is ~74 994 bytes of base64 and several terminals inherit it;
 /// tmux caps at 1 MB only with `set-clipboard on`. A payload over the limit is
 /// silently *truncated* by some terminals and dropped entirely by others, and a
-/// half-pasted selection is worse than a clear failure — so past this we fall back
-/// to the local helper rather than gamble.
+/// half-pasted selection is worse than a clear failure — so past this the yank is
+/// refused with a message rather than gambling.
+///
+/// Refused, NOT fallen back to the local helper. Under `via = "auto"` over SSH —
+/// the case OSC 52 exists for — the local helper isn't enabled, and writing the
+/// *server's* clipboard would not be a useful fallback anyway. Only
+/// `via = "both"` has a second mechanism to reach.
 const OSC52_MAX_BASE64: usize = 74_994;
 
 /// Ask the TERMINAL to set the clipboard, via OSC 52.
@@ -402,7 +407,8 @@ const OSC52_MAX_BASE64: usize = 74_994;
 /// host spyc runs on, which over SSH is the *server* — text the user can never
 /// paste.
 ///
-/// `Err` when the payload is too large to send safely; the caller falls back.
+/// `Err` when the payload is too large to send safely ([`OSC52_MAX_BASE64`]) — the
+/// caller reports it; there is no fallback unless `via = "both"` enabled one.
 /// Success here means "the sequence was written", not "the terminal honored it":
 /// OSC 52 is write-only with no reply, and support varies (kitty/WezTerm/iTerm2/
 /// Ghostty/Alacritty yes; tmux needs `set -g set-clipboard on`; some terminals gate
@@ -1137,7 +1143,7 @@ mod osc52_tests {
 
     /// Over-limit payloads must ERROR rather than be sent: several terminals
     /// silently truncate an oversized OSC 52, and half a selection on the clipboard
-    /// is worse than a reported failure (the caller falls back to the local helper).
+    /// is worse than a reported failure the user can act on.
     #[test]
     fn an_oversized_payload_is_refused_not_truncated() {
         // 3 bytes -> 4 base64 chars, so this comfortably exceeds the cap.


### PR DESCRIPTION
**M14, M15, M16, M23 and M24** of the pre-2.1 review — all `medium`, all the
same shape: the 2.1 window shipped features and the docs describing them didn't
move. Batched because they are one class, in overlapping files, and reviewing
five one-paragraph PRs costs more than it buys.

## M15 — `docs/KEYBINDINGS.md` had zero mouse content

A file that opens with *"The complete keymap"* said nothing about the wheel,
clicks, drags, `Shift`-bypass or `:mouse` — while `[mouse] capture` **defaults
on**. A 2.1 user whose terminal selection stops working looks here first and
finds nothing.

New `## Mouse` section: what each gesture does, tab-click, the `Ctrl`-drag
variant, the three `:mouse` states, and the capture/selection trade with its
`Shift` bypass — plus a pointer from the intro's binding-tier paragraph, since
"not a key" is exactly why it went missing.

## M16 — two shipped mouse features documented nowhere

`#279` (click a pane tab to switch to it) and `#281` (the chrome-selection
surface covers the prompt row and the activity HUD, not just the status and
divider lines). Both were inside an enumeration that reads as complete, which is
the worst place for a gap. FEATURES now names both, and the drag entry lists all
four chrome rows rather than two.

## M14 — two-host skill docs for a three-host feature

`src/skill/mod.rs` iterates `[Claude, Codex, Agy]` and has since `78fe33f`
(#194); FEATURES listed two directories, said "one embedded copy serves
**both**", and offered "adding another host is one `Host` variant" as future work
for a host already present. Now three, with agy's real path
(`~/.gemini/config/skills/spyc/`).

## M23 — a fallback promised in four places and performed in none

`CONFIGURATION.md` and two code comments claimed an oversized OSC-52 payload
"falls back to the local helper". `deliver_clipboard` has no such fallback: under
`via = "auto"` **over SSH** — the case OSC 52 exists for — `clipboard_delivery`
returns `(local: false, osc52: true)`, so an oversize selection errors and
nothing is copied. The claim holds only under `via = "both"`, which is not the
default.

**Corrected the docs, not the code.** The behaviour is right: writing the
*server's* clipboard is not a useful fallback over SSH, and the user is told. The
defect was three places asserting a property no code has — precisely what
AGENTS.md's "comments state what IS" rule exists to prevent.

A **fourth** instance turned up while grepping to confirm the three were gone: a
test's own doc comment (`clipboard.rs:1146`) repeating it. Fixed in the same
pass; finding one copy of a false claim is a reason to grep for the rest.

## M24 — an orphaned doc comment

`prepare_frame`'s doc block was stranded on top of `frame_layout`'s by `6515ac3`
(#219), so `frame_layout` carried a description of a function it isn't and
`prepare_frame` had none. Moved back; `frame_layout`'s own doc — the one
explaining the three ways the mouse diverged before it existed — is untouched.

## Verification

Each claim re-derived on HEAD rather than taken from the review: `skill/mod.rs`'s
`hosts()`/`host_dir` for the three directories, `clipboard_delivery` +
`deliver_clipboard` for the absent fallback, `render/mod.rs:494-507` for which
function the orphaned comment describes, and a grep confirming no "falls back to
the helper" claim survives anywhere in `src/` or the markdown.

Doc-only apart from the comment moves; no behaviour change, no test. The one
mechanical check available — that the code no longer states the fallback — is the
grep above.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)