### PR TITLE
fix(pane): scrolling past the end of a scrollback returns you to the live pane

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -397,7 +397,9 @@ spyc's workflow: browse files above, talk to Claude below.
   capture and an agent's transcript, and (in an agent transcript)
   `t` toggles tool-call lines. The pty keeps running off-screen — output
   you miss while reading lands in scrollback for the next view. `Esc`
-  snaps back to live.
+  snaps back to live — and so does scrolling *down past the end*, so a
+  flick out the bottom returns you to the agent rather than parking you
+  at `[EOF]`.
   - The fundamental limit is that full-screen TUIs do *virtual
     scrolling* inside a fixed grid — old content lives in app
     memory, not the terminal — so even a parallel vt100 parser

--- a/docs/HARNESS.md
+++ b/docs/HARNESS.md
@@ -139,6 +139,9 @@ Inside either view:
   only; a long tool-heavy session is much easier to read with them off)
 - `l` — toggle line numbers
 - `/` — search, `r` — reload
+- scrolling **down past the end** leaves scroll mode and snaps back to the live
+  pane — the same as `Esc`, so a flick out the bottom returns you to the agent
+  instead of parking you at `[EOF]`
 
 Transcript sources per agent live under `src/state/` (`claude_transcript.rs`,
 `codex_transcript.rs`, `agy_transcript.rs`). zot has none yet.

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -180,7 +180,8 @@ in place:
   scrolled-back rather than live). On an agent tab it shows the
   agent's transcript instead whenever the terminal has nothing to
   show; `T` swaps between the two when both exist, `t` toggles
-  tool-call lines, `r` reloads.
+  tool-call lines, `r` reloads. Scrolling down past the end exits back
+  to the live pane, same as `Esc`.
 
 Inside the pager: `/` search with `n`/`N`, `:N` jump-to-line,
 `V` arms visual line mode — first `V` places a line cursor you

--- a/src/app/pager_handler/mod.rs
+++ b/src/app/pager_handler/mod.rs
@@ -452,13 +452,22 @@ impl App {
     /// over, not the focused one, so the wheel scrolls what you are looking at.
     pub(super) fn scroll_pager_in_slot(&mut self, slot: PagerSlot, delta: i32) {
         let viewport = self.pager_viewport();
-        if let Some(view) = self.pager_in_slot_mut(slot) {
+        // A wheel-down that can't move in a `^a v` scrollback exits it, the same as
+        // the keyboard's `j` — see `exit_scrollback_past_the_end`. Decided against
+        // THIS slot rather than the focused pager: the wheel follows the pointer, so
+        // the view under it is the one that gets to close.
+        let exit_scrollback = self.pager_in_slot_mut(slot).is_some_and(|view| {
             // Prefer the height the renderer recorded for THIS pager; `pager_viewport`
             // reports the focused one, which is a different box when the pointer is
             // over the other column.
             let h = view.last_viewport_h.get();
             let h = if h >= 2 { h } else { viewport };
-            view.scroll_by(delta, h);
+            let is_scrollback = view.pane_scroll;
+            let moved = motion::scrolled_down(view, delta, h);
+            is_scrollback && delta > 0 && !moved
+        });
+        if exit_scrollback {
+            self.close_pane_scroll_pager();
         }
     }
 

--- a/src/app/pager_handler/motion.rs
+++ b/src/app/pager_handler/motion.rs
@@ -11,6 +11,24 @@ use crate::app::{App, Effect, PagerReturn, TaskStatus, sh_c};
 
 impl App {
     /// Fall-through: scroll / vi-motion / toggles / close / editor handoff.
+    /// A down-scroll in a `^a v` scrollback that had nowhere left to go: leave
+    /// scroll mode and snap back to the live pane.
+    ///
+    /// The same "scroll past the end and you're back" contract the raw vt100
+    /// scroll mode already has ([`crate::pane::Pane::scroll_down_or_exit`]), and
+    /// the one spyc gives codex's own overlay by sending it `q`. This pager is
+    /// spyc's, so there is no key to send — it just closes.
+    ///
+    /// Gated on `pane_scroll`: a `D` doc, a `:grep` overlay or the scrollback's
+    /// own `H` help (which deliberately carries `pane_scroll = false`) must sit
+    /// still at their end. The user didn't open those *over* something they are
+    /// trying to get back to.
+    fn exit_scrollback_past_the_end(&mut self) {
+        if self.active_pager_ref().is_some_and(|v| v.pane_scroll) {
+            self.close_pane_scroll_pager();
+        }
+    }
+
     pub(super) fn handle_pager_motion(&mut self, key: KeyEvent, viewport: u16) -> Vec<Effect> {
         let Some(view) = active_pager_mut!(self) else {
             return Vec::new();
@@ -155,21 +173,33 @@ impl App {
                     self.view.pager_pending_bracket = Some(c);
                 }
             }
-            KeyCode::Char('j') | KeyCode::Down => view.scroll_by(1, viewport),
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !scrolled_down(view, 1, viewport) {
+                    self.exit_scrollback_past_the_end();
+                }
+            }
             KeyCode::Char('k') | KeyCode::Up => view.scroll_by(-1, viewport),
             KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                view.scroll_by(i32::from(viewport) / 2, viewport);
+                if !scrolled_down(view, i32::from(viewport) / 2, viewport) {
+                    self.exit_scrollback_past_the_end();
+                }
             }
             KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 view.scroll_by(-i32::from(viewport) / 2, viewport);
             }
             KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                view.scroll_by(i32::from(viewport), viewport);
+                if !scrolled_down(view, i32::from(viewport), viewport) {
+                    self.exit_scrollback_past_the_end();
+                }
             }
             KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 view.scroll_by(-i32::from(viewport), viewport);
             }
