### PR TITLE
docs(mouse): four comments describing a mode spyc does emit, two describing the wrong function

### DIFF
--- a/src/app/mouse/forward.rs
+++ b/src/app/mouse/forward.rs
@@ -85,13 +85,6 @@ impl super::super::App {
 }
 
 impl super::super::App {
-    /// Give the keyboard to `region`, reusing the same entry points `^a j`/`^a k`
-    /// and `^a a`/`^a b` use.
-    ///
-    /// `set_pane_focus` is doing real work here, not just being tidy: it declines
-    /// while `^a z`-zoomed (the target region is collapsed off-screen) and, coming
-    /// back from the pane, restores whichever split column the user left from.
-    /// Assigning `state.focus` directly would lose both.
     /// Give the keyboard to the region that OWNS `slot`.
     ///
     /// Distinct from [`Self::focus_region`], which answers from layout geometry: a
@@ -114,6 +107,13 @@ impl super::super::App {
         }
     }
 
+    /// Give the keyboard to `region`, reusing the same entry points `^a j`/`^a k`
+    /// and `^a a`/`^a b` use.
+    ///
+    /// `set_pane_focus` is doing real work here, not just being tidy: it declines
+    /// while `^a z`-zoomed (the target region is collapsed off-screen) and, coming
+    /// back from the pane, restores whichever split column the user left from.
+    /// Assigning `state.focus` directly would lose both.
     pub(super) fn focus_region(&mut self, region: Option<Region>) {
         match region {
             Some(Region::Pane) => self.set_pane_focus(true),

--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -68,12 +68,11 @@ fn gesture_and_delta(kind: MouseEventKind, lines: usize) -> Option<(Gesture, i32
         MouseEventKind::Down(MouseButton::Left) => (Gesture::Left, 0),
         MouseEventKind::Down(MouseButton::Middle) => (Gesture::Middle, 0),
         MouseEventKind::Down(MouseButton::Right) => (Gesture::Right, 0),
-        // spyc asks the terminal only for 1000 (press/release), so `Moved`/`Drag`
-        // shouldn't arrive at all — `proc.rs` filters them for the terminals that
-        // send them anyway. Consequence, deliberate: click-drag selection INSIDE a
-        // child doesn't work. That needs 1002 (motion only while a button is
-        // held), which unlike 1003 wouldn't cost the idle-redraw invariant — a
-        // later change. Matched explicitly so adding one is a visible decision.
+        // `Up` and `Drag` never reach here — `handle_mouse` routes both to the
+        // child that took the press, before this. `Moved` is dropped in `proc.rs`
+        // (1002 reports motion only while a button is held, so a buttonless
+        // `Moved` is motion spyc never asked for). Horizontal wheel has no
+        // behaviour. All matched explicitly so adding one is a visible decision.
         MouseEventKind::Up(_)
         | MouseEventKind::Drag(_)
         | MouseEventKind::Moved
@@ -257,12 +256,8 @@ impl super::App {
         let lines = self.state.config.mouse.scroll_lines.max(1);
         // `delta` is only meaningful for a wheel gesture; buttons ignore it.
         let Some((gesture, delta)) = gesture_and_delta(ev.kind, lines) else {
-            // Drags, motion, horizontal wheel: no behaviour. spyc asks the terminal
-            // only for 1000 (press/release), so `Moved`/`Drag` shouldn't arrive at
-            // all — `proc.rs` filters them for the terminals that send them anyway.
-            // Consequence, deliberate: click-drag selection INSIDE a child doesn't
-            // work. That needs 1002 (motion only while a button is held), which
-            // unlike 1003 wouldn't cost the idle-redraw invariant — a later change.
+            // Motion or a horizontal wheel: no behaviour. Releases and drags are
+            // already gone — both returned above, to whoever took the press.
             return Vec::new();
         };
 

--- a/src/app/mouse/route.rs
+++ b/src/app/mouse/route.rs
@@ -209,6 +209,16 @@ impl MouseSnapshot {
         self.pane_wants_mouse && !self.pane_closed && !self.has_scroll_pager
     }
 
+    /// Whether spyc should do the selecting over the pane itself.
+    ///
+    /// The complement of [`Self::can_forward_to_child`] on the mouse axis: a child
+    /// that speaks mouse draws its OWN selection (#224), and painting ours on top
+    /// would double it up. What's left — codex, a plain shell — has no other way to
+    /// be selected. Still requires a live, visible grid.
+    const fn pane_is_selectable(self) -> bool {
+        !self.pane_wants_mouse && !self.pane_closed && !self.has_scroll_pager
+    }
+
     /// Whether a pending chord set now would ever be seen by the resolver.
     ///
     /// A leader chord is only safe to arm if the NEXT key reaches
@@ -221,16 +231,6 @@ impl MouseSnapshot {
     /// A latch is not merely cosmetic: the popup stays on screen, and the first
     /// key that eventually reaches the resolver is consumed as a continuation —
     /// in the leader menu `p` is a chdir and `P` overwrites PROJECT_HOME.
-    /// Whether spyc should do the selecting over the pane itself.
-    ///
-    /// The complement of [`Self::can_forward_to_child`] on the mouse axis: a child
-    /// that speaks mouse draws its OWN selection (#224), and painting ours on top
-    /// would double it up. What's left — codex, a plain shell — has no other way to
-    /// be selected. Still requires a live, visible grid.
-    const fn pane_is_selectable(self) -> bool {
-        !self.pane_wants_mouse && !self.pane_closed && !self.has_scroll_pager
-    }
-
     const fn resolver_will_see_the_next_key(self) -> bool {
         !self.is_prompting && !matches!(self.pager_mount, Some(Mount::Overlay))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -684,12 +684,12 @@ impl crossterm::Command for DisableWheelReporting {
         // Reverse order of the enable, so a terminal that tracks a mode stack
         // unwinds cleanly.
         //
-        // Clears 1002/1003 too, which spyc never ENABLES: a foreground child
-        // (vim, htop) sets its own motion reporting, and one that dies without
-        // resetting — SIGKILL, a crash — hands the tty back with 1002/1003 still
-        // on. Clearing only our own pair would then leave motion reporting live,
-        // which both defeats the 1007 exclusivity `resume_tui` re-establishes and
-        // leaks motion events into the user's shell after spyc exits.
+        // Clears 1003, which spyc never enables: a foreground child (vim, htop)
+        // sets its own any-motion reporting, and one that dies without resetting
+        // — SIGKILL, a crash — hands the tty back with it still on. Clearing only
+        // what spyc turned on would leave motion reporting live, which both
+        // defeats the 1007 exclusivity `resume_tui` re-establishes and leaks
+        // motion events into the user's shell after spyc exits.
         f.write_str("\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l")
     }
     #[cfg(windows)]
@@ -1077,11 +1077,13 @@ pub fn resume_tui(terminal: &mut Tui) -> Result<()> {
         // the tty back with its own 1000/1002/1003 still live; enabling 1007 on
         // top of that is the both-modes-on state the pairing exists to prevent,
         // and the terminal may then deliver one wheel tick twice.
+        //
+        // Resuming therefore comes back with mouse reporting OFF, deliberately:
+        // `settle_mouse_mode` re-enables it on the next loop iteration if
+        // `[mouse] capture` says so, which keeps one path deciding it.
         DisableWheelReporting,
         EnableAlternateScroll
     )?;
-    // `suspend_tui` already cleared this; the reconcile re-enables per config on
-    // the next iteration if the user wants capture.
     terminal.hide_cursor()?;
     force_full_repaint(terminal)?;
     Ok(())


### PR DESCRIPTION
Six comment defects from the pre-2.1 review's E and SYNTHESIS reports — all
`low`, all live on HEAD, all in the mouse/terminal path. One PR because they are
two families of two-line diffs across four files; six reviews of "this sentence
is false" would cost more than it buys.

## Four copies of a claim that stopped being true

`src/lib.rs:674` emits `\x1b[?1000h\x1b[?1002h\x1b[?1006h`. spyc **does** ask for
1002. Four comments say otherwise, including one thirteen lines below that string:

- `lib.rs:687` — "Clears 1002/1003 too, **which spyc never ENABLES**". It clears
  1002 because spyc turned it on; 1003 is the one spyc never enables, and the
  reason given (a crashed child hands the tty back with motion reporting live)
  only ever applied to 1003.
- `mouse/mod.rs`, twice — "spyc asks the terminal only for 1000 (press/release),
  so `Moved`/`Drag` shouldn't arrive at all", and "click-drag selection INSIDE a
  child doesn't work. That needs 1002 … **a later change**". Drags arrive and are
  forwarded — thirteen lines above the second copy, `handle_mouse` calls
  `forward_drag`. The "a later change" phrasing is also exactly what
  `comments_carry_no_reasoning_leakage` exists to keep out; the guard's `SLOP`
  list doesn't carry the temporal shapes (F-E12), so nothing caught it.
- `lib.rs`'s `resume_tui` — F-E14, a comment with no referent: "`suspend_tui`
  already cleared **this**; the reconcile re-enables per config" sits above
  `terminal.hide_cursor()?`, which it does not describe. "This" meant mouse
  capture. Attached to the `DisableWheelReporting` it belongs to, phrased as what
  resuming leaves the terminal in and which path decides.

`src/app/proc.rs` is the one copy that was updated when 1002 landed ("`Drag` is
forwarded: spyc asks for 1002", "`Moved` is still dropped") — so the corrected
text follows its wording rather than inventing a second account.

## Two doc blocks attached to the wrong function

Carried verbatim through the mouse-module split, the same splice as F11:

- `mouse/route.rs` — `resolver_will_see_the_next_key`'s doc (the leader-chord
  latch rationale, `p` is a chdir and `P` overwrites PROJECT_HOME) sat above
  `pane_is_selectable`, whose own doc followed inside the same block; the function
  it described had none.
- `mouse/forward.rs` — `focus_region`'s doc (why `set_pane_focus` is load-bearing:
  it declines while zoomed and restores the split column) sat above
  `focus_pager_slot`, same shape.

Both moved. Nothing else changed — no behaviour in this commit.

`make check-ci` → `=== GATE: PASS ===`.