### PR TITLE
docs(readme): slim the README to a storefront, relocate the reference detail

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -55,6 +55,47 @@ install -m 755 target/release/spyc ~/.local/bin/
 `make doctor` checks that the toolchain and cross-compile prerequisites
 are present before you start.
 
+## Running CURRENT (the development stream)
+
+Every channel in [INSTALL.md](INSTALL.md) installs a **RELEASE** — tagged,
+signed, frozen. `main` is spyc's **CURRENT** stream: every merged change
+lands there behind CI. It is what the author dog-foods daily, and where a
+fix reaches you first.
+
+It is also unreleased by definition — rolling, and it may break. There are
+no prebuilt binaries, so CURRENT is source-only and the clone + `make
+install` above *is* the install. Update by pulling and rebuilding:
+
+```sh
+git pull && make install
+```
+
+A CURRENT build says so: the version carries a `-CURRENT` suffix naming the
+minor it is heading for.
+
+```sh
+$ spyc --version
+spyc <x.y.z>-CURRENT (<sha>)
+```
+
+`2.1.0-CURRENT` is *on the way to* 2.1.0, never 2.1.0 itself. That suffix is
+static for the whole minor cycle, so the trailing SHA is the only thing that
+tells two CURRENT builds apart — quote it in a bug report. `--verbose` prints
+it alongside the toolchain and terminal spyc saw:
+
+```sh
+$ spyc --verbose
+🌶️ spyc 2.1.0-CURRENT
+  git:     69a5ff1
+  built:   …
+  rustc:   …
+```
+
+To go back to a release, install through any channel in
+[INSTALL.md](INSTALL.md) — a tagged build simply has no suffix. The full
+stream model (CURRENT, STABLE, RELEASE, and how releases are cut) is in
+[docs/RELEASE_ENGINEERING.md](docs/RELEASE_ENGINEERING.md).
+
 ## Development build
 
 For iterating on the code, a debug build is faster:

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -482,6 +482,12 @@ One string per binding in a `keymap = [ ... ]` array. Forms:
 `<KEY>` is a single char (`f`), a Ctrl-combo (`^P`), or a named key (`<F2>`). The
 DSL binds single keys — for multi-key chords, use `init.lua`'s `spyc.map`.
 
+> **`^a` and `^w` are reserved.** spyc intercepts both as chord prefixes, so a
+> shell (or tmux) running inside the pane never sees readline's
+> `beginning-of-line` / `unix-word-rubout`. If you run an interactive shell as the
+> pane child, rebind the prefixes here; inside tmux, keep spyc's `^a` distinct
+> from tmux's own prefix (and `set -s escape-time 0` for snappy input).
+
 Several low-frequency features ship as `:` commands **without** a default key so
 the keymap stays uncluttered — bind the ones you use:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,18 @@ Pre-built, signed binaries are the easy path — Homebrew, `apt`, or a
 Release tarball, no Rust toolchain required. To compile spyc yourself
 (to hack on it or run unreleased changes), see [BUILD.md](BUILD.md).
 
+## Platforms
+
+**macOS** and **Linux**, on `x86_64` and `aarch64`. macOS ships as a
+universal binary; Linux binaries are static (musl), so they run on any
+distro regardless of its glibc.
+
+**Windows is supported through WSL**, not natively — run spyc inside a
+WSL2 distro and it behaves like any other Linux install. Native Windows
+is a stated non-goal (see [ROADMAP.md](ROADMAP.md)); `portable-pty`
+technically works there, but the terminal and pty failure modes aren't
+a cost the project is paying.
+
 ## Install
 
 ### Homebrew (macOS and Linux)

--- a/README.md
+++ b/README.md
@@ -27,289 +27,161 @@
 
 ## Why spyc?
 
-Put an AI coding agent in your terminal and you usually get a chat
-window. You still describe your working tree to it, paste paths back
-and forth, and lose track of what it's looking at. spyc runs the agent
-in a pane beside a keyboard-driven file commander, on macOS and Linux,
-and gives it live, structured access to exactly what you're looking at
-via a local MCP socket.
+Put an AI coding agent in your terminal and you get a chat window. You still
+describe your working tree to it, paste paths back and forth, and lose track of
+what it's looking at.
 
