### PR TITLE
fix(skill): a torn manifest write clobbers the edits it promised not to

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -156,7 +156,7 @@ fn write_root_marker(state_dir: &Path, ctx_path: &Path) {
     let path = root_marker_path_in(state_dir, std::process::id());
     // A non-UTF-8 root would be stored lossily and later fail the
     // canonical compare → refuse; an acceptable (and safe) edge.
-    if std::fs::write(&path, canon.to_string_lossy().as_bytes()).is_ok() {
+    if crate::fs::write_atomic(&path, canon.to_string_lossy().as_bytes()).is_ok() {
         // Match the socket's owner-only posture: the file only holds a
         // directory path, but no reason to expose project roots to other
         // local users.

--- a/src/skill/mod.rs
+++ b/src/skill/mod.rs
@@ -265,21 +265,30 @@ pub fn status_all() -> Vec<(Host, Status)> {
 /// Write every asset + the manifest into `dir`, creating it if needed.
 /// Overwrites unconditionally — callers decide whether that is allowed (the
 /// startup prompt refuses to clobber a [`Status::Modified`] skill unprompted).
+/// Both halves go through [`crate::fs::write_atomic`], and the manifest is the
+/// one that matters: [`read_manifest`] returns `None` for anything it can't
+/// parse, [`status_in`] turns that into [`Status::NotInstalled`], and a
+/// `NotInstalled` skill is overwritten *unconditionally*. So a manifest torn by
+/// a crash or a full disk converts "locally edited, never clobbered unprompted"
+/// into "clobbered on next launch" — the user's own edits, discarded by the
+/// promise that was supposed to protect them.
 pub fn install_in(dir: &Path) -> std::io::Result<()> {
     for asset in ASSETS {
         let path = dir.join(asset.rel);
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(&path, asset.body)?;
+        crate::fs::write_atomic(&path, asset.body.as_bytes())?;
     }
     let manifest = serde_json::json!({
         "version": env!("CARGO_PKG_VERSION"),
         "files": embedded_hashes(),
     });
-    std::fs::write(
-        dir.join(MANIFEST),
-        serde_json::to_string_pretty(&manifest).unwrap_or_default(),
+    crate::fs::write_atomic(
+        &dir.join(MANIFEST),
+        serde_json::to_string_pretty(&manifest)
+            .unwrap_or_default()
+            .as_bytes(),
     )
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -380,11 +380,27 @@ mod state_writes_are_atomic {
     //! what stops the next straggler. It found three on the day it was written
     //! (`inventory`, `harpoon`, `skill_prompt`) that a hand-audit had missed.
     //!
-    //! Scoped to `src/state/`, where the writers of the XDG state root live.
+    //! Scoped to the directories that hold persistent-state writers, which is
+    //! **not** just `src/state/`: it was, and two writers then landed outside it
+    //! that the scan could not see — `src/skill/` (the assets and the
+    //! `.spyc-skill.json` manifest) and `src/mcp/server.rs` (the trusted-root
+    //! sidecar). The skill one had teeth: `read_manifest` returns `None` for an
+    //! unparseable manifest, `status_in` turns that into `NotInstalled`, and a
+    //! `NotInstalled` skill is overwritten unconditionally — so a torn write
+    //! converted "never clobbered unprompted" into "clobbered".
+    //!
     //! Test fixtures legitimately use `fs::write` to build scratch files, so —
     //! following `no_subprocess_git_in_production` — only the portion of each
     //! file before its first `#[cfg(test)]` is scanned, and whole-file test
     //! modules are skipped.
+    //!
+    //! Known limit, recorded so it isn't mistaken for coverage: the scan matches
+    //! one literal. A module writing through `File::create` + `write_all`,
+    //! `OpenOptions`, or `serde_json::to_writer` passes silently.
+    //! `state/graveyard.rs` already does exactly that for its `.tar.zst` payload
+    //! — deliberate and documented there (metadata written last, orphans reaped
+    //! by the health check), but it means "empty ALLOWED is the healthy state"
+    //! describes a narrower property than it reads as.
     use std::path::Path;
 
     /// Deliberate exceptions: relative paths under `src/`, each with the
@@ -433,11 +449,16 @@ mod state_writes_are_atomic {
         }
     }
 
+    /// Directories whose production code persists state the user would miss.
+    const ROOTS: &[&str] = &["state", "skill", "mcp"];
+
     #[test]
     fn persistent_state_is_written_atomically() {
         let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
         let mut offenders = Vec::new();
-        scan(&src.join("state"), &src, &mut offenders);
+        for root in ROOTS {
+            scan(&src.join(root), &src, &mut offenders);
+        }
         offenders.sort();
         assert!(
             offenders.is_empty(),


### PR DESCRIPTION
**C-F7** of the pre-2.1 review (`C-mcp-state-security.md`) — `low`, live on HEAD.

The skill install promises one thing about local edits: `install_in`'s own doc
says the startup prompt "refuses to clobber a `Status::Modified` skill
unprompted". A non-atomic manifest write breaks that promise in the worst
direction:

1. `install_in` wrote `.spyc-skill.json` with plain `std::fs::write`.
2. `read_manifest` returns `None` for anything it can't parse.
3. `status_in` turns `None` into `Status::NotInstalled`.
4. A `NotInstalled` skill is overwritten **unconditionally**.

So a manifest torn by a crash or a full disk doesn't degrade to "ask the user" —
it degrades to "the skill was never installed", and the next launch discards
whatever the user had written there. The one file whose job is to protect their
edits was the one that could destroy them.

Both halves now go through `crate::fs::write_atomic`. `src/mcp/server.rs`'s
trusted-root sidecar too — that one already failed safe (a torn read is an
untrusted marker → refuse), so it is consistency rather than a fix.

## The guard couldn't see any of it

`state_writes_are_atomic` scanned `src/state/` only. Its own doc called that
"where the writers of the XDG state root live", which was true when written and
then stopped being true — `src/skill/` and `src/mcp/server.rs` both landed
outside it. An empty `ALLOWED` list read as "everything is atomic" while two
writers were simply out of frame.

The scan now covers `state`, `skill` and `mcp`.

**Bite-checked** by restoring both raw writes: the guard fails with
`Offenders: ["skill/mod.rs"]`. Before this change the identical code passed.

## And the limit it still has, written down

The scan matches one literal, `fs::write(`. A module switching to
`File::create` + `write_all`, `OpenOptions`, or `serde_json::to_writer` passes
silently — `state/graveyard.rs` already does exactly that for its `.tar.zst`
payload, deliberately and documented there. Recorded in the guard's doc so
"empty ALLOWED is the healthy state" isn't read as a stronger claim than it is.

Not fixed here, and deliberately: the write **ordering** (assets first, manifest
last) means a crash between them still leaves hashes disagreeing with an older
manifest → `Status::Modified` → spyc reporting the user's skill as hand-edited
when it was spyc's own half-write. That is a spurious prompt, not data loss, and
no single-file atomicity can fix it — it needs a staged directory swap.

`make check-ci` → `=== GATE: PASS ===`.