### PR TITLE
fix(archive): the entry cap bounds the index, not just the walk

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -276,6 +276,14 @@ write_back = "ask"         # "ask" | "never" — offer to write pending changes
 snapshot_max_mb = 64       # graveyard-snapshot the original below this size
 ```
 
+`max_entries` bounds the index spyc builds — members walked plus the directories
+it synthesizes for them — and a listing that hit it says it is truncated. It does
+**not** bound what the container's own parser does first: `zip` materializes one
+record per central-directory entry before spyc sees any of them, so a zip with a
+genuinely huge central directory is fully resident whatever the cap says. (The
+crate does guard its pre-allocation against a lying entry count, so a small file
+can't force a large one.)
+
 `max_depth` is about disk, not correctness: a container inside a container has to
 be copied out whole before anything can read it, so every level costs its own
 size in staging. Set it to 0 to refuse nested archives entirely.

--- a/src/archive/index.rs
+++ b/src/archive/index.rs
@@ -380,6 +380,16 @@ impl IndexBuilder {
         implied.dedup();
         self.facts.implied_dirs = implied.len();
         for inner in implied {
+            // The cap bounds the index, not just the walk. `push` stops at it;
+            // without the same check here a deeply-nested archive left it far
+            // behind (three members five deep produced eighteen entries against
+            // a cap of three), and the "capped at N members" warning then named
+            // a number that hadn't held for a while. Sorted, so the ancestors
+            // that do fit are the shallowest — the reachable prefix of the tree.
+            if self.entries.len() >= self.cap {
+                self.truncated = true;
+                break;
+            }
             // Through the same counter as a real member: a synthesized `a/`
             // beside a stored `A/` is still a collision on a case-insensitive
             // volume, and handing it rank 0 unconditionally would put two
@@ -671,6 +681,30 @@ mod tests {
         let (index, _) = b.finish(PathBuf::from("/a.zip"), ArchiveFormat::Zip, 10);
         assert!(index.truncated);
         assert_eq!(index.entries.len(), 2);
+    }
+
+    /// The cap has to bound the *index*, not just the walk.
+    ///
+    /// `push` stops at the cap, but `finish` then synthesized every implied
+    /// ancestor with no check — so deeply-nested members carried the index past
+    /// `[archive] max_entries` and the "capped at N members" warning named a
+    /// number the index had already left behind.
+    #[test]
+    fn the_entry_cap_bounds_the_directories_finish_synthesizes() {
+        let mut b = IndexBuilder::new(3);
+        // Three members, each five directories deep: 3 pushed + 15 implied
+        // ancestors, all synthesized at `finish`.
+        for name in ["p/q/r/s/t/1.txt", "u/v/w/x/y/2.txt", "d/e/f/g/h/3.txt"] {
+            assert_ne!(b.push(name, Draft::file(1, Locator::Staged)), Pushed::Full);
+        }
+        let (index, _) = b.finish(PathBuf::from("/a.zip"), ArchiveFormat::Zip, 10);
+        assert_eq!(
+            index.entries.len(),
+            3,
+            "the index grew past its own cap: {:?}",
+            index.entries.iter().map(|e| &e.inner).collect::<Vec<_>>()
+        );
+        assert!(index.truncated, "and must say the listing is short");
     }
 
     /// Two names differing only by case would overwrite each other on a

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -197,8 +197,11 @@
 #                        without decompressing it). Over this, the mount
 #                        is refused rather than filling the disk.
 #   warn_over_mb       (default 128)    confirm before extracting more.
-#   max_entries        (default 200000) cap on indexed members; past it
-#                        the listing shows itself as truncated.
+#   max_entries        (default 200000) cap on indexed members, including
+#                        the directories spyc synthesizes for them; past it
+#                        the listing shows itself as truncated. Bounds
+#                        spyc's index, not the zip parser's own read of
+#                        the central directory, which happens first.
 #   max_depth          (default 2)      how deep archives may nest. A
 #                        container inside a container has to be copied
 #                        out whole before it can be read, so each level


### PR DESCRIPTION
**A-LOW-4** of the pre-2.1 review (`A-archive.md`) — `low`, live on HEAD.
Carries **A-LOW-5** with it: both are about what `[archive] max_entries` bounds,
and settling that in two PRs would mean two edits to the meaning of one knob.

`IndexBuilder::push` stops at `cap` and reports `Pushed::Full` so the caller
stops walking. Then `finish` called `synthesize_implied_dirs`, which pushed every
implied ancestor straight onto `entries` with no check at all.

Measured by the new test: **three members, five directories deep, against a cap
of three → an index of eighteen.** Six times the cap, and the
`index capped at N members` warning went on naming a number the index had left
behind — the listing said "truncated at 3" while holding 18.

The synthesis is bounded by the same cap now, and sets `truncated` when it bites.
`implied` is already sorted, so the ancestors that do fit are the shallowest —
the reachable prefix of the tree rather than an arbitrary slice of it. A member
whose ancestor didn't fit is unreachable by walking, which is what `truncated`
already tells the user about every capped listing.

## A-LOW-5 — the doc half

`max_entries` reads as though it bounds the cost of opening a container. It
doesn't: `ZipArchive::new` runs before the cap applies and materializes one
`ZipFileData` per central-directory record — three boxed strings/slices, two
`Arc<[u8]>`, a `Vec<ExtraField>` — for every record, before spyc sees the first
entry. The crate does guard its pre-allocation against a lying `number_of_files`,
so a small file can't force a huge reservation, but a genuinely large central
directory is fully resident regardless.

`CONFIGURATION.md` and the `--print-config` template now say what the cap covers
(including the synthesized directories this commit brought under it) and what
happens before it.

## Test

`the_entry_cap_bounds_the_directories_finish_synthesizes` — red before at
`left: 18, right: 3`, and prints the whole entry list so the failure names the
ancestors that shouldn't be there.

**Bite-checked** by removing the cap check: **259 of the 260 archive tests still
pass**, only this one reports — including
`the_entry_cap_truncates_and_stops_the_walk`, which covers the other half of the
same cap and is what made this look covered.

`make check-ci` → `=== GATE: PASS ===`.