-The agent can ask spyc *what is the cursor on, what is staged, what is
-pinned, what is in this directory* — no copy-paste, no path description.
-Pick three files and ask a question; the agent sees your selection. When
-it mentions a path in its response, press `gf` to jump straight there.
+spyc runs the agent in a pane beside a keyboard-driven file commander and gives
+it live, structured access to what you're looking at over a local MCP socket.
+The agent asks spyc *what is the cursor on, what is staged, what is picked* —
+no copy-paste, no path description. Pick three files, ask a question, and it
+sees your selection. When it names a path in its answer, `gf` jumps you there.
 
 The file manager is the shared workspace where you and your agents actually
 work — not a file list bolted onto a chat window.
 
 ## What it is
 
-A two-pane terminal program:
+A two-pane terminal program. The **top pane** is a vim-flavoured file commander
+with git-aware listings; the **bottom pane** is a child process — Claude Code by
+default (Codex, Antigravity and zot are first-class too), in practice anything.
+They share focus through a screen-style `^a` chord prefix.
 
-- The **top pane** is a keyboard-driven, vim-flavoured file commander with
-  git-aware listings.
-- The **bottom pane** is a child process — Claude Code by default (Codex,
-  Antigravity, and zot are first-class too), but in practice any program.
-
-The panes share focus through a screen-style `^a` chord prefix, and the
-commander exposes a local MCP socket the agent connects to. Everything else
-(vi motions, marks, picks, inventory, pager, shell integration) is what you'd
-expect from a keyboard-driven file manager — the MCP bridge is what sets spyc
-apart from Yazi, Broot, or Ranger.
+Everything else — vi motions, marks, picks, inventory, pager, shell integration —
+is what you'd expect from a keyboard-driven file manager. The MCP bridge is what
+sets spyc apart from Yazi, Broot, or Ranger.
 
 <img src="docs/assets/screenshot.png" alt="spyc mid-task: two file columns browsing a worktree's src/ and its repo root, the activity HUD in the top right, three agent tabs on the divider with per-tab activity dots, and the active agent's output filling the lower pane" width="820">
 
-A real session, mid-task. Two file columns browse the same worktree (`^s n`) —
-`src/` on the left, the repo root on the right — while the status bar names the
-project, the session, the branch, and the agent pinned to the pane. Three agent
-tabs sit on the divider, each carrying its own activity dot; the boxed one is
-active. Top right is the `A` monitor: draws per second, git/fs/MCP throughput,
-pid and uptime, the running version, and a tally of every MCP tool the agents
-have called this session. Two bands are blurred out of the capture: the agent's
-own status line along the bottom, and one command echo that carried an absolute
-home path.
+A real session, mid-task: two columns on one worktree (`^s n`), three agent tabs
+on the divider each carrying its own activity dot, and the `A` monitor top-right
+reporting draws per second, throughput, and every MCP tool the agents have
+called. Two bands are blurred — the agent's own status line, and one command
+echo carrying an absolute home path.
 
 **The name.** Say it *"spy-see"* — near enough to *spicy*, which is where the
 chili comes from. It carries a lineage too: `spy` and the keyboard-driven file
-commanders that came before it, rebuilt from scratch in Rust for the age of
-coding agents.
+commanders before it, rebuilt from scratch in Rust for the age of coding agents.
 
 <sub>spyc is an independent project, not affiliated with or endorsed by Side Effects Software Inc. or Anthropic.</sub>
 
 ## A tour
 
-The bridge above is what makes spyc different. This is the rest of it — the
-commander you spend the day in.
-
 ### Read anything, one key
 
 <img src="docs/assets/demo-pager.gif" alt="Opening README.md as rendered markdown, then a Rust file with syntax highlighting, then a binary as a hex dump — all in the same pager" width="820">
 
-Markdown renders — headings, tables, fenced code — source arrives
-syntax-highlighted, and a binary falls back to a hex dump. Same key every time,
-no editor, and the file list is still right there. Images open as actual
-pictures on a terminal with a graphics protocol, and `^s |` puts any of it in a
-live-reloading side column.
+Markdown renders, source arrives syntax-highlighted, a binary falls back to a
+hex dump — same key every time, no editor, file list still there. Images open as
+actual pictures on a terminal with a graphics protocol.
 
 ### Keep a file open beside the list
 
 <img src="docs/assets/demo-vsplit.gif" alt="A preview column opening full-height beside the file list with an agent pane below, flipping to top-only and back, swapping to a Rust file, scrolling and widening it, then a second full file-commander in the same column" width="820">
 