-            KeyCode::PageDown | KeyCode::Char(' ') => view.scroll_by(i32::from(viewport), viewport),
+            KeyCode::PageDown | KeyCode::Char(' ') => {
+                if !scrolled_down(view, i32::from(viewport), viewport) {
+                    self.exit_scrollback_past_the_end();
+                }
+            }
             KeyCode::PageUp | KeyCode::Char('b') => view.scroll_by(-i32::from(viewport), viewport),
             KeyCode::Char('g') | KeyCode::Home => view.scroll_to_top(),
             KeyCode::Char('G') | KeyCode::End => view.scroll_to_bottom(viewport),
@@ -477,5 +507,96 @@ impl App {
             _ => {}
         }
         Vec::new()
+    }
+}
+
+/// Scroll `view` down by `delta` and report whether it actually moved.
+///
+/// `false` means it was already at the end. Deliberately derived from the scroll
+/// position rather than from a separate "am I at the bottom?" computation:
+/// `scroll_by` already clamps against `scroll_max`, and a second derivation of
+/// where the bottom is would be free to disagree with the first — which is how a
+/// view ends up either refusing to exit or exiting one line early.
+pub(super) fn scrolled_down(
+    view: &mut crate::ui::pager::PagerView,
+    delta: i32,
+    viewport: u16,
+) -> bool {
+    let before = view.scroll;
+    view.scroll_by(delta, viewport);
+    view.scroll != before
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::App;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn down() -> KeyEvent {
+        KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE)
+    }
+
+    fn fifty_lines() -> Vec<ratatui::text::Line<'static>> {
+        (0..50).map(|i| format!("line {i}").into()).collect()
+    }
+
+    /// **Scrolling down past the end of a `^a v` scrollback returns you to the
+    /// live pane.** The same contract the raw vt100 scroll mode has, and the one
+    /// spyc gives codex's own overlay by sending it `q` — this pager is spyc's, so
+    /// it just closes. Without it the user is parked at `[EOF]` hunting for `Esc`.
+    #[test]
+    fn scrolling_past_the_end_of_a_scrollback_returns_to_the_live_pane() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let dir = tmp.path().join("work");
+            std::fs::create_dir(&dir).unwrap();
+            let mut app = App::test_app(dir);
+            app.open_pane_tab("cat");
+            app.install_lower_pane_scroll_view(" pane (history)".to_string(), fifty_lines(), None);
+            assert!(app.view.scroll_pager.is_some(), "the scrollback mounted");
+
+            // Mid-history: the scroll moves, so it must NOT close.
+            app.handle_pager_motion(down(), 10);
+            assert!(
+                app.view.scroll_pager.is_some(),
+                "a scroll with somewhere to go must not exit"
+            );
+
+            // Park at the very end, then one more down.
+            if let Some(v) = app.view.scroll_pager.as_mut() {
+                v.scroll_by(1000, 10);
+            }
+            app.handle_pager_motion(down(), 10);
+            assert!(
+                app.view.scroll_pager.is_none(),
+                "a down-scroll with nowhere to go exits back to the live pane"
+            );
+        });
+    }
+
+    /// The gate: a pager that is NOT a pane scrollback (a `D` doc, a `:grep`
+    /// overlay, the scrollback's own `H` help) sits still at its end. Nothing
+    /// behind it is being reached for, so closing on a stray down-scroll would
+    /// only lose the user's place.
+    #[test]
+    fn a_non_scrollback_pager_stays_open_at_its_end() {
+        let tmp = tempfile::tempdir().unwrap();
+        crate::state::with_state_root(tmp.path(), || {
+            let dir = tmp.path().join("work");
+            std::fs::create_dir(&dir).unwrap();
+            let mut app = App::test_app(dir);
+            let mut view =
+                crate::ui::pager::PagerView::new_styled("doc".to_string(), fifty_lines());
+            view.mount = crate::ui::pager::Mount::TopPane;
+            assert!(!view.pane_scroll, "a `D` doc is not a pane scrollback");
+            view.scroll_by(1000, 10);
+            app.view.pager = Some(view);
+
+            app.handle_pager_motion(down(), 10);
+            assert!(
+                app.view.pager.is_some(),
+                "only a pane scrollback exits on a down-scroll past the end"
+            );
+        });
     }
 }


