### PR TITLE
fix(mouse): a wheel tick over an inline agent scrolls spyc's own history

### DIFF
--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -67,7 +67,8 @@ pty, not inferred.
 
 | agent | screen | mouse reporting | wheel behavior in spyc |
 |---|---|---|---|
-| **claude** | alternate screen (`?1049h`) | `?1000h ?1002h ?1003h ?1006h` | Forwarded verbatim — claude scrolls and selects natively. A real mouse report carries coordinates a synthesized key can't, so forwarding always wins. |
+| **claude** — `/tui fullscreen` | alternate screen (`?1049h`) | `?1000h ?1002h ?1003h ?1006h` | Forwarded verbatim — claude scrolls and selects natively. A real mouse report carries coordinates a synthesized key can't, so forwarding always wins. |
+| **claude** — `/tui default` | inline, **no** scroll region | **none** | Nothing to forward and no verified scroll key, so a sustained wheel-up opens **spyc's own** captured history (`^a v`'s pager). Inline claude's completed output reaches the main buffer, so unlike codex there genuinely is a capture to show. |
 | **codex** | inline, with a DECSTBM scroll region | **none** | codex discards mouse events outright, so spyc synthesizes arrows to drive its own `^T` transcript overlay. |
 | **agy** | configurable; default `native terminal (inline)` | none (inline) / `ButtonMotion` (altscreen) | Inline: spyc sends **Shift+Arrow**, agy's own scroll affordance. Altscreen: agy requests motion reporting, so it scrolls natively. |
 | **zot** | — | — | No transcript or scroll integration yet; treated as a plain child. |
@@ -77,6 +78,13 @@ agy's own settings UI frames the trade-off well, and it applies generally:
 selection; **inline** preserves terminal behavior but may truncate long
 conversations.
 
+claude's own mode is `/tui`, persisted as `"tui": "default" | "fullscreen"` in
+`~/.claude/settings.json` — `default` (inline) is what you get out of the box, and
+an invalid value there makes claude skip the whole settings file. spyc doesn't
+read that key: it branches on what the pty actually did (`?1049h` observed, and
+whether the child asked for mouse reporting), which stays right when you flip the
+mode mid-session.
+
 ### The consequence people hit
 
 An **alternate-screen** agent's history never enters the terminal's main buffer,
@@ -84,6 +92,12 @@ so it is never in spyc's vt100 scrollback. codex's history isn't either — its
 scroll region keeps completed turns off the main buffer, so **zero** rows reach
 spyc's emulator. In both cases "just scroll up" cannot work, no matter what spyc
 does. Section 3 is what does work.
+
+Text selection follows the same fork, and needs nothing extra: a child that asked
+for mouse reporting draws its **own** selection (fullscreen claude), and a child
+that didn't gets **spyc's** drag-select over the pane grid, copied to the
+clipboard on release. Only the wheel needed the third answer above, because it
+has somewhere else to go — spyc's capture — when neither side owns it.
 
 ---
 
@@ -100,9 +114,18 @@ does. Section 3 is what does work.
 That's `decide_scroll_source` in `src/app/pane_scroll.rs` — a pure function, if
 you want to read the exact ladder.
 
-So for claude, codex and agy, `^a v` reads the agent's **own transcript file**,
-not the screen. That's strictly better than capture: real text, no grid or
-repaint artifacts, and searchable. Inside that view:
+So for codex and agy — and for claude in `/tui fullscreen` — `^a v` reads the
+agent's **own transcript file**, not the screen. That's strictly better than
+capture: real text, no grid or repaint artifacts, and searchable.
+
+**Inline claude is the exception**: it isn't alt-screen, so the bypass doesn't
+apply and its transcript stays behind `[pane] claude_transcript_scrollback`
+(default off) — `^a v` and the wheel both show vt100 capture instead. That
+capture is real (inline claude's output reaches the main buffer), and it carries
+what the transcript never will, like whatever the shell printed before the agent
+started. Set the key to `true` if you'd rather have the conversation.
+
+Inside either view:
 
 - `t` — toggle the agent's tool-call / tool-result lines (transcript scrollback
   only; a long tool-heavy session is much easier to read with them off)

