### PR TITLE
fix(mcp): the read cap bounds the bytes, not the archive's claim about them

### DIFF
--- a/src/archive/read/mod.rs
+++ b/src/archive/read/mod.rs
@@ -338,7 +338,9 @@ pub fn materialize(archive: &Path, entry: &IndexEntry, staging_root: &Path) -> R
     }
     create_parent(&dest)?;
     let bytes = match entry.locator {
-        Locator::Zip { index: pos } => read_zip_member(archive, pos)?,
+        // Materialize wants the whole member — the mount budget is what bounds
+        // this path, not a per-read ceiling.
+        Locator::Zip { index: pos } => read_zip_member(archive, pos, u64::MAX)?,
         Locator::TarData { offset } => read_tar_member(archive, offset, entry.size)?,
         // Already on disk (a streamed mount, or the user's own file) — if it
         // isn't there, it was removed behind our back.
@@ -380,18 +382,44 @@ pub fn materialize(archive: &Path, entry: &IndexEntry, staging_root: &Path) -> R
 /// extracted, so a read from outside the event loop that staged its own copy
 /// would make the archive read as changed.
 pub fn member_bytes(archive: &Path, entry: &IndexEntry) -> Result<Vec<u8>> {
+    member_bytes_within(archive, entry, u64::MAX)
+}
+
+/// A member's bytes, refusing anything past `cap`.
+///
+/// The **declared** size cannot enforce a ceiling. For a zip the crate
+/// decompresses the real stream, so a central directory claiming `size: 1` for a
+/// 300 KB member hands back all 300 KB — measured, and it is how the MCP read cap
+/// was bypassed (HIGH-2's PoC). A caller with a byte limit has to count what
+/// ARRIVES, and stop there rather than after.
+///
+/// (A tar is safe in that direction on its own: the stored bytes end where the
+/// next header begins, so `take(size)` under-reads on a lie rather than
+/// over-reading. The cap applies to both anyway — one rule beats two.)
+pub fn member_bytes_within(archive: &Path, entry: &IndexEntry, cap: u64) -> Result<Vec<u8>> {
     if !entry.readable {
         bail!("{}: encrypted or unsupported compression", entry.inner);
     }
-    match entry.locator {
-        Locator::Zip { index: pos } => read_zip_member(archive, pos),
-        Locator::TarData { offset } => read_tar_member(archive, offset, entry.size),
+    // One byte past the cap, so "exactly at the limit" is allowed and "over" is
+    // detectable without reading the rest of it.
+    let probe = cap.saturating_add(1);
+    let bytes = match entry.locator {
+        Locator::Zip { index: pos } => read_zip_member(archive, pos, probe),
+        Locator::TarData { offset } => read_tar_member(archive, offset, entry.size.min(probe)),
         // Only a streamed mount produces these, and its bytes are already on
         // disk — there is nothing in the container to re-read them from.
         Locator::Staged | Locator::Implied => {
             bail!("{}: staged bytes are missing", entry.inner)
         }
+    }?;
+    if bytes.len() as u64 > cap {
+        bail!(
+            "{}: larger than the {} KB read limit",
+            entry.inner,
+            cap / 1024
+        );
     }
+    Ok(bytes)
 }
 
 /// How much of a declared size we are willing to reserve before seeing a byte.
@@ -408,12 +436,15 @@ pub(super) fn reserve_for(declared: u64) -> usize {
     usize::try_from(declared.min(RESERVE_CAP)).unwrap_or(0)
 }
 
-fn read_zip_member(archive: &Path, pos: usize) -> Result<Vec<u8>> {
+fn read_zip_member(archive: &Path, pos: usize, limit: u64) -> Result<Vec<u8>> {
     let file = File::open(archive).with_context(|| format!("opening {}", archive.display()))?;
     let mut zip = zip::ZipArchive::new(BufReader::new(file))?;
-    let mut member = zip.by_index(pos)?;
-    let mut bytes = Vec::with_capacity(reserve_for(member.size()));
-    member.read_to_end(&mut bytes)?;
+    let member = zip.by_index(pos)?;
+    let mut bytes = Vec::with_capacity(reserve_for(member.size().min(limit)));
+    // Bounded on the way in, not checked on the way out: the caller's ceiling is
+    // there to keep an oversized member out of memory, so reading it all and
+    // then complaining would have already paid the cost.
+    member.take(limit).read_to_end(&mut bytes)?;
     Ok(bytes)
 }
 

--- a/src/archive/read/tests.rs
+++ b/src/archive/read/tests.rs
@@ -1051,6 +1051,61 @@ fn tar_with_declared_size(path: &Path, name: &str, declared: &[u8; 12], body: &[
 /// and `every_declared_size_allocation_is_capped` is what ties the two together
 /// by requiring the call sites to use it — which is how `write.rs` kept a raw
 /// `with_capacity` through HIGH-1's fix.
+/// HIGH-2's PoC, in the direction that stayed live: a member **understating**
+/// its size.
+///
+/// The finding named three consequences of trusting a zip's declared size. Two
+/// were fixed — the allocation (`reserve_for`) and the decompression-bomb gate
+/// (`size_is_exact`). The third, the MCP 100 KB read cap, checked the declaration
+/// and nothing checked the bytes: a central directory claiming `size: 1` for a
+/// 300 KB member sailed past the cap and `member_bytes` returned all 300 KB.
+/// Measured, before this fix, at exactly that.
+///
+/// A tar can't do this (its stored bytes end where the next header begins, so a
+/// lie under-reads), which is part of why the zip half was easy to miss.
+#[test]
+fn an_understated_zip_size_cannot_smuggle_bytes_past_a_read_cap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let archive = tmp.path().join("liar.zip");
+    let body = vec![b'A'; 300_000];
+    {
+        let mut w = zip::ZipWriter::new(File::create(&archive).unwrap());
+        w.start_file("big.txt", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        w.write_all(&body).unwrap();
+        w.finish().unwrap();
+    }
+    // Patch the central directory's uncompressed-size field to 1. `ZipWriter`
+    // writes an honest header; the whole point is a dishonest one.
+    let mut raw = std::fs::read(&archive).unwrap();
+    let cd = raw
+        .windows(4)
+        .rposition(|w| w == [0x50, 0x4b, 0x01, 0x02])
+        .expect("central directory header");
+    raw[cd + 24..cd + 28].copy_from_slice(&1u32.to_le_bytes());
+    std::fs::write(&archive, &raw).unwrap();
+
+    let indexed = index_seekable(&archive, ArchiveFormat::Zip, 1000).unwrap();
+    let entry = indexed.index.get("big.txt").expect("indexed");
+    assert_eq!(
+        entry.size, 1,
+        "the index must carry the LIE; without that this test proves nothing"
+    );
+
+    // A 100 KB ceiling, the same one `mcp::readers` applies.
+    let cap = 100 * 1024;
+    let err = member_bytes_within(&archive, entry, cap)
+        .expect_err("300 KB must not come back under a 100 KB cap");
+    assert!(
+        format!("{err:#}").contains("read limit"),
+        "must say why: {err:#}"
+    );
+
+    // The uncapped path is unchanged — this is a ceiling, not a new refusal.
+    let all = member_bytes(&archive, entry).expect("uncapped read still works");
+    assert_eq!(all.len(), 300_000, "and still returns the real bytes");
+}
+
 #[test]
 fn a_declared_size_far_beyond_the_file_does_not_drive_an_allocation() {
     let tmp = tempfile::tempdir().unwrap();

--- a/src/mcp/readers.rs
+++ b/src/mcp/readers.rs
@@ -258,8 +258,10 @@ fn read_member_from_archive(archive: &Path, inner: &str) -> Result<String, Strin
     if entry.kind == crate::archive::index::ArchiveEntryKind::Dir {
         return Err(format!("{inner}: is a directory"));
     }
-    // Checked before reading, so an enormous member costs an index lookup rather
-    // than the allocation.
+    // A cheap short-circuit on the DECLARED size: an honestly-large member is
+    // refused for the cost of an index lookup. It is NOT the enforcement — the
+    // declaration is the archive's claim, and a zip understating it hands back
+    // the real stream regardless (HIGH-2). `member_bytes_within` bounds the bytes.
     if entry.size > MAX_READ_BYTES {
         return Err(format!(
             "{inner}: file too large ({} KB, limit {} KB)",
@@ -267,7 +269,7 @@ fn read_member_from_archive(archive: &Path, inner: &str) -> Result<String, Strin
             MAX_READ_BYTES / 1024
         ));
     }
-    let bytes = crate::archive::read::member_bytes(archive, entry)
+    let bytes = crate::archive::read::member_bytes_within(archive, entry, MAX_READ_BYTES)
         .map_err(|e| format!("{inner}: {e:#}"))?;
     let check_len = bytes.len().min(8192);
     if bytes[..check_len].contains(&0) {

--- a/src/mcp/tests/mod.rs
+++ b/src/mcp/tests/mod.rs
@@ -1457,6 +1457,78 @@ fn searching_inside_a_mount_is_refused_rather_than_answered_emptily() {
 /// The archive branch of `get_file_content` used to answer before the root
 /// check, so "spyc has this mounted" was the only bound on it — and a mount can
 /// be anywhere. The member path can't be canonicalized (the mount root is a
+/// HIGH-2 at the layer that owns the ceiling.
+///
+/// `read_member_content` refuses a member over `MAX_READ_BYTES` by testing
+/// `entry.size` — the archive's own claim. A zip understating it walks straight
+/// through that check, and the crate then decompresses the real stream. This
+/// pins the WIRING: the sibling test in `archive::read` covers
+/// `member_bytes_within` itself, and the whole finding is that a bounded
+/// function nobody calls bounds nothing.
+#[test]
+fn an_understated_member_size_does_not_defeat_the_mcp_read_cap() {
+    use std::io::Write as _;
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().join("project");
+    std::fs::create_dir_all(&dir).unwrap();
+    let staging = tmp.path().join("staging");
+
+    // A zip whose central directory claims 1 byte for a 300 KB member.
+    let archive = dir.join("liar.zip");
+    {
+        let mut w = zip::ZipWriter::new(std::fs::File::create(&archive).unwrap());
+        let opts = zip::write::SimpleFileOptions::default();
+        w.start_file("big.txt", opts).unwrap();
+        w.write_all(&vec![b'A'; 300_000]).unwrap();
+        w.start_file("small.txt", opts).unwrap();
+        w.write_all(b"honest\n").unwrap();
+        w.finish().unwrap();
+    }
+    let mut raw = std::fs::read(&archive).unwrap();
+    let cd = raw
+        .windows(4)
+        .position(|w| w == [0x50, 0x4b, 0x01, 0x02])
+        .expect("central directory header");
+    raw[cd + 24..cd + 28].copy_from_slice(&1u32.to_le_bytes());
+    std::fs::write(&archive, &raw).unwrap();
+
+    let ctx = context::SpycContext {
+        cwd: archive.clone(),
+        cursor_file: None,
+        picks: vec![],
+        inventory: vec![],
+        filter: None,
+        git_branch: None,
+        project_home: Some(dir.clone()),
+        search_root: Some(dir.clone()),
+        session_name: String::new(),
+        pid: 0,
+        version: String::new(),
+        archive_mounts: vec![context::ArchiveMountRef {
+            root: archive.clone(),
+            staging,
+            source: None,
+        }],
+    };
+    let ctx_path = context::context_path(&dir);
+    context::write_context_file(&ctx_path, &ctx).unwrap();
+
+    let out = super::readers::read_member_content(&archive.join("big.txt"), &ctx_path, &dir)
+        .expect("recognised as a member");
+    let err = out.expect_err("300 KB must not come back under a 100 KB cap");
+    assert!(
+        err.contains("read limit") || err.contains("too large"),
+        "the refusal must name the limit: {err}"
+    );
+
+    // The honest member in the same archive is unaffected — a ceiling, not a
+    // new refusal.
+    let ok = super::readers::read_member_content(&archive.join("small.txt"), &ctx_path, &dir)
+        .expect("recognised")
+        .expect("and served");
+    assert!(ok.contains("honest"), "{ok:?}");
+}
+
 /// file, so everything under it is ENOTDIR), but the container is an ordinary
 /// file and that is what has to be inside the root.
 #[test]


### PR DESCRIPTION
**HIGH-2's third consequence was never closed.** Found by verifying the audit's
closure record against the code instead of trusting it — the same sweep that
turned up HIGH-1's third site (#412).

H2 named three ways a zip's *declared* uncompressed size was trusted. Two were
fixed: the allocation (`reserve_for`) and the decompression-bomb gate
(`size_is_exact`). The third — the MCP 100 KB read cap — was not.

```rust
// read_member_content, on HEAD
if entry.size > MAX_READ_BYTES { return Err(…) }   // the archive's claim
let bytes = member_bytes(archive, entry)?;          // the real stream
```

`entry.size` is the central directory's number. The `zip` crate decompresses the
actual member, so a header claiming `size: 1` walks through the check and hands
back everything. **Measured on HEAD: declared 1, returned 300,000 bytes** — the
reviewer's original PoC, still live, straight into an agent's context and memory.

A tar can't do this: its stored bytes end where the next header begins, so a lie
under-reads. That asymmetry is part of why the zip half was easy to miss.

## The fix

`member_bytes_within(archive, entry, cap)` bounds the read **on the way in**
(`take(cap + 1)`), so an oversized member never lands in memory to be complained
about afterwards. `member_bytes` keeps its meaning as the uncapped read for
materialize and yank, where the mount budget is the ceiling.

The declared-size pre-check stays as a cheap short-circuit — an honestly-large
member is still refused for the cost of an index lookup — but its comment now
says it is not the enforcement.

## Two tests, and the second is the point

- `an_understated_zip_size_cannot_smuggle_bytes_past_a_read_cap` — the function.
- `an_understated_member_size_does_not_defeat_the_mcp_read_cap` — the **wiring**.

I needed the second one. While writing this I edited `readers.rs` inside a `&&`
chain that short-circuited on a `grep -c` returning 0, so the wiring silently
never landed — and the function test passed anyway, because it calls
`member_bytes_within` directly. I nearly shipped a bounded function that nothing
called.

**Bite-checked at exactly that state** — bounded function, unwired caller:

```
archive::read::tests::an_understated_zip_size_… ... ok
mcp::tests::an_understated_member_size_…        ... FAILED
```

Which is this campaign's first recurring shape (*the pure decision is tested and
its wiring is not*) reproduced in the fix for it.

`make check-ci` → `=== GATE: PASS ===`.