### PR TITLE
test(archive): a corrupt DOS date is tested against spyc, not against the zip crate

### DIFF
--- a/src/archive/read/mod.rs
+++ b/src/archive/read/mod.rs
@@ -657,6 +657,13 @@ fn apply_mode(_dest: &Path, _mode: Option<u32>) {}
 /// A zip's DOS timestamp carries no timezone; every tool reads it as local wall
 /// time. We take it as UTC so the same archive lists identically everywhere,
 /// which matters more here than agreeing with the machine that wrote it.
+///
+/// The `.ok()?` chain is belt-and-braces, not the live guard: `zip` validates on
+/// parse (`try_from_msdos(..).ok()`), so a corrupt DOS field reaches this as
+/// `last_modified() == None` and never gets here. Reaching it would take
+/// `DateTime::from_msdos_unchecked`, which is `unsafe`. The user-visible half —
+/// a corrupt date lists with no mtime rather than an invented one — is pinned by
+/// `an_impossible_date_reads_as_no_timestamp`.
 fn zip_mtime(dt: zip::DateTime) -> Option<SystemTime> {
     let date = jiff::civil::Date::new(
         i16::try_from(dt.year()).ok()?,

--- a/src/archive/read/tests.rs
+++ b/src/archive/read/tests.rs
@@ -518,11 +518,76 @@ fn a_dos_timestamp_converts_to_a_real_instant() {
     );
 }
 
+/// **A member with a corrupt DOS timestamp still lists, with no timestamp.**
+///
+/// The requirement is about the archive, not about one function: month 0 / day 0
+/// is not a date, so the row must show no mtime rather than a crash or an
+/// invented one.
+///
+/// The old version of this test asserted
+/// `zip::DateTime::from_date_and_time(2026, 0, 0, …).is_err()` — the `zip`
+/// crate's own constructor, never touching spyc. Driven end to end instead,
+/// which is the only way the shape occurs for real: every checked constructor
+/// refuses an impossible date, so one can arrive only by being *parsed* out of
+/// an archive.
+///
+/// Worth knowing where the guard actually is: `zip` validates on parse
+/// (`try_from_msdos(..).ok()`), so `last_modified()` answers `None` and
+/// [`zip_mtime`] is never reached with an invalid date at all. Its own
+/// `.ok()?` chain is belt-and-braces against that changing, and this test does
+/// not — cannot — exercise it; reaching it needs `DateTime::from_msdos_unchecked`,
+/// which is `unsafe`. What this pins is the user-visible half.
 #[test]
-fn an_impossible_date_does_not_panic() {
-    // A corrupt DOS field can name day 0 or month 0; that must read as
-    // "no timestamp", not a crash on the indexing worker.
-    assert!(zip::DateTime::from_date_and_time(2026, 0, 0, 0, 0, 0).is_err());
+fn an_impossible_date_reads_as_no_timestamp() {
+    let tmp = tempfile::tempdir().unwrap();
+    let intact = tmp.path().join("intact.zip");
+    zip_at(&intact, &[("a.txt", b"hi", 0o644)]);
+    // The premise: an untouched archive of the same shape DOES carry a
+    // timestamp. Without this the assertion below could pass on a build that
+    // never reads mtimes at all.
+    assert!(
+        index_seekable(&intact, ArchiveFormat::Zip, 1000)
+            .unwrap()
+            .index
+            .get("a.txt")
+            .and_then(|e| e.mtime)
+            .is_some(),
+        "the fixture must have a timestamp to lose"
+    );
+
+    let archive = tmp.path().join("corrupt-date.zip");
+    zip_at(&archive, &[("a.txt", b"hi", 0o644)]);
+    zero_dos_timestamps(&archive);
+
+    let indexed = index_seekable(&archive, ArchiveFormat::Zip, 1000).unwrap();
+    let entry = indexed.index.get("a.txt").expect("the member still lists");
+    assert_eq!(
+        entry.mtime, None,
+        "month 0 / day 0 is not a date — drop the timestamp, don't invent one"
+    );
+}
+
+/// Zero the DOS mod-time/mod-date fields in every local header and central
+/// directory record, giving month 0 and day 0 — what a truncated or corrupt
+/// archive carries, and what no `zip` constructor will build.
+fn zero_dos_timestamps(path: &Path) {
+    let mut bytes = std::fs::read(path).expect("read the zip");
+    // Local file header: PK, then version/flags/method (6 bytes),
+    // then modtime+moddate. Central directory: PK, with two extra
+    // version fields ahead of the same pair.
+    for i in 0..bytes.len().saturating_sub(4) {
+        let off = match &bytes[i..i + 4] {
+            [0x50, 0x4b, 0x03, 0x04] => Some(i + 10),
+            [0x50, 0x4b, 0x01, 0x02] => Some(i + 12),
+            _ => None,
+        };
+        if let Some(o) = off
+            && o + 4 <= bytes.len()
+        {
+            bytes[o..o + 4].fill(0);
+        }
+    }
+    std::fs::write(path, bytes).expect("write the patched zip");
 }
 
 // --- containment: a link may not decide where a later member lands ---


### PR DESCRIPTION
**M20** of the pre-2.1 review (`F-tests-guards.md`, F12b) — `medium`, and the
report's "clearest single 'asserts the mock' instance in the diff".

The whole body of `an_impossible_date_does_not_panic` was:

```rust
assert!(zip::DateTime::from_date_and_time(2026, 0, 0, 0, 0, 0).is_err());
```

That is a test of a third-party constructor. The name and comment promised that
`zip_mtime` survives a corrupt DOS field on the indexing worker; `zip_mtime` was
never called.

## What replaced it, and why not what the finding asked for

The finding's suggested fix — "call `zip_mtime` with the impossible `DateTime`" —
turns out not to be reachable. I only found that out because **my first
replacement didn't bite**: driving a corrupt archive through `index_seekable`
passed even with `zip_mtime` rewritten to panic on an invalid date.

Cause: `zip` validates on parse (`read.rs:547`,
`last_modified_time: DateTime::try_from_msdos(..).ok()`), so `last_modified()`
answers `None` and `zip_mtime` is never handed an invalid `DateTime` at all.
Constructing one takes `DateTime::from_msdos_unchecked`, which is `unsafe` — and
this project treats `unsafe` as exceptional rather than expedient. Spending it to
reach a belt-and-braces branch that the crate already shields isn't the trade.

So the test pins the **requirement** rather than the function: a member whose DOS
date names month 0 / day 0 still lists, with no mtime — not a crash, and not an
invented timestamp. That is the user-visible property, and it holds wherever the
guard happens to live.

Built end to end, because the shape can't be written: every checked constructor
refuses an impossible date, so the fixture patches the mod-time/mod-date fields
in the local headers and central directory afterwards — the same technique the
zip-slip fixture already uses for a tar header `tar::Builder` won't emit.

It asserts its own premise first: an untouched archive of the same shape *does*
carry a timestamp, so the assertion can't pass on a build that never reads mtimes
at all.

**Bite-checked** on the regression it actually guards — making `index_zip` fall
back to `SystemTime::UNIX_EPOCH` when the date is unreadable:

```
left: Some(SystemTime { tv_sec: 0, tv_nsec: 0 })
right: None
```

## And the comment now says where the guard is

`zip_mtime`'s doc records that its `.ok()?` chain is belt-and-braces rather than
the live guard, and which test covers the half that is reachable. Without that,
the next reader repeats exactly the investigation above — and the previous
version of this test is evidence that they will.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)