### PR TITLE
fix(archive): HIGH-1's third site was never fixed, and nothing could tell

### DIFF
--- a/src/archive/read/mod.rs
+++ b/src/archive/read/mod.rs
@@ -402,9 +402,9 @@ pub fn member_bytes(archive: &Path, entry: &IndexEntry) -> Result<Vec<u8>> {
 /// is left in raw mode. Reserve a modest amount and let `read_to_end` grow on
 /// bytes that actually arrived: the declared size may bound a read, never an
 /// allocation.
-const RESERVE_CAP: u64 = 1 << 20;
+pub(super) const RESERVE_CAP: u64 = 1 << 20;
 
-fn reserve_for(declared: u64) -> usize {
+pub(super) fn reserve_for(declared: u64) -> usize {
     usize::try_from(declared.min(RESERVE_CAP)).unwrap_or(0)
 }
 

--- a/src/archive/read/tests.rs
+++ b/src/archive/read/tests.rs
@@ -1012,7 +1012,7 @@ fn materialize_refuses_a_member_behind_a_planted_link() {
 ///
 /// Built by hand: `tar::Builder` writes an honest header, and the whole point is
 /// a dishonest one.
-fn tar_with_declared_size(path: &Path, name: &str, declared: &[u8; 12], body: &[u8]) {
+fn tar_header_with_declared_size(name: &str, declared: &[u8; 12], body: &[u8]) -> Vec<u8> {
     let mut h = [0u8; 512];
     h[..name.len()].copy_from_slice(name.as_bytes());
     h[100..108].copy_from_slice(b"0000644\0");
@@ -1031,12 +1031,26 @@ fn tar_with_declared_size(path: &Path, name: &str, declared: &[u8; 12], body: &[
     let mut out = Vec::from(h);
     out.extend_from_slice(body);
     out.resize(out.len().div_ceil(512) * 512, 0);
+    out
+}
+
+fn tar_with_declared_size(path: &Path, name: &str, declared: &[u8; 12], body: &[u8]) {
+    let mut out = tar_header_with_declared_size(name, declared, body);
     out.extend_from_slice(&[0u8; 1024]);
     std::fs::write(path, out).unwrap();
 }
 
 /// The octal maximum (~64 GB) behind an empty body. Before the fix this reached
 /// `Vec::with_capacity(68719476735)`.
+///
+/// **What this pins is the READ, not the allocation.** `take(size).read_to_end`
+/// bounds the bytes either way, so these assertions hold with `reserve_for`
+/// removed — verified. The allocation half cannot be reproduced end-to-end here:
+/// a tar's octal size field tops out at ~64 GB, and a 64 GB reservation does not
+/// abort on a 64-bit host that overcommits. `reserve_for` is unit-tested below,
+/// and `every_declared_size_allocation_is_capped` is what ties the two together
+/// by requiring the call sites to use it — which is how `write.rs` kept a raw
+/// `with_capacity` through HIGH-1's fix.
 #[test]
 fn a_declared_size_far_beyond_the_file_does_not_drive_an_allocation() {
     let tmp = tempfile::tempdir().unwrap();
@@ -1069,6 +1083,66 @@ fn a_reservation_is_capped_however_large_the_claim() {
     assert_eq!(reserve_for(64), 64);
     assert_eq!(reserve_for(u64::MAX), RESERVE_CAP as usize);
     assert_eq!(reserve_for(RESERVE_CAP * 4096), RESERVE_CAP as usize);
+}
+
+/// Every declared-size allocation in `src/archive/` goes through
+/// [`reserve_for`].
+///
+/// HIGH-1 named three sites. Two were fixed and `reserve_for` was unit-tested,
+/// and `write.rs`'s `read_at` kept `Vec::with_capacity(usize::try_from(size))`
+/// for the whole campaign — reachable, because a plain `.tar` is seekable, so
+/// mounting one extracts nothing and the extract budget never inspects it: a
+/// header lying about its size mounts fine and lands there on the first
+/// `:archive write`.
+///
+/// Nothing caught it. The end-to-end test pins the *read* (which `take` bounds
+/// anyway) and the unit test pins the *function* — neither connects the function
+/// to its call sites, and the allocation itself can't be provoked from a tar
+/// header on a 64-bit host (octal sizes cap at ~64 GB, which overcommit absorbs).
+///
+/// So the property has to be checked structurally. A raw `with_capacity` on a
+/// container's declared size is the one shape this whole finding is about.
+#[test]
+fn every_declared_size_allocation_is_capped() {
+    // Split so this guard's own source can't match the needle.
+    let needle = ["with_", "capacity("].concat();
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/archive");
+    let mut offenders = Vec::new();
+
+    fn scan(dir: &std::path::Path, needle: &str, offenders: &mut Vec<String>) {
+        for entry in std::fs::read_dir(dir).expect("read archive dir") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                scan(&path, needle, offenders);
+                continue;
+            }
+            if path.extension().is_none_or(|e| e != "rs") {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("read .rs");
+            let production = crate::guard_support::production_half(&text);
+            for (i, line) in production.lines().enumerate() {
+                // Comments about the hazard are not the hazard.
+                if line.trim_start().starts_with("//") || !line.contains(needle) {
+                    continue;
+                }
+                if !line.contains("reserve_for(") {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                    offenders.push(format!("{name}:{}", i + 1));
+                }
+            }
+        }
+    }
+    scan(&root, &needle, &mut offenders);
+    offenders.sort();
+
+    assert!(
+        offenders.is_empty(),
+        "these reserve a container's declared size before seeing a byte — route \
+         them through `read::reserve_for`, which caps it. A big enough lie \
+         *aborts* the process rather than unwinding, so the panic hook never \
+         restores the terminal. Offenders: {offenders:?}"
+    );
 }
 
 /// The bomb gate has to measure what arrives. A header declaring 0 while the

--- a/src/archive/write.rs
+++ b/src/archive/write.rs
@@ -327,10 +327,17 @@ fn header_for(entry: &super::IndexEntry, size: u64) -> tar::Header {
     header
 }
 
+/// Read a tar member's stored bytes for the repack.
+///
+/// `size` is the member's **declared** size, straight off an attacker-supplied
+/// header, so it bounds the read (`take`) and must never bound the allocation —
+/// see [`read::reserve_for`]. A plain `.tar` is seekable, so mounting one costs
+/// no disk and the extract budget never looks at it: a header lying about its
+/// size sails through the mount and lands here on the first `:archive write`.
 fn read_at(archive: &Path, offset: u64, size: u64) -> Result<Vec<u8>> {
     let mut f = File::open(archive).with_context(|| format!("opening {}", archive.display()))?;
     f.seek(SeekFrom::Start(offset))?;
-    let mut bytes = Vec::with_capacity(usize::try_from(size).unwrap_or(0));
+    let mut bytes = Vec::with_capacity(read::reserve_for(size));
     f.take(size).read_to_end(&mut bytes)?;
     Ok(bytes)
 }


### PR DESCRIPTION
Found while verifying the claim that the pre-2.1 audit was fully closed. It
wasn't: **HIGH-1 named three sites and only two were fixed.**

```rust
// src/archive/write.rs — read_at, on HEAD
let mut bytes = Vec::with_capacity(usize::try_from(size).unwrap_or(0));
```

`size` is a tar member's **declared** size, straight off an attacker-supplied
header. `reserve_for` — added by HIGH-1's own fix, with a doc comment explaining
that an oversized reservation *aborts* the process rather than unwinding, so the
panic hook never restores the terminal — was applied to the two read sites and
not to this one.

**Reachable.** A plain `.tar` is seekable, so mounting one extracts nothing and
`decide_mount` never inspects it (`needs_extraction: false`). A header lying
about its size therefore mounts cleanly and reaches `read_at` on the first
`:archive write`, via `StepSource::Archived` + `Locator::TarData`.

## Why three tests all missed it

This is the campaign's own recurring shape — *the adjacent case is tested* —
in its sharpest form. Three things existed and none of them connected:

1. `a_declared_size_far_beyond_the_file_does_not_drive_an_allocation` pins the
   **read**, not the allocation. `take(size).read_to_end` bounds the bytes
   whether or not the reservation is capped — **verified: it passes with
   `reserve_for` removed from both read sites.** Its doc now says so.
2. `reserve_for` is unit-tested, correctly, but a tested function proves nothing
   about the sites that don't call it.
3. The end-to-end abort **cannot be provoked from a tar fixture** on a 64-bit
   host: the octal size field tops out at ~64 GB, and a 64 GB reservation is
   absorbed by overcommit. My first attempt at a write-path regression test
   passed with the defect restored, which is how I found this out.

So the property is only checkable structurally.

## The fix

`read_at` routes through `read::reserve_for`, and
`every_declared_size_allocation_is_capped` requires every `with_capacity` in
`src/archive/` production code to do the same.

**Bite-checked against all three of HIGH-1's sites** — the guard names each:

| restored defect | guard output |
|---|---|
| `write.rs`'s `read_at` (i.e. HEAD) | `Offenders: ["write.rs:340"]` |
| `read_zip_member` | `Offenders: ["mod.rs:415"]` |

That first row is the point: this is what HEAD looks like, and the guard fails on
it.

`make check-ci` → `=== GATE: PASS ===`.