--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -567,6 +567,94 @@ mod tests {
         panic!("the pane never reported mouse mode");
     }
 
+    /// An inline-agent pane carrying real captured history. `cat` is the child
+    /// so it spawns in a test; the tab's command reads `claude`, which is all
+    /// `agent::detect` consults. The echoed lines overflow the grid, so rows
+    /// genuinely leave the screen and land in the emulator's scrollback.
+    fn inline_agent_pane_with_history(app: &mut App, dir: &std::path::Path) {
+        let wake = app.make_pane_wake();
+        let pane = crate::pane::Pane::spawn("cat", 24, 80, dir, &app.view.context_path, wake)
+            .expect("spawn cat");
+        let entry = crate::pane::tabs::TabEntry::new(
+            pane,
+            crate::pane::tabs::TabInfo::new("claude", dir.to_path_buf()),
+        );
+        app.runtime.pane_tabs = Some(crate::pane::tabs::PaneTabs::new(entry));
+        let tabs = app.runtime.pane_tabs.as_mut().expect("a pane tab");
+        let feed: String = (0..80).map(|i| format!("history line {i}\n")).collect();
+        tabs.active_mut()
+            .send_bytes(feed.as_bytes())
+            .expect("write to the pty");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            tabs.active_mut().drain_output();
+            if tabs
+                .active_mut()
+                .with_screen_mut(crate::ui::scrollback::scrollback_len)
+                > 0
+            {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        panic!("the pane never captured any scrollback");
+    }
+
+    /// **A wheel tick over an inline agent's pane has to move the history spyc
+    /// captured.** claude in its default TUI mode takes no alternate screen and
+    /// requests no mouse modes (both verified in a pty), and spyc has no
+    /// verified scroll key for it — so `route_mouse`'s `Region::Pane` ladder
+    /// fell through to `Swallow`: nothing moved, and nothing said why. That
+    /// reached us as "scrolling doesn't work with claude". Inside a pane spyc IS
+    /// the terminal, so its own scrollback is the surface the wheel is asking
+    /// for — and unlike codex there IS one, because inline claude sets no
+    /// DECSTBM region and its completed output reaches the main buffer.
+    #[test]
+    fn a_sustained_wheel_up_over_an_inline_agent_reaches_spycs_history() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let dir = tmp.path().join("work");
+            std::fs::create_dir(&dir).unwrap();
+            let mut app = App::test_app(dir.clone());
+            app.view.term_size = (120, 24);
+            inline_agent_pane_with_history(&mut app, &dir);
+
+            // The two conditions that make this the swallowed case, asserted so
+            // the test keeps naming its own premise: if claude ever starts
+            // speaking mouse inline, this must fail loudly here rather than pass
+            // for a reason it isn't testing.
+            assert!(
+                !app.runtime
+                    .pane_tabs
+                    .as_ref()
+                    .expect("a pane tab")
+                    .active()
+                    .wants_mouse(),
+                "inline claude requests no mouse modes"
+            );
+            assert!(
+                app.active_pane_wheel_scroll().is_none(),
+                "and spyc has no verified scroll key to synthesize for it"
+            );
+
+            crate::set_mouse_capture_for_test(true);
+            let layout = app.frame_layout(ratatui::layout::Rect::new(0, 0, 120, 24));
+            let pane_rect = layout.pane.expect("a pane is open");
+            let point = (pane_rect.x + 2, pane_rect.y + 1);
+            for _ in 0..super::route::OPEN_AFTER_UP_TICKS {
+                app.handle_mouse(at(MouseEventKind::ScrollUp, point.0, point.1));
+            }
+            crate::set_mouse_capture_for_test(false);
+
+            assert!(
+                app.runtime.pane_scroll_settle.is_some() || app.view.scroll_pager.is_some(),
+                "a sustained wheel-up over an inline agent must reach for the pane's \
+                 captured history; instead the tick vanished"
+            );
+        });
+    }
+
     /// **The capture gate.** A terminal or multiplexer can report the mouse when
     /// spyc never asked — a foreground child that died without resetting, for
     /// one. Acting on those with the feature off is how a stray middle click