### PR DESCRIPTION
Reported from driving inline claude: the `^a v` pager parks at `[EOF]` and stays
there, leaving you to find `Esc`.

The raw vt100 scroll mode has had the opposite behaviour for ages
(`Pane::scroll_down_or_exit`), and spyc gives codex's own overlay the same thing
by sending it `q` when a wheel-down runs out of history. This pager is spyc's, so
there is no key to send — it just closes.

## What's wired

Every downward motion (`j` / Down, `^d`, `^f`, PageDown / Space) plus **the
wheel**, which reaches the pager by a different path (`scroll_pager_in_slot`) and
would otherwise have kept the old behaviour — the exact split that lets a fix
look done while the gesture people actually use is untouched.

The wheel decides against the slot under the **pointer**, not the focused pager,
matching how every other wheel decision in spyc is made.

## "At the end" is not computed twice

Derived from *the scroll not moving*. `scroll_by` already clamps against
`scroll_max`, so asking whether it moved reuses that single derivation rather than
computing where the bottom is a second time — two derivations would be free to
disagree, and the failure modes are "refuses to exit" and "exits one line early".

Note `scroll_max` deliberately reserves a row past the last line so `[EOF]` is
reachable (vim/less parity), which means you get one deliberate keypress *at* the
end before it closes. Not an accidental exit.

## What stays put

Gated on `pane_scroll`, so a `D` doc, a `:grep` overlay and the scrollback's own
`H` help all sit still at their end. Nothing behind those is being reached for,
and closing them on a stray flick would only lose the user's place. That's the
second test.

## Tests

Both directions, beside the code in `motion.rs` rather than widening
`handle_pager_motion`'s visibility to reach it from the harness. The exit test was
**verified to bite** — neutering the close makes it fail.

`make check-ci` → `=== GATE: PASS ===`.

## Not in this PR

The same report included garbled rendering of Devanagari text in the capture view.
That is a separate defect with a different cause — width drift when a positional
cell grid is re-rendered as flowed text — and it needs its own decision about how
far to go. Written up for the owner rather than guessed at here.

Generated with [Claude Code](https://claude.com/claude-code)
