### PR TITLE
test(archive): pin why an escaping link doesn't make the mount read-only

### DIFF
--- a/src/archive/scan.rs
+++ b/src/archive/scan.rs
@@ -37,8 +37,11 @@ pub struct IndexFacts {
     pub hardlinks: usize,
     /// tar members that are neither file, dir, nor symlink (fifo, device).
     pub specials: usize,
-    /// Symlink members whose target escapes the mount, listed but never created
-    /// on disk.
+    /// Symlink members whose target escapes the mount: listed, never created on
+    /// disk, and rebuilt from this index on write-back — see [`assess`] for why
+    /// that last part is what keeps the mount writable. Only ever nonzero for a
+    /// *streamed* mount; a seekable container extracts nothing at index time, so
+    /// no link is attempted and none is refused.
     pub escaping_links: usize,
     /// Members whose destination was only reachable by traversing a symlink, so
     /// nothing was written for them. Distinct from [`Self::escaping_links`]: that
@@ -100,6 +103,17 @@ impl Capability {
 /// survive verbatim even though spyc can't read them. tar has no such escape:
 /// its members are rebuilt from captured header fields, so a hardlink or device
 /// node — which those fields can't express — makes the archive read-only.
+///
+/// [`IndexFacts::escaping_links`] does not fail it either, which reads at first
+/// like an inconsistency with `skipped()`: both are members spyc declined to
+/// create on disk. The difference is that the rule is about **reproducing**, not
+/// about extracting. A rejected name never entered the index, so a repack has
+/// nothing to write; an escaping link is a full index entry — kind, mode,
+/// `link_target` — and `write_tar` rebuilds it from exactly that, never from the
+/// staging tree it was kept out of. So it round-trips, and refusing to write the
+/// archive would cost the user their edits to protect a member that was never at
+/// risk. Pinned by `an_escaping_link_survives_a_repack_it_was_never_extracted_for`;
+/// the day that stops holding, this exemption has to go with it.
 pub fn assess(facts: &IndexFacts, format: ArchiveFormat) -> Capability {
     if facts.skipped() > 0 {
         return Capability::ReadOnly(format!(

--- a/src/archive/write.rs
+++ b/src/archive/write.rs
@@ -886,6 +886,94 @@ mod tests {
         );
     }
 
+    /// A member spyc refused to create on disk still has to come back.
+    ///
+    /// `assess` lets an archive containing an escaping symlink stay `ReadWrite`,
+    /// and that is only defensible because the repack rebuilds the link from the
+    /// **index** — which never lost it — rather than from the staging tree, where
+    /// it was deliberately never created. Nothing tested that, so the exemption
+    /// rested entirely on a reading of the code: a later change routing the
+    /// symlink branch through `symlink_metadata` (as the mode already is, for
+    /// staged members) would drop the link silently and turn the `ReadWrite`
+    /// verdict into data loss.
+    #[cfg(unix)]
+    #[test]
+    fn an_escaping_link_survives_a_repack_it_was_never_extracted_for() {
+        let tmp = tempfile::tempdir().unwrap();
+        let archive = tmp.path().join("links.tar.gz");
+        let staging = tmp.path().join("staging");
+        {
+            let enc = flate2::write::GzEncoder::new(
+                File::create(&archive).unwrap(),
+                flate2::Compression::default(),
+            );
+            let mut b = tar::Builder::new(enc);
+            let mut h = tar::Header::new_gnu();
+            h.set_entry_type(tar::EntryType::Symlink);
+            h.set_size(0);
+            h.set_mode(0o777);
+            b.append_link(&mut h, "escape", "../../../etc/passwd")
+                .unwrap();
+            let mut h2 = tar::Header::new_gnu();
+            h2.set_size(4);
+            h2.set_mode(0o644);
+            b.append_data(&mut h2, "drop.txt", &b"gone"[..]).unwrap();
+            b.into_inner().unwrap().finish().unwrap();
+        }
+        let indexed = read::stream_mount(
+            &archive,
+            ArchiveFormat::TarGz,
+            &staging,
+            u64::MAX,
+            1000,
+            &std::sync::atomic::AtomicBool::new(false),
+        )
+        .unwrap();
+
+        // The premises, so this can't pass for the wrong reason.
+        assert_eq!(indexed.facts.escaping_links, 1, "the link was refused");
+        assert!(
+            !staging.join("escape").exists(),
+            "and really is absent from staging"
+        );
+        assert_eq!(
+            crate::archive::scan::assess(&indexed.facts, ArchiveFormat::TarGz),
+            crate::archive::scan::Capability::ReadWrite,
+            "an escaping link does not demote the mount — this test is why"
+        );
+
+        // Write something else, so the link is a member carried across untouched.
+        let mut journal = Journal::default();
+        journal.delete("drop.txt");
+        let steps = plan_repack(
+            &indexed.index,
+            &journal,
+            &StagedStats::new(),
+            &StagedStats::new(),
+        );
+        repack(&indexed.index, &steps, &staging, &opts()).unwrap();
+
+        let after = read::stream_mount(
+            &archive,
+            ArchiveFormat::TarGz,
+            &tmp.path().join("staging2"),
+            u64::MAX,
+            1000,
+            &std::sync::atomic::AtomicBool::new(false),
+        )
+        .unwrap();
+        let link = after
+            .index
+            .get("escape")
+            .expect("the link is still a member");
+        assert_eq!(link.kind, ArchiveEntryKind::Symlink);
+        assert_eq!(
+            link.link_target.as_deref(),
+            Some("../../../etc/passwd"),
+            "and points where it always did"
+        );
+    }
+
     /// The refill must not undo the change being written: an edited staged copy is
     /// the pending change, so a member that IS there is left alone.
     #[test]


### PR DESCRIPTION
**A-LOW-1** of the pre-2.1 review (`A-archive.md`) — filed as `low`: "an escaping
symlink is a cosmetic warning, not a capability demotion", with the proposed fix
being to demote the mount.

**The premise doesn't hold, so the proposed fix is not the right one.** Measured
before writing anything:

```
PROBE escaping_links=1 capability=ReadWrite
PROBE repack=None                       (no error)
PROBE after: escape kind=Symlink target=Some("../../../etc/passwd")
```

`assess`'s rule is "a repack must be able to reproduce every member it isn't
deliberately changing" — and the link **is** reproduced, byte-identical in
target. So the exemption is consistent with the rule as written. The apparent
inconsistency with `skipped()` comes from reading the rule as *extracted*: a
rejected name never entered the index and a repack has nothing to write, while an
escaping link is a full index entry (kind, mode, `link_target`) that `write_tar`
rebuilds from exactly that, never from the staging tree it was kept out of.

Demoting would cost the user their pending edits to protect a member that was
never at risk.

## What is actually wrong: the exemption is load-bearing and undefended

Nothing tested the round trip. The `ReadWrite` verdict is only correct *because*
the symlink branch reads the index — and #392 has just shown that this file
already reads `symlink_metadata` for a staged member's mode. One change routing
the target the same way and the link vanishes on write-back, silently, with the
mount still cheerfully reporting itself writable.

`an_escaping_link_survives_a_repack_it_was_never_extracted_for` closes that. It
asserts its three premises first — the link was refused, it really is absent from
staging, and `assess` really does return `ReadWrite` — so it cannot pass for the
wrong reason, then deletes a *different* member so the link is carried across
untouched, and checks it comes back pointing where it always did.

**Bite-checked** by making the symlink branch read the target off disk instead of
the index: **259 of the 260 archive tests still pass**, only this one reports.
That is the finding's real content — the behaviour was right and nothing was
holding it there.

The `assess` doc now says why the counter carries no weight, which is the
omission that made a careful reviewer read it as an inconsistency (encrypted and
unknown-method members get exactly this paragraph; escaping links had none). The
field doc also records something the review surfaced: `escaping_links` is only
ever nonzero for a **streamed** mount — a seekable container extracts nothing at
index time, so no link is attempted and none is refused.

The finding's secondary concern — that the counter carrying no weight "matters if
a fix for BLOCKER-1 routes ladder detection through it" — is moot: #347 fixed the
ladder by deciding containment against the filesystem per path component, not
through this counter.

`make check-ci` → `=== GATE: PASS ===`.