--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -379,6 +379,7 @@ impl super::App {
             }
             MouseSink::PaneForward => self.forward_to_child(ev, &layout),
             MouseSink::PaneScrollKeys => self.send_scroll_keys(delta),
+            MouseSink::PaneHistory => self.wheel_into_pane_history(delta),
 
             MouseSink::FocusAndSelect(slot) => {
                 // The pager's OWN region, not the one the layout says is under the
@@ -581,7 +582,11 @@ mod tests {
         );
         app.runtime.pane_tabs = Some(crate::pane::tabs::PaneTabs::new(entry));
         let tabs = app.runtime.pane_tabs.as_mut().expect("a pane tab");
-        let feed: String = (0..80).map(|i| format!("history line {i}\n")).collect();
+        let mut feed = String::new();
+        for i in 0..80 {
+            use std::fmt::Write as _;
+            let _ = writeln!(feed, "history line {i}");
+        }
         tabs.active_mut()
             .send_bytes(feed.as_bytes())
             .expect("write to the pty");
@@ -651,6 +656,49 @@ mod tests {
                 app.runtime.pane_scroll_settle.is_some() || app.view.scroll_pager.is_some(),
                 "a sustained wheel-up over an inline agent must reach for the pane's \
                  captured history; instead the tick vanished"
+            );
+        });
+    }
+
+    /// The two ways the same gesture must leave the pane alone: a DOWN tick,
+    /// because the live screen already IS the bottom (opening there is what put
+    /// the agent-view path into an open/close flicker loop), and
+    /// `[mouse] pane_scroll_view = "off"`, the documented way back to the old
+    /// silence for anyone who wants their wheel to do nothing here.
+    #[test]
+    fn a_down_tick_or_pane_scroll_view_off_leaves_the_pane_alone() {
+        let _lock = crate::mouse_test_lock();
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let dir = tmp.path().join("work");
+            std::fs::create_dir(&dir).unwrap();
+            let mut app = App::test_app(dir.clone());
+            app.view.term_size = (120, 24);
+            inline_agent_pane_with_history(&mut app, &dir);
+            crate::set_mouse_capture_for_test(true);
+            let layout = app.frame_layout(ratatui::layout::Rect::new(0, 0, 120, 24));
+            let pane_rect = layout.pane.expect("a pane is open");
+            let point = (pane_rect.x + 2, pane_rect.y + 1);
+            let reached_for_history =
+                |a: &App| a.runtime.pane_scroll_settle.is_some() || a.view.scroll_pager.is_some();
+
+            for _ in 0..(super::route::OPEN_AFTER_UP_TICKS * 2) {
+                app.handle_mouse(at(MouseEventKind::ScrollDown, point.0, point.1));
+            }
+            assert!(
+                !reached_for_history(&app),
+                "scrolling DOWN past the live screen must not open history"
+            );
+
+            app.view.pane_scroll_streak = None;
+            app.state.config.mouse.pane_scroll_view = crate::config::PaneScrollView::Off;
+            for _ in 0..(super::route::OPEN_AFTER_UP_TICKS * 2) {
+                app.handle_mouse(at(MouseEventKind::ScrollUp, point.0, point.1));
+            }
+            crate::set_mouse_capture_for_test(false);
+            assert!(
+                !reached_for_history(&app),
+                "pane_scroll_view = \"off\" must keep the wheel silent over the pane"
             );
         });
     }