-`^s |` (or `^a |`) opens a preview column on the cursor file, full-height by
-default — set `[layout] vsplit_mode = "top_only"` to keep the agent pane
-full-width below instead, and `^s f` flips an open split either way. Press the
-key on a *different* file and the preview swaps to that one; press it again on
-the same file and it closes. The previewed file re-renders when it changes on
-disk, so it doubles as a watch window while something else writes.
+`^s |` opens a live preview column on the cursor file; press it on another file
+to swap, again to close. It re-renders when the file changes on disk, so it
+doubles as a watch window while something else writes.
 
 ### Review it where you are
 
 <img src="docs/assets/demo-review.gif" alt="The git gutter marking modified files, gd opening a syntax-highlighted side-by-side diff, | toggling unified, gb blaming the file" width="820">
 
-The gutter marks what changed; `gd` opens a syntax-highlighted diff against
-HEAD, `|` toggles side-by-side and unified, `gb` blames the file. All of it
-in-process through gix — spyc never shells out to `git`.
+The gutter marks what changed; `gd` diffs against HEAD, `|` toggles
+side-by-side/unified, `gb` blames. All in-process through gix — spyc never
+shells out to `git`.
 
 ### Script it in Lua
 
 <img src="docs/assets/demo-lua.gif" alt="Reading a Lua script in the pager, then pressing the key it is bound to and watching every file with a TODO get picked" width="820">
 
 `map T lua todos` binds a key to a script. This one runs spyc's own
-gitignore-aware content search, then picks every file with a TODO left in it —
-and `=!` narrows the listing to exactly those. Scripts run off the main thread
-behind a kill switch, and `init.lua` can register `:` commands and event hooks
-too.
+gitignore-aware search and picks every file with a TODO left in it. Scripts run
+off the main thread behind a kill switch; `init.lua` can register `:` commands
+and event hooks too.
 
 ### See which agent needs you
 
 <img src="docs/assets/demo-agents.gif" alt="Two claude tabs running; one keeps working while the other blocks on a question, turning its tab dot red and pulsing the window border" width="820">
 
-Two agents, one question: which one is waiting on *you*. Each tab carries a
-live dot — pulsing while it works, settling to a hot-red square the moment it
-blocks — and that transition rings a spice-heat border pulse and a desktop
-notification, so you can be in another window and still get pulled back to the
-right pane. It's driven by the agent reporting its own status over MCP, not by
-scraping the screen.
+Each tab carries a live dot — pulsing while the agent works, settling to a
+hot-red square the moment it blocks — and that transition fires a border pulse
+and a desktop notification, so you get pulled back from another window. Driven
+by the agent reporting its own status over MCP, not by scraping the screen.
 
