### PR TITLE
test(guards): the per-column allowlist stopped guarding the file it was written for

### DIFF
--- a/src/app/mod_tests.rs
+++ b/src/app/mod_tests.rs
@@ -35,20 +35,6 @@ mod guard_tests {
         );
     }
 
-    /// `state.left`/`right` address a SPECIFIC column (render draws both
-    /// explicitly; the fs-watch dedup-keys per column). "Where the user is
-    /// working" — a spawn cwd, a restore target, the dir an op acts on — must
-    /// use `cur()`/`cur_mut()` so a focused second commander is honored. The
-    /// June-2026 vsplit review found six spawn/restore sites stranded on
-    /// `state.left.listing.dir` (`:;`, the bare pane spawn, pager-edit,
-    /// graveyard restore, …). A new read outside the allowlist is that smell —
-    /// route it through `cur()`, or (if it's genuinely the left column) add the
-    /// file to ALLOW with a why. See AGENTS.md → per-column scoping.
-    ///
-    /// Allowlisted: the left-column fs-watch dedup keys (`run.rs`; the right
-    /// column has its own `watched_listing_right`), the startup `initial_cwd`
-    /// (`bootstrap.rs`, pre-split), and the status-bar header (`chrome.rs`,
-    /// deliberately anchored to the primary column).
     /// A user-visible error must carry its CAUSE, not just its context line.
     ///
     /// anyhow's plain `Display` (`{e}`) prints only the OUTERMOST context and
@@ -107,9 +93,30 @@ mod guard_tests {
         );
     }
 
+    /// `state.left`/`right` address a SPECIFIC column (render draws both
+    /// explicitly; the fs-watch dedup-keys per column). "Where the user is
+    /// working" — a spawn cwd, a restore target, the dir an op acts on — must
+    /// use `cur()`/`cur_mut()` so a focused second commander is honored. The
+    /// June-2026 vsplit review found six spawn/restore sites stranded on
+    /// `state.left.listing.dir` (`:;`, the bare pane spawn, pager-edit,
+    /// graveyard restore, …). A new read outside the allowlist is that smell —
+    /// route it through `cur()`, or (if it's genuinely the left column) add the
+    /// file to ALLOW with a why. See AGENTS.md → per-column scoping.
+    ///
+    /// Allowlisted: the left-column fs-watch dedup keys (`run.rs`; the right
+    /// column has its own `watched_listing_right`) and the startup `initial_cwd`
+    /// (`bootstrap.rs`, pre-split). **Not** the status bar — `render/chrome.rs`
+    /// was exempted as "deliberately anchored to the primary column", which
+    /// stopped being true when #322 made the status bar describe the focused
+    /// column and `the_status_bar_describes_the_focused_column` pinned it. An
+    /// exemption outliving its reason is worse than none: it pre-approves the
+    /// regression in the one file that had just been fixed for it.
+    ///
+    /// Entries are matched on the path relative to `src/app`, not the bare file
+    /// name — `chrome.rs` exempted every file so named at any depth.
     #[test]
     fn state_left_listing_dir_uses_are_allowlisted() {
-        const ALLOW: &[&str] = &["run.rs", "bootstrap.rs", "chrome.rs"];
+        const ALLOW: &[&str] = &["run.rs", "bootstrap.rs"];
         // Split so this guard's own source can't match the needle.
         let needle = format!("{}{}", "state.left", ".listing.dir");
         let app = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/app");
@@ -118,9 +125,13 @@ mod guard_tests {
             // Production portion only — a `#[cfg(test)]` block may legitimately
             // poke `state.left` to set up a fixture.
             let production = crate::guard_support::production_half(src);
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if production.contains(&needle) && !ALLOW.contains(&name) {
-                offenders.push(name.to_string());
+            let rel = path
+                .strip_prefix(&app)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .into_owned();
+            if production.contains(&needle) && !ALLOW.contains(&rel.as_str()) {
+                offenders.push(rel);
             }
         });
         offenders.sort();
@@ -153,9 +164,13 @@ mod guard_tests {
         let mut offenders = Vec::new();
         scan_rs(&app, &mut |path, src| {
             let production = crate::guard_support::production_half(src);
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if production.contains(&needle) && !ALLOW.contains(&name) {
-                offenders.push(name.to_string());
+            let rel = path
+                .strip_prefix(&app)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .into_owned();
+            if production.contains(&needle) && !ALLOW.contains(&rel.as_str()) {
+                offenders.push(rel);
             }
         });
         offenders.sort();


### PR DESCRIPTION
**F10** and **F11** of the pre-2.1 review (`F-tests-guards.md`) — both `low`,
both live on HEAD, both in `src/app/mod_tests.rs`, both the same shape: this
file drifted and nothing noticed. Splitting them would put two three-line diffs
through the same review of the same function.

## F10 — a stale exemption pre-approves the regression it was written to catch

```rust
const ALLOW: &[&str] = &["run.rs", "bootstrap.rs", "chrome.rs"];
```

`chrome.rs` was exempted as "the status-bar header, deliberately anchored to the
primary column". That was true at v2.0.0. Then `b1478f1` *fix(status): the
status bar describes the focused column, not always column a (#322)* landed in
this same window — removing the read, reversing the rationale, and adding
`the_status_bar_describes_the_focused_column` to pin the new behaviour.

The exemption stayed. So `render/chrome.rs` — the one file that had just been
fixed for this exact bug — was the one file free to reintroduce it.

**Bite-checked, both directions.** With a `state.left.listing.dir` read injected
into `render/chrome.rs`'s production half:

- HEAD's guard: `test result: ok. 1 passed` — silent.
- After this change: fails with ``state.left.listing.dir` read outside the
  allowlist in: ["render/chrome.rs"]`.

Secondary, fixed here too: entries matched on `file_name()`, so `chrome.rs`
exempted *any* file so named at any depth under `src/app`. Matching is now on
the path relative to `src/app`, which is also what the failure message now
prints — `render/chrome.rs` rather than the ambiguous `chrome.rs`.

## F11 — the doc block describes the wrong function

`flashed_errors_render_their_whole_chain` was inserted *into the middle of*
`state_left_listing_dir_uses_are_allowlisted`'s doc comment (the diff hunk
`@@ -49,6 +49,45 @@` shows the splice). The result: the per-column rationale and
the allowlist explanation were attached to the anyhow-cause guard, and the guard
they belong to had no doc comment at all — while the house style asks every guard
to carry the failure that motivated it.

Moved back. No behaviour in this half; it is why F10 was possible to miss, since
the sentence naming `chrome.rs` was nowhere near the constant listing it.

`make check-ci` → `=== GATE: PASS ===`.