--- a/src/app/mouse/route.rs
+++ b/src/app/mouse/route.rs
@@ -70,6 +70,16 @@ pub enum MouseSink {
     /// so the translation can't degenerate into the wheel-to-arrows history
     /// cycling that `[mouse] capture` exists to avoid.
     PaneScrollKeys,
+    /// Scroll the history spyc itself captured for the pane, via `^a v`'s own
+    /// pager ([`crate::app::App::wheel_into_pane_history`]).
+    ///
+    /// For a child that neither speaks mouse nor has a verified scroll key —
+    /// claude in its default (inline) TUI mode, a plain shell. There is no
+    /// third party to ask: inside a pane spyc IS the terminal, so the scrollback
+    /// it captured is the only history the wheel can be asking for. Distinct
+    /// from [`Self::PaneScrollKeys`], which drives a view the CHILD owns and
+    /// spyc cannot see.
+    PaneHistory,
     /// Give the keyboard to the pane AND forward the event to its child — the
     /// left-click-through contract. Both halves, in one variant, because a sink
     /// that only forwarded was how the focus half came to be silently missing
@@ -536,17 +546,25 @@ pub const fn route_mouse(snap: MouseSnapshot, gesture: Gesture) -> MouseSink {
         Region::Pane => {
             if snap.can_forward_to_child() {
                 MouseSink::PaneForward
-            } else if snap.pane_scroll_keys && !snap.pane_closed && !snap.has_scroll_pager {
+            } else if snap.pane_closed || snap.has_scroll_pager {
+                // The same two guards forwarding uses, hoisted so every arm below
+                // inherits them: a dead child has nothing to scroll, and a `^a v`
+                // pager owns the pane's rect (its own wheel handling is claimed
+                // above by `covering_pager`), so anything here would move
+                // something the user cannot see.
+                MouseSink::Swallow
+            } else if snap.pane_scroll_keys {
                 // The child ignores mouse reports but scrolls on a keypress
-                // (agy). Same two guards forwarding uses: a dead child has
-                // nothing to scroll, and a `^a v` pager owns the pane's rect, so
-                // keys would scroll a child the user can't see.
+                // (agy, codex).
                 MouseSink::PaneScrollKeys
             } else {
-                // No verified scroll key and nothing to forward (codex): silence
-                // beats typing `\e[<64;20;5M` — or a history-recalling Up — into
-                // a child that never asked for either.
-                MouseSink::Swallow
+                // Nothing to forward and no verified scroll key: claude in its
+                // default inline TUI mode, or a plain shell. Forwarding is still
+                // out — it types `\e[<64;20;5M` into a child that never asked
+                // (the #170 class) — and so is synthesizing an Up that usually
+                // recalls prompt history. What's left is spyc's OWN capture of
+                // this pane, which is the history the wheel is reaching for.
+                MouseSink::PaneHistory
             }
         }
         // Chrome. Nothing to scroll, and clicking it is a later addition (tab
@@ -808,14 +826,16 @@ mod tests {
         assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::PaneForward);
     }
 
+    /// A child that never enabled mouse mode is never forwarded to — that's the
+    /// #170 class, `\e[<64;20;5M` typed into its prompt. With no verified scroll
+    /// key either (inline claude, a plain shell) the wheel scrolls the history
+    /// **spyc** captured for the pane; silence was the old answer, and it read as
+    /// "scrolling doesn't work".
     #[test]
-    fn pane_child_without_mouse_mode_swallows_never_forwards() {
-        // The #170 class: forwarding to a child that never enabled mouse mode
-        // types `\e[<64;20;5M` into its prompt. Silence is the correct answer for
-        // a child with no verified scroll key either (codex).
+    fn pane_child_without_mouse_mode_gets_spycs_history_never_a_forward() {
         let s = snap(Some(Region::Pane));
         assert!(!s.pane_wants_mouse && !s.pane_scroll_keys);
-        assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::Swallow);
+        assert_eq!(route_mouse(s, Gesture::Wheel), MouseSink::PaneHistory);
     }
 
     /// An agent that ignores mouse reports but scrolls on a keypress (agy) gets
@@ -844,21 +864,25 @@ mod tests {
 
     /// Same two guards forwarding uses. A dead child has nothing to scroll, and a
     /// `^a v` pager owns the pane's rect — scrolling the child behind it would move
-    /// something the user cannot see.
+    /// something the user cannot see. Covers both non-forward arms: with a verified
+    /// scroll key and without one (where the wheel would otherwise reach for
+    /// spyc's own capture), since both would act on a pane that isn't there.
     #[test]
-    fn scroll_keys_are_suppressed_for_a_dead_or_covered_child() {
-        for (closed, covered) in [(true, false), (false, true)] {
-            let s = MouseSnapshot {
-                pane_scroll_keys: true,
-                pane_closed: closed,
-                has_scroll_pager: covered,
-                ..snap(Some(Region::Pane))
-            };
-            assert_eq!(
-                route_mouse(s, Gesture::Wheel),
-                MouseSink::Swallow,
-                "closed={closed} covered={covered}"
-            );
+    fn wheel_over_the_pane_is_suppressed_for_a_dead_or_covered_child() {
+        for keys in [true, false] {
+            for (closed, covered) in [(true, false), (false, true)] {
+                let s = MouseSnapshot {
+                    pane_scroll_keys: keys,
+                    pane_closed: closed,
+                    has_scroll_pager: covered,
+                    ..snap(Some(Region::Pane))
+                };
+                assert_eq!(
+                    route_mouse(s, Gesture::Wheel),
+                    MouseSink::Swallow,
+                    "scroll_keys={keys} closed={closed} covered={covered}"
+                );
+            }
         }
     }
 

--- a/src/app/mouse/scroll.rs
+++ b/src/app/mouse/scroll.rs
@@ -9,8 +9,8 @@
 
 use super::super::Effect;
 use super::route::{
-    AgentViewAction, AgentViewInputs, PendingViewIntent, TOGGLE_SETTLE, decide_agent_view_action,
-    pending_view_confirmed, scroll_streak_step,
+    AgentViewAction, AgentViewInputs, OPEN_AFTER_UP_TICKS, PendingViewIntent, TOGGLE_SETTLE,
+    decide_agent_view_action, pending_view_confirmed, scroll_streak_step,
 };
 
 impl super::super::App {
@@ -18,6 +18,56 @@ impl super::super::App {
     pub(super) fn active_pane_wheel_scroll(&self) -> Option<crate::agent::WheelScroll> {
         let tabs = self.runtime.pane_tabs.as_ref()?;
         crate::agent::detect(&tabs.active_info().command).wheel_scroll()
+    }
+
+    /// A wheel tick over a pane whose child neither speaks mouse nor has a
+    /// verified scroll key: show the history **spyc** captured for it, through
+    /// `^a v`'s own pager.
+    ///
+    /// This is claude in its default (inline) TUI mode and any plain child. There
+    /// is no third party to delegate to — inside a pane spyc IS the terminal, so
+    /// its capture is the only history that exists, and swallowing the tick (the
+    /// old answer) reads as "scrolling doesn't work".
+    ///
+    /// Gated exactly as an agent's own view is: only a sustained scroll UP opens
+    /// history, since one stray tick shouldn't swap the pane out from under the
+    /// user, and `[mouse] pane_scroll_view = "off"` keeps the old silence. A DOWN
+    /// tick has nowhere to go — the live screen already is the bottom.
+    ///
+    /// Empty scrollback is deliberately NOT checked here:
+    /// [`Self::open_pane_scroll_pager`] routes to an agent's transcript when
+    /// there is one, and otherwise flashes why the capture is empty — the same
+    /// outcome with the reason attached, which is what silence was missing.
+    pub(super) fn wheel_into_pane_history(&mut self, delta: i32) -> Vec<Effect> {
+        if matches!(
+            self.state.config.mouse.pane_scroll_view,
+            crate::config::PaneScrollView::Off
+        ) {
+            return Vec::new();
+        }
+        // Already showing (or about to show) this pane's history: the mounted
+        // pager claims the wheel itself via `covering_pager`, and re-entering
+        // during the snapshot's settle window would respawn a transcript worker
+        // per tick.
+        if self.view.scroll_pager.is_some() || self.runtime.pane_scroll_settle.is_some() {
+            return Vec::new();
+        }
+        let Some(tabs) = self.runtime.pane_tabs.as_ref() else {
+            return Vec::new();
+        };
+        let dir: i8 = if delta < 0 { -1 } else { 1 };
+        let (streak, _) = scroll_streak_step(
+            self.view.pane_scroll_streak,
+            tabs.active_index(),
+            dir,
+            std::time::Instant::now(),
+        );
+        self.view.pane_scroll_streak = Some(streak);
+        if dir >= 0 || streak.ticks < OPEN_AFTER_UP_TICKS {
+            return Vec::new();
+        }
+        self.open_pane_scroll_pager();
+        Vec::new()
     }
 
     /// Translate a wheel tick into the child's own scroll keys.


### PR DESCRIPTION
A user reported "scrolling doesn't working with claude". They weren't in
`/tui fullscreen`.

## What was broken

claude has two TUI modes, and spyc's pane routing only ever accounted for one.
Captured from a pty, both modes:

| | `tui: "default"` (inline, the out-of-the-box mode) | `tui: "fullscreen"` |
|---|---|---|
| `?1049h` alternate screen | — | yes |
| `?1000/1002/1003/1006h` mouse | **none** | all four |
| DECSTBM scroll region | none | none |

So inline claude has nothing to forward a wheel report to, and spyc has no
verified `wheel_scroll()` key to synthesize for it (correctly — claude's own
Up recalls prompt history). `route_mouse`'s `Region::Pane` ladder therefore fell
through to `MouseSink::Swallow`: the tick vanished, with no message explaining
why. A plain shell pane hit the identical dead end.

## The fix

Inside a pane spyc **is** the terminal, so the scrollback spyc captured is the
history the wheel is reaching for. A new `MouseSink::PaneHistory` arm opens
`^a v`'s own pager on a sustained wheel-up.

Unlike codex — whose DECSTBM region keeps completed turns off the main buffer, so
zero rows reach the emulator — inline claude's output *does* reach the main
buffer, so there is genuinely a capture to show. That asymmetry is why this arm
is right here and stays wrong for codex, which keeps its existing scroll-keys arm.

Gated exactly as an agent's own view is, reusing `scroll_streak_step` /
`OPEN_AFTER_UP_TICKS` rather than inventing a second notion of "sustained":

- **up only** — the live screen already is the bottom; opening on a down tick is
  what put the codex path in an open/close flicker loop
- **`OPEN_AFTER_UP_TICKS`** — one stray tick shouldn't swap the pane out from
  under the user
- **`[mouse] pane_scroll_view = "off"`** — keeps the old silence for anyone who
  wants their wheel inert over the pane

Empty scrollback is deliberately not special-cased: `open_pane_scroll_pager`
already routes to a transcript when there is one and otherwise flashes why the
capture is empty — the same outcome with the reason attached, which is precisely
what silence was missing.

## Notes for review

- **The dead-child / covered-by-a-pager guards are hoisted** ahead of both
  non-forward arms. They previously lived on the scroll-keys arm alone; copying
  them onto a third arm would be two derivations of one fact, and they'd drift.
- **A plain shell pane is fixed by the same arm** — it had the same silent wheel.
  Intentional scope, called out in the commit.
- **Select & copy needed nothing.** `pane_is_selectable()` is the exact
  complement of `can_forward_to_child()`, so a child that requests no mouse modes
  already gets spyc's own drag-select over the grid, copied on release. The wheel
  was the only asymmetric gesture, because its ladder has a third condition
  (`pane_scroll_keys`) that claude fails.
- **No new detection machinery.** The observed `?1049h` and `wants_mouse` already
  discriminate the modes, and they stay correct when `/tui` is flipped
  mid-session — which reading `~/.claude/settings.json` would not.

## Tests

`test(mouse):` lands first and was **verified red** before the fix, failing on
the history assertion after passing its two premise assertions (no mouse modes,
no scroll key) — so it fails loudly rather than silently passing if claude ever
starts speaking mouse inline. It drives the real `handle_mouse` entry against a
real pty whose captured scrollback is polled for, not assumed.

The negative gates (down-tick, `pane_scroll_view = "off"`) were bite-checked by
removing the direction guard: the test fails without it.

`make check-ci` → `=== GATE: PASS ===`. Hand-tested inline and fullscreen from a
release build.

## Docs

`docs/HARNESS.md` described fullscreen as claude's only shape and claimed `^a v`
always reads its transcript — both false inline. The claude row is now split per
mode, with the mode's own naming (`"default"` / `"fullscreen"`, and that an
invalid value makes claude skip the entire settings file) and a note that
selection follows the same fork for free.

Generated with [Claude Code](https://claude.com/claude-code)