-## Quick start
-
-### Prerequisites
-
-- **A coding agent** — Claude Code is the default
-  (`npm install -g @anthropic-ai/claude-code`); Codex and Antigravity also work. spyc runs as a plain file manager without one, but the agent
-  bridge is the whole point.
-- **Nerd Font** (recommended) for the powerline status bar; press `C` inside
-  spyc for a mono fallback. Install: `brew install --cask font-meslo-lg-nerd-font`
-- **Linux clipboard helper** — yank needs `wl-copy` (Wayland) or `xclip` /
-  `xsel` (X11); macOS uses the built-in `pbcopy`. See
-  [INSTALL.md](INSTALL.md#clipboard-helper-linux-only).
-- **Rust** 1.88+ — only if you build from source (see [BUILD.md](BUILD.md)).
-
-### Install
+## Install
 
 Pre-built, signed binaries — no Rust toolchain needed:
 
 ```sh
-# macOS & Linux — Homebrew
-brew install Tripstack-Corp/tap/spyc
-
-# Debian / Ubuntu — apt (signed repo)
-sudo install -d -m 0755 /etc/apt/keyrings
-curl -fsSL https://tripstack-corp.github.io/spyc/KEY.gpg | sudo tee /etc/apt/keyrings/spyc.asc >/dev/null
-echo "deb [signed-by=/etc/apt/keyrings/spyc.asc] https://tripstack-corp.github.io/spyc ./" | sudo tee /etc/apt/sources.list.d/spyc.list >/dev/null
-sudo apt update && sudo apt install spyc
+brew install Tripstack-Corp/tap/spyc          # macOS & Linux
+cargo install spyc                            # any platform, with Rust
 ```
 
-Or grab a tarball from
-[Releases](https://github.com/Tripstack-Corp/spyc/releases), or — with a Rust
-toolchain — install from [crates.io](https://crates.io/crates/spyc) (also the
-easy path on Arch and any distro without a native package):
+Debian/Ubuntu users get a signed apt repo, and every release ships verified
+tarballs. **Full install guide — apt, tarballs, terminal, font, clipboard and
+MCP setup — is in [INSTALL.md](INSTALL.md);** building from source and running
+the rolling CURRENT stream are in [BUILD.md](BUILD.md).
 
-```sh
-cargo install spyc
-```
+You'll want a coding agent for the pane (`npm install -g @anthropic-ai/claude-code`)
+and a [Nerd Font](https://www.nerdfonts.com/) for the powerline status bar —
+press `C` inside spyc for a mono fallback if you'd rather not install one.
 
-To **build from source** instead, see [BUILD.md](BUILD.md). Full setup —
-terminal, font, clipboard, MCP, and verification — is in [INSTALL.md](INSTALL.md).
-
-### Running CURRENT (the development stream)
-
-Everything above installs a **RELEASE** — a tagged, signed, frozen version. If
-you'd rather run ahead of it, `main` is spyc's **CURRENT** stream: every merged
-change lands there, gated by CI. It's what the author dog-foods daily, and it's
-where a fix reaches you first.
-
-It is also, by definition, unreleased: rolling, and it may break. There are no
-prebuilt binaries — CURRENT is source-only, so you need a Rust toolchain.
-
-```sh
-# Use single-branch to avoid downloading the heavy gh-pages branch
-git clone --single-branch --branch main https://github.com/Tripstack-Corp/spyc.git
-cd spyc
-make install        # release build → ~/.local/bin/spyc
-```
-
-Update it by pulling and rebuilding:
-
-```sh
-git pull && make install
-```
-
-A CURRENT build says so: the version carries a `-CURRENT` suffix naming the minor
-it's heading for.
-
-```sh
-$ spyc --version
-spyc <x.y.z>-CURRENT (<sha>)
-```
-
-The trailing SHA is the exact build: the version line is static for a whole
-minor cycle, so it's the only thing that tells two CURRENT builds apart.
-
-That suffix is how you tell a development build from the release of the same
-number — `2.1.0-CURRENT` is *on the way to* 2.1.0, never 2.1.0 itself. The
-suffix stays put for the whole cycle, so for a bug report you want the commit
-too, which `--verbose` prints alongside the toolchain and terminal it saw:
-
-```sh
-$ spyc --verbose
-🌶️ spyc 2.1.0-CURRENT
-  git:     69a5ff1
-  built:   …
-  rustc:   …
-```
-
-On a rolling stream that SHA is what actually identifies your build — quote it.
-
-To go back to a release, install via any channel above; a tagged build simply has
-no suffix. Toolchain and cross-compilation detail is in [BUILD.md](BUILD.md); the
-full stream model — CURRENT, STABLE, RELEASE, and how releases are cut — is in
-[docs/RELEASE_ENGINEERING.md](docs/RELEASE_ENGINEERING.md).
-
-### Launch
+## Your first 5 minutes
 
 ```sh
 spyc            # opens in the current directory
-spyc -r         # resume a previous session (tabs + each agent's conversation)
+spyc -r         # resume a session (tabs + each agent's conversation)
 ```
 
-Move with `hjkl`, `Enter` to open a file/dir, `e` for `$EDITOR`, `?` for the
-full help overlay.
+Move with `hjkl`, `Enter` opens, `e` edits, `?` shows the full help overlay.
+Then try the part that makes spyc spyc, in a git repo:
 
-### Your first 5 minutes
-
-The whole point is the agent in the side pane seeing exactly what you see.
-Try it in a git repo:
-
-1. Run `spyc`.
-2. Press `t` on two or three files to **pick** them.
-3. Press `^\` (Ctrl+Backslash) to open the agent pane — it launches `claude`
-   by default (install it first; see Prerequisites).
-4. Ask: **"How do these files interact?"** The agent reads your picks over
-   MCP — no pasting paths.
-5. When it names a file in its answer, press `gf` to jump straight to it.
+1. Press `t` on two or three files to **pick** them.
+2. Press `^\` to open the agent pane — it launches `claude` by default.
+3. Ask: **"How do these files interact?"** The agent reads your picks over MCP,
+   with no pasting of paths.
+4. When it names a file, press `gf` to jump straight to it.
 
 `^a j` / `^a k` switch focus between the list and the pane.
 
 ## The MCP bridge
 
-This is what sets spyc apart. On startup it runs a local MCP server and writes
-the agent's config automatically — no flags, no setup. The agent can then ask
-spyc, at any point:
+On startup spyc runs a local MCP server and writes the agent's config
+automatically — no flags, no setup. The agent can then ask spyc:
 
 - **What you're looking at** — `get_spyc_context`: cwd, cursor file, picks,
   inventory, active filter, git branch.
 - **Where things are** — `search_paths` / `search_content` (gitignore-aware),
   plus `search_picks` and `search_inventory` for state generic filesystem tools
   can't see.
+- **Git and worktrees** — status, log and diff in-process, plus worktree
+  create/open/remove without ever shelling out to `git worktree`.
 
-Press `gf` / `gF` to jump from the agent's output back to a file (and line).
-Multiple instances coexist safely, and enterprise `managed-mcp.json` policies
-are respected — details in [INSTALL.md](INSTALL.md#mcp-configuration).
-
-### Teaching the agent to use it
-
-The MCP handshake tells an agent these tools exist, but it has to stay short.
-For the depth — worktree lifecycle, which of the four search corpora to reach
-for, the three `git_diff` scopes — install spyc's skill:
+The handshake has to stay short, so the depth ships as an installable skill:
 
 ```sh
-spyc --install-skill
-#  → ~/.claude/skills/spyc/          (Claude Code)
-#  → ~/.codex/skills/spyc/           (codex; honors $CODEX_HOME)
+spyc --install-skill      # → Claude Code, codex, and agy skill dirs
 ```
 
-Claude Code and codex use the same skill format, so one install covers both, and
-each picks it up automatically in every project.
-
-spyc offers a `[Y/n]` update on startup when its own copy has moved past what
-you installed; decline and it won't ask again until the skill actually changes.
-If you've edited the installed copy, it says so rather than overwriting your work
-silently. Manage it in-app with `:skill` (`status`, `update`, `remove`, `ask`).
+spyc offers a `[Y/n]` update when its copy moves ahead of yours, never
+overwrites edits you've made, and is managed in-app with `:skill`. Multiple
+spyc instances coexist safely, and enterprise `managed-mcp.json` policies are
+respected — see [INSTALL.md](INSTALL.md#mcp-configuration).
 
 ## Running multiple agents
 
-Run agents across several tabs and two problems show up; spyc handles both.
-
-- **Which one needs me?** Each tab carries a live **activity dot** — a hot
-  pulse while the agent works, a settled square when it's **blocked** (waiting
-  on you) or **done**. The agent reports its own state over MCP, so it's right
-  even while it redraws its UI. A transition into blocked/done fires a desktop
-  notification naming the tab plus a brief border flash, so the nudge reaches
-  you in another window. Tunable under `[notify]`.
-- **Two agents, same files?** An advisory **scope registry** lets agents
-  declare what they're editing or merging (`register_scope` / `list_scopes` /
-  `wait_for_scope_clear`) so parallel agents stay out of each other's way — no
-  daemon, in-memory, persisted across `-r`.
-
-Sessions auto-save (and re-save seconds after any change, so a crash loses
-almost nothing); `spyc -r` restores every tab and resumes each agent's
-conversation. Full design:
-[`docs/AGENT_ORCHESTRATION.md`](docs/AGENT_ORCHESTRATION.md).
+Each tab's **activity dot** answers *which one needs me* — hot pulse while
+working, settled square when blocked or done, with a desktop notification on the
+transition. An advisory **scope registry** (`register_scope` / `list_scopes` /
+`wait_for_scope_clear`) keeps parallel agents off each other's files. Sessions
+auto-save within seconds of any change, so a crash loses almost nothing and
+`spyc -r` resumes every tab and conversation. Design:
+[docs/AGENT_ORCHESTRATION.md](docs/AGENT_ORCHESTRATION.md).
 
 ## Keybindings
 
-The essentials below. Press `?` in spyc for the full overlay, or see
+The essentials. Press `?` in spyc for the full overlay, or see
 [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md) for the complete map.
 
 | Key | Action |
@@ -322,60 +194,39 @@ The essentials below. Press `?` in spyc for the full overlay, or see
 | `^a s` | Send picked paths to the pane |
 | `gf` / `gF` | Jump from pane output to a file (+ line) |
 | `F` / `:grep` | Fuzzy filename finder / project content search |
-| `?` | Full help overlay |
-| `q` | Quit |
+| `?` / `q` | Full help overlay / quit |
 
 ## Configuration
 
 spyc reads `.spycrc.toml` from `~/.spycrc.toml` (user) and `./.spycrc.toml`
-(project); changes apply live (`^R` to force). Bootstrap a fully-commented
-config with every default:
+(project), applying changes live. Bootstrap a fully-commented file with every
+default:
 
 ```sh
 spyc --print-config > ~/.spycrc.toml
 ```
 
-You can rebind keys, set colors and layout, tune agent notifications, and
-script with Lua. Full reference: [`CONFIGURATION.md`](CONFIGURATION.md).
-
-> **Shell users — `^a` and `^w` are reserved.** spyc intercepts them as chord
-> prefixes, so a shell (or tmux) running inside the pane won't see readline's
-> `beginning-of-line` / `unix-word-rubout`. If you run an interactive shell as
-> the pane child, rebind the prefixes in `.spycrc.toml`; inside tmux, keep
-> spyc's `^a` distinct from tmux's prefix (or `set -s escape-time 0` for snappy
-> input).
-
-> **Project configs are sandboxed.** A `./.spycrc.toml` can set colors, layout,
-> ignore masks, and rebind keys to built-in actions — but its *executing*
-> bindings (`unix` shell commands, `lua` scripts, `jump`) are ignored; only your
-> `~/.spycrc.toml` may bind those. So opening spyc in a cloned repo can't run
-> commands a malicious `.spycrc.toml` planted there.
-
-## Recommended setup
-
-- **Terminal:** [iTerm2](https://iterm2.com/) (macOS), WezTerm, Kitty, Ghostty, or Alacritty
-- **Font:** Any [Nerd Font](https://www.nerdfonts.com/) for the powerline status bar.
-  Press `C` to toggle mono mode if you prefer not to install one.
-- **Claude Code:** `npm install -g @anthropic-ai/claude-code`
-- **Platforms:** macOS and Linux (x86_64, aarch64). Windows via WSL.
-
-See [INSTALL.md](INSTALL.md) for detailed setup instructions.
+Rebind keys, set colors and layout, tune agent notifications, script in Lua.
+Note that `^a` and `^w` are reserved as chord prefixes, and a project-local
+config can't bind executing verbs — full reference, including both rules, in
+[CONFIGURATION.md](CONFIGURATION.md).
 
 ## More docs
 
-- [FEATURES.md](FEATURES.md) -- complete feature reference
-- [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md) -- the full keymap (the `?` overlay in browsable form)
-- [CONFIGURATION.md](CONFIGURATION.md) -- config reference: `.spycrc.toml`, notifications, keymap DSL, Lua
-- [INSTALL.md](INSTALL.md) -- install (Homebrew, apt, binary), terminal, font, clipboard, and MCP setup
-- [BUILD.md](BUILD.md) -- build from source: Rust toolchain, `make install`, cross-compilation
-- [ARCHITECTURE.md](ARCHITECTURE.md) -- concurrency model, MVU target shape, persistence, MCP transport
-- [docs/HARNESS.md](docs/HARNESS.md) -- running agents in spyc: recommended settings, per-agent screen modes, where scrollback lives, session-recovery quirks
-- [docs/AGENT_ORCHESTRATION.md](docs/AGENT_ORCHESTRATION.md) -- how the activity dots, notifications, session-resume, and scope registry fit together
-- [DESIGN.md](DESIGN.md) -- UI design language: components, surfaces, palette, extension checklist
-- [CHANGELOG.md](CHANGELOG.md) -- release history
-- [ROADMAP.md](ROADMAP.md) -- strategy, direction, and the decisions log
-- [CONTRIBUTING.md](CONTRIBUTING.md) -- contribution guidelines and SemVer policy
-- [Issues](https://github.com/Tripstack-Corp/spyc/issues) -- the live backlog: bugs, features, and ideas (labeled, on the [roadmap board](https://github.com/orgs/Tripstack-Corp/projects/1))
+| | |
+|---|---|
+| [FEATURES.md](FEATURES.md) | complete feature reference |
+| [docs/KEYBINDINGS.md](docs/KEYBINDINGS.md) | the full keymap, browsable |
+| [CONFIGURATION.md](CONFIGURATION.md) | `.spycrc.toml`, notifications, keymap DSL, Lua |
+| [INSTALL.md](INSTALL.md) | install channels, terminal, font, clipboard, MCP setup |
+| [BUILD.md](BUILD.md) | build from source, cross-compilation, the CURRENT stream |
+| [docs/HARNESS.md](docs/HARNESS.md) | running agents in spyc: per-agent quirks and settings |
+| [docs/AGENT_ORCHESTRATION.md](docs/AGENT_ORCHESTRATION.md) | activity dots, notifications, resume, scope registry |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | concurrency model, MVU shape, persistence, MCP transport |
+| [DESIGN.md](DESIGN.md) | UI design language: components, surfaces, palette |
+| [CHANGELOG.md](CHANGELOG.md) · [ROADMAP.md](ROADMAP.md) | release history · strategy and decisions log |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | contribution guidelines and SemVer policy |
+| [Issues](https://github.com/Tripstack-Corp/spyc/issues) | the live backlog, on the [roadmap board](https://github.com/orgs/Tripstack-Corp/projects/1) |
 
 ## License
 


### PR DESCRIPTION
**383 → 234 lines (−39%).** The cut is almost entirely *duplication*, not content — ~120 lines of Quick start restated an `INSTALL.md` that was already 317 lines, and "Recommended setup" repeated its terminal/font sections outright.

The storefront now reads: what it is → the screenshot → the tour → **two** install commands → first 5 minutes → the MCP bridge → keys → config → a docs index. Everything else is a link.

## What moved (nothing deleted outright)

| Content | New home | Why |
|---|---|---|
| Install matrix — apt block, tarballs, prerequisites, recommended setup | `INSTALL.md` | already carried all of it |
| "Running CURRENT (the development stream)" | `BUILD.md` | it already had the `git clone --single-branch` + `make install` recipe the README duplicated, and CURRENT is source-only |
| **`^a`/`^w` are reserved** warning | `CONFIGURATION.md`, beside the keymap DSL | **README was the only copy** |
| **Platforms** — macOS/Linux, x86_64/aarch64, Windows via WSL | `INSTALL.md`, new section | also README-only, and "does this run on my machine" deserves a real home |

The project-config sandbox blockquote was *dropped* rather than moved — `CONFIGURATION.md`'s "Security" paragraph already covers it. (My first grep missed it; the second found it before I deleted anything.)

## Kept, because it's what a storefront is for

All six media assets, the five-part tour (prose tightened, **no GIF dropped**), the first-5-minutes on-ramp, the essentials keybinding table, and the docs index — now a two-column table instead of a 15-item bullet list.

## Two accuracy gains while rewriting

- The skill-install note names all three hosts (claude / codex / agy); the old copy listed two.
- The MCP bridge section now mentions the **git + worktree** tools — a differentiator the old copy omitted entirely.

## Verification

All **12** relative links and all **8** image paths resolve. Every distinctive command from the old README was grepped across the doc set to confirm it still lands somewhere: `--verbose`, `--print-config`, `--install-skill`, the apt keyring line, `unix-word-rubout`, `font-meslo`, `wl-copy`, `managed-mcp.json`, `single-branch`. Docs-only — zero `.rs` touched.

## Note on the docs-site question

While measuring this I found that **GitHub Pages is already live on this repo and serving the signed apt archive** from `gh-pages` root — and `INSTALL.md` tells users to add `deb … https://tripstack-corp.github.io/spyc ./`, so that URL is on real machines. Any docs site here must not repoint the Pages source, must not use a generator that force-pushes an orphan branch (that deletes the index *and* every published `.deb`), and must not add a custom domain (it 301-redirects the apt base URL). Recommendation: when the site happens, host it separately and leave `gh-pages` to apt. Not part of this PR.

Generated with [Claude Code](https://claude.com/claude-code)
