### PR TITLE
test(guards): the module index can be satisfied by a longer sibling

### DIFF
--- a/src/app/mod_tests.rs
+++ b/src/app/mod_tests.rs
@@ -218,7 +218,14 @@ mod guard_tests {
             if matches!(name, "mod.rs" | "mod_tests.rs" | "test_harness.rs") {
                 continue;
             }
-            if !agents.contains(name) {
+            // Delimited, not substring: a bare `contains` lets a LONGER sibling
+            // satisfy a shorter name. An undocumented `route.rs` would be
+            // covered by the string `archive_route.rs`, `tabs.rs` by
+            // `pane_tabs.rs`, `scroll.rs` by `pane_scroll.rs`, `ops.rs` by
+            // `file_ops.rs` — four real pairs in this tree, so the guard would
+            // fail open exactly where the names are most similar. Every bullet
+            // backticks its module, and a few name one by path.
+            if !agents.contains(&format!("`{name}`")) && !agents.contains(&format!("/{name}")) {
                 missing.push(name.to_string());
             }
         }
@@ -226,8 +233,9 @@ mod guard_tests {
         assert!(
             missing.is_empty(),
             "src/app/ feature modules missing from the AGENTS.md module index: {missing:?}. \
-             Add a bullet for each (AGENTS.md → \"Keep docs in sync\") — a module absent \
-             from the map is the worktree_clean.rs gap the June-2026 review caught."
+             Add a bullet for each, naming the module in backticks (AGENTS.md → \
+             \"Keep docs in sync\") — a module absent from the map is the \
+             worktree_clean.rs gap the June-2026 review caught."
         );
     }
 

--- a/src/app/render/snapshots/spyc__app__render__render_tests__snapshot_frame_second_commander.snap
+++ b/src/app/render/snapshots/spyc__app__render__render_tests__snapshot_frame_second_commander.snap
@@ -1,6 +1,5 @@
 ---
 source: src/app/render/mod.rs
-assertion_line: 1010
 expression: "render_to_string(&mut app, 80, 24)"
 ---
  🌶️   /projects/other  [picks:0 inv:0 m1:on m2:on hidden:0 sort:name]          


### PR DESCRIPTION
**F15** and **F17** of the pre-2.1 review (`F-tests-guards.md`) — both
`informational`, both live on HEAD, both in the test infrastructure.

## F15 — a substring match fails open exactly where names collide

`every_app_module_is_in_the_agents_index` asked `agents.contains(name)`. So an
undocumented `route.rs` is "documented" by the string `archive_route.rs`
appearing anywhere in AGENTS.md. Four such pairs exist in this tree right now:

| undocumented module | would be covered by |
|---|---|
| `route.rs` | `archive_route.rs` |
| `tabs.rs` | `pane_tabs.rs` |
| `scroll.rs` | `pane_scroll.rs` |
| `ops.rs` | `file_ops.rs` |

The guard fails open precisely where module names are most similar — which is
where a missing bullet is hardest to spot by eye. Latent today (all 64 top-level
modules carry their own backticked mention), and the guard exists because of a
gap that wasn't latent: `worktree_clean.rs`, caught by the June-2026 review.

Now matched delimited — `` `name` `` or `/name` — which is how every bullet
already writes it.

**Bite-checked both directions** by stripping `route.rs`'s own mentions from
AGENTS.md while leaving `archive_route.rs` intact:

- HEAD's guard: `test result: ok. 1 passed` — the false pass, reproduced.
- After this change: `missing from the AGENTS.md module index: ["route.rs"]`.

## F17 — a snapshot header that guarantees a spurious diff

`snapshot_frame_second_commander.snap` carried `assertion_line: 1010`. Current
`insta` strips that field on accept, and its sibling snapshots don't have it — so
it was left behind by an older accept and will produce a churn diff on any edit
that shifts line numbers past 1010 in `render/mod.rs`. Removed; the 27 render
snapshot tests still pass, which is the check that it was metadata and not
content.

`make check-ci` → `=== GATE: PASS ===`.