### PR TITLE
docs: the last three informational findings — say the quiet parts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,7 +53,15 @@ log: agent harnesses commonly auto-approve MCP tool calls while gating
 shell execution behind per-command permission prompts, so an unvalidated
 `root` would bypass a boundary the *user* believes exists.
 
-**That set is not fixed, and the agent can widen it.** Two of its
+**The trusted anchor is spyc's launch directory, and every directory
+under it.** `is_within_allowed` accepts any descendant of the context
+root, which is where spyc was started. Launch it from `$HOME` — an
+ordinary thing to do with a file manager — and `~/.ssh` and `~/.aws` are
+inside an allowed root for every read tool. That follows from the design
+being about *scoping* rather than *confinement*, and it is what separates
+"validated against a set of roots" sounding tight from being tight.
+
+**That set is not fixed either, and the agent can widen it.** Two of its
 entries come from the cursor (`cwd`, `search_root`), and `navigate_to`
 sets `cwd` to any path the agent names — so `navigate_to("/etc")`
 followed by `search_content(…, root="/etc")` is allowed. `open_worktree`

--- a/src/app/clipboard.rs
+++ b/src/app/clipboard.rs
@@ -425,6 +425,12 @@ impl super::App {
     /// error carries every attempt's reason, since "yank failed" with no cause is
     /// the report that wastes an afternoon.
     ///
+    /// The cost of that rule, deliberate and worth knowing: under `Both` over
+    /// SSH, an oversized selection's OSC-52 refusal is discarded when the local
+    /// helper succeeds — so the text reached the *server's* clipboard only, and
+    /// the user is told "yanked". `Both` + SSH is exactly the configuration where
+    /// the swallowed error is the one they needed; `via = "osc52"` reports it.
+    ///
     /// OSC 52 is attempted first under `Both`: it can fail *knowably* (payload over
     /// the size limit), and a real error beats the local helper's silent
     /// success-on-the-wrong-machine.

--- a/src/pane/tabs.rs
+++ b/src/pane/tabs.rs
@@ -130,6 +130,12 @@ pub struct TabInfo {
     /// (`App::toggle_pane_suspend`); a `SIGCONT` resumes it. App-controlled, so
     /// it stays accurate without probing process state. Every tab but a shell
     /// one reaches this (a shell's `^z` is forwarded for its own job control).
+    ///
+    /// **Not persisted.** `SavedTab` has no counterpart, so a suspended tab
+    /// restores running — correctly: a `SIGSTOP` is a property of a process that
+    /// no longer exists after a restart, and re-creating the flag would show 💤
+    /// over a live child nothing had stopped. Pinned by
+    /// `a_restored_tab_is_not_suspended`.
     pub suspended: bool,
     /// Latest semantic self-report from the agent (`report_status` MCP tool),
     /// or `None`. Overrides output timing per the [`ReportedStatus`] authority
@@ -711,6 +717,38 @@ mod tests {
             tabs.push(dummy_tab());
         }
         tabs
+    }
+
+    /// A `^z`-suspended tab comes back running, and nothing carries the flag.
+    ///
+    /// `SIGSTOP` is a property of a process that doesn't survive the restart, so
+    /// re-creating `suspended` on restore would paint 💤 over a live child
+    /// nothing had stopped. That is the right call and it was undocumented and
+    /// unpinned — the same decision `a_restored_pane_starts_in_normal_cursor_mode`
+    /// pins for DECCKM.
+    #[test]
+    fn a_restored_tab_is_not_suspended() {
+        let info = TabInfo::new("claude", std::env::temp_dir());
+        assert!(!info.suspended, "a freshly built tab is not suspended");
+
+        // The save format is the other half: a field it doesn't carry cannot come
+        // back, whatever the tab looked like at quit time.
+        // Fields listed exhaustively on purpose: adding `suspended` to the save
+        // format would break this line before it reached the assertion.
+        let saved = serde_json::to_value(crate::state::sessions::SavedTab {
+            command: "claude".to_string(),
+            label: "claude".to_string(),
+            cwd: std::env::temp_dir(),
+            agent_kind: crate::state::sessions::AgentKind::Claude,
+            agent_session_id: None,
+            agent_session_name: None,
+            claim_owner: String::new(),
+        })
+        .expect("SavedTab serializes");
+        assert!(
+            saved.get("suspended").is_none(),
+            "SavedTab must not persist the suspend flag: {saved}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
**C-F12**, **D10** and **D11** of the pre-2.1 review — the informational tail.
Each is a deliberate decision that was correct and unwritten, which is the
category that gets "fixed" later by someone who reads it as a bug.

## C-F12 — the trusted anchor is the launch directory, and everything under it

`SECURITY.md` documents that the agent can *widen* the allowed-root set (F1's
subject, fixed in #382). It never said where the set starts: `is_within_allowed`
accepts any descendant of the context root, and the context root is where spyc
was launched.

Launch spyc from `$HOME` — an ordinary thing to do with a file manager — and
`~/.ssh` and `~/.aws` are inside an allowed root for every read tool, before any
widening. That follows from the design being about *scoping* rather than
*confinement*, and it is the difference between "validated against a set of
roots" sounding tight and being tight. Now stated.

## D10 — under `both` over SSH, the swallowed error is the one you needed

`deliver_clipboard` succeeds if **any** enabled mechanism succeeded, which is
right: with `via = "both"`, a terminal that ignores OSC 52 shouldn't make a
working local copy look like a failure.

The cost is one specific configuration. Over SSH with `both`, an oversized
selection's OSC-52 refusal is discarded because the local helper succeeded — so
the text reached the **server's** clipboard only, where the user can never paste
from it, and they are told "yanked". That is precisely the setup where the
discarded error was the informative one. Recorded on the function, with the
escape hatch (`via = "osc52"` reports it) named.

## D11 — a suspended tab restores running, on purpose

`TabInfo.suspended` isn't persisted, and neither the field doc nor `SavedTab`
said so. It is the right call — `SIGSTOP` is a property of a process that does
not survive the restart, so re-creating the flag would paint 💤 over a live child
nothing had stopped — but "right and unwritten" is how a correct behaviour gets
"fixed".

`a_restored_tab_is_not_suspended` pins it, the same way
`a_restored_pane_starts_in_normal_cursor_mode` pins the equivalent DECCKM
decision. It asserts both halves: a freshly built tab is unsuspended, and the
save format carries no such field.

The `SavedTab` literal lists its fields **exhaustively** rather than using
`..Default::default()`, so adding `suspended` to the save format is a compile
error inside the test rather than a silently-passing assertion. Bite-checked —
adding the field fails the build at the construction, before the assertion is
reached.

`make check-ci` → `=== GATE: PASS ===`.