### PR TITLE
test: three assertions that couldn't tell the pass from the failure

### DIFF
--- a/src/app/harness_tests/archive.rs
+++ b/src/app/harness_tests/archive.rs
@@ -534,9 +534,15 @@ fn eviction_hands_back_the_staging_tree_to_clean() {
 
 /// Run whatever the screen produced, then whatever the drain produced, until the
 /// effects settle — the loop's behaviour, minus the threads.
+/// The hop limit is a runaway guard, not a budget — reaching it means the chain
+/// grew past what this driver models, and every assertion after the call would
+/// then run against half-applied state and fail somewhere unrelated. Say so here
+/// instead.
+const SETTLE_HOPS: usize = 4;
+
 fn settle(app: &mut App, effects: Vec<Effect>) {
     let mut queue = effects;
-    for _ in 0..4 {
+    for _ in 0..SETTLE_HOPS {
         if queue.is_empty() {
             return;
         }
@@ -582,6 +588,12 @@ fn settle(app: &mut App, effects: Vec<Effect>) {
         next.extend(file_fx);
         queue = next;
     }
+    assert!(
+        queue.is_empty(),
+        "effects still pending after {SETTLE_HOPS} hops: {queue:?}. The chain got \
+         longer than this driver models — raise SETTLE_HOPS deliberately rather \
+         than letting the caller assert against half-applied state."
+    );
 }
 
 /// The issue's headline for this PR: `y` on a member puts its *contents* in the

--- a/src/app/mouse/route.rs
+++ b/src/app/mouse/route.rs
@@ -1249,16 +1249,33 @@ mod tests {
     /// with the status row. Frame row `R` inside a pane starting at row `Y` must
     /// reach the child as pane row `R - Y`; skipping this makes clicks land
     /// `pane.y` rows off, which reads as the child's bug rather than ours.
+    ///
+    /// Run over an offset frame origin as well as `0,0`. `compute_layout` gives
+    /// the pane `x == area.x`, which is 0 for every layout production reaches
+    /// today — so the column assertion below held equally whether `mouse_report`
+    /// subtracted the origin or ignored it, and dropping the subtraction was a
+    /// green change. The row half has had its `pane.y > 0` premise since it was
+    /// written; this is the same premise on the other axis.
     #[test]
     fn mouse_report_translates_into_the_panes_coordinate_space() {
         use crossterm::event::{KeyModifiers, MouseEvent, MouseEventKind};
 
-        for pos in [StatusPosition::Top, StatusPosition::Bottom] {
-            let layout = App::compute_layout(Rect::new(0, 0, 80, 24), true, 40, pos);
+        for (pos, origin_x) in [
+            (StatusPosition::Top, 0u16),
+            (StatusPosition::Top, 7),
+            (StatusPosition::Bottom, 0),
+            (StatusPosition::Bottom, 7),
+        ] {
+            let layout = App::compute_layout(Rect::new(origin_x, 0, 80, 24), true, 40, pos);
             let pane = layout.pane.expect("pane_open = true");
             assert!(
                 pane.y > 0,
                 "{pos:?}: pane must be offset for this to prove anything"
+            );
+            assert_eq!(
+                pane.x, origin_x,
+                "{pos:?}: the frame origin must reach the pane, or the column \
+                 assertions below prove nothing"
             );
 
             // Two rows into the pane, five columns in.

--- a/src/mcp/tests/mod.rs
+++ b/src/mcp/tests/mod.rs
@@ -1438,9 +1438,18 @@ fn searching_inside_a_mount_is_refused_rather_than_answered_emptily() {
             .as_str()
             .or_else(|| resp["result"]["content"][0]["text"].as_str())
             .unwrap_or_default();
+        // `isError` is the discriminating bit. Without it the assertion below
+        // is satisfied by an empty *answer* whose message merely names the
+        // archive path — which is the exact outcome this test's name exists to
+        // exclude, so the test could not tell a refusal from the bug.
+        assert_eq!(
+            resp["result"]["isError"],
+            json!(true),
+            "{tool} answered instead of refusing: {resp}"
+        );
         assert!(
-            msg.contains("archive") || msg.contains("not a directory"),
-            "{tool} should refuse a mount: {resp}"
+            msg.contains("mounted archive") && msg.contains("get_file_content"),
+            "{tool}'s refusal must say what to do instead: {resp}"
         );
     }
 }


### PR DESCRIPTION
**F13**, **F14** and **F12e** of the pre-2.1 review (`F-tests-guards.md`) — all
`low`, all live on HEAD, all the same defect: a test whose assertion is satisfied
by the outcome its own name says must not happen. Grouped because the fix is one
idea applied three times and each diff is a few lines; splitting would be three
reviews of the same argument.

## F13 — a refusal and an empty answer looked identical

`searching_inside_a_mount_is_refused_rather_than_answered_emptily` asserted:

```rust
msg.contains("archive") || msg.contains("not a directory")
```

The refusal text names the archive's path — and so would an ordinary empty
result. The one bit that distinguishes them, `isError`, was never read. So the
test could not tell "refused" from "answered emptily", which is the entire
distinction in its name.

It now asserts `result.isError == true`, and that the message carries the
actionable half (`get_file_content`) rather than merely mentioning an archive.

**Bite-checked both directions** by dropping `isError` from `send_tool_error`, so
the refusal degrades into exactly the plain answer the test exists to exclude:

- HEAD's assertion: `test result: ok. 1 passed` — blind.
- After this change: `search_content answered instead of refusing`.

## F14 — the column half had no premise, so it couldn't fail

The row half guards `assert!(pane.y > 0, "pane must be offset for this to prove
anything")`. The column half had no equivalent, and `compute_layout` gives the
pane `x == area.x`, which is 0 in every layout production reaches — so with
`ev.column = pane.x + 5`, `report.col` is 5 whether `mouse_report` subtracts the
origin or ignores it. Arithmetic, not a subtle race.

The test now runs each `status_position` over an offset frame origin as well as
`0,0`, and asserts `pane.x == origin_x` first so the premise can't quietly go
away.

**Bite-checked** with `forward.rs`'s `col: ev.column.saturating_sub(origin.x)` →
`col: ev.column`: now fails (`Top: col must be pane-relative`); on HEAD the
finding recorded the same change as green.

Low severity because a non-zero `pane.x` is unreachable today — it becomes
reachable the moment a `FullHeight` vsplit hosts the pane in the right column,
which is when a silent off-by-`pane.x` would read as the child's bug.

## F12e — the effect driver gave up quietly

`settle()` ran `for _ in 0..4` with no check that the queue had drained, so an
effect chain grown past four hops left later assertions running against
half-applied state — failing somewhere unrelated, or passing for the wrong
reason.

The limit is now a named `SETTLE_HOPS` with an assertion after the loop that
prints what is still pending.

**Bite-checked** by shortening it to 1: three archive tests fail naming the
stranded effect (`effects still pending after 1 hops: [Inventory(Yank { … })]`)
instead of failing later on state that was never applied.

`make check-ci` → `=== GATE: PASS ===`.