### PR TITLE
docs(archive): file the Aug-2026 engagement records, minus the two still live

### DIFF
--- a/docs/archive/engagements/README.md
+++ b/docs/archive/engagements/README.md
@@ -1,0 +1,44 @@
+# Engagement records — code review and cleanup, Aug 2026
+
+The briefs, proposals and deliverables from the two engagements that ran before
+the pre-2.1 review (`docs/archive/review-2.1/`). Kept because the deliverables
+name which PR closed which finding, which is the only place that mapping exists
+outside individual commit messages.
+
+| File | What it is | Outcome |
+|---|---|---|
+| `spyc-review-remediation-prompt.md` (+ `v2`, `v3`, `v4`) | The engagement brief, four drafts. `v4` is the one the deliverable cites. | superseded by the deliverable |
+| `review-remediation-deliverable.md` | F1–F7, twelve PRs | all merged |
+| `agents-md-trim-proposal.md` | F7 — AGENTS.md was 43 KB of always-loaded context | executed, #243 |
+| `mouse-rs-decomposition-proposal.md` | F4 Part B — split `src/app/mouse.rs` | executed, #244–#246 |
+
+## What is deliberately NOT archived here
+
+Two documents stayed in `docs/drafts/` because they still carry unfinished work.
+Moving them would have filed them as done:
+
+- **`pane-identity-transport-proposal.md`** (C7) — a design proposal recommending
+  pane id in the MCP `initialize` handshake. Never built. `pane_id` exists today
+  only as an optional *tool argument* on `report_status` / `register_scope` /
+  `release_scope` — which is the option the proposal explicitly rejects, because
+  attribution then fails silently whenever an agent forgets to send it.
+  `readers.rs` still documents the cursor-independent session-wide allowed set
+  that per-pane roots were meant to retire.
+- **`cleanup-engagement-deliverable.md`** — C1–C9 are merged, but its
+  "Found along the way — not fixed" section lists seven items and they are not
+  all closed. Item 2 asks SECURITY.md to state that pane attribution is not
+  authorization — an env-supplied pane id is forgeable by the agent, and so is
+  the per-pane socket, since both are owned by the same uid the agent runs as.
+  SECURITY.md still does not say it.
+
+## A note on the AGENTS.md trim
+
+F7 was executed and the section it targeted did shrink — `## What it does` went
+from 16,427 bytes to 8,272. The file as a whole did not: it was 43,256 bytes when
+the proposal called it too large and is larger now, with `## Architecture` (the
+guard-checked module index, plus its per-entry prose) grown from 10,895 to 20,457
+and holding the largest share.
+
+That is not an unclosed comment — the cut that was approved was made. It is a
+fresh observation, recorded here so the next person to open the trim proposal
+knows the finding is more true than when it was written, not less.

--- a/docs/archive/engagements/agents-md-trim-proposal.md
+++ b/docs/archive/engagements/agents-md-trim-proposal.md
@@ -1,0 +1,112 @@
+# AGENTS.md trim — cut list awaiting approval (F7)
+
+**Status:** proposal. No edits made to AGENTS.md.
+**Measured at:** `72d3ae7` — 163 lines, 42,855 bytes, loaded into every agent
+turn in this repo.
+
+## The finding is real, and one section owns it
+
+| Section | bytes | share | load-bearing markers |
+|---|---|---|---|
+| **`## What it does`** | **16,270** | **38%** | **0** |
+| `## Architecture` | 10,801 | 25% | 1 |
+| `## Conventions` | 7,146 | 17% | **17** |
+| `## MCP tools` | 3,109 | 7% | 0 |
+| `### Commits, merges, CHANGELOG` | 1,757 | 4% | 0 |
+| `## MVU invariants` | 1,138 | 3% | 1 |
+| everything else | ~2,600 | 6% | 0 |
+
+"Load-bearing markers" counts mentions of a guard name, `SPYC-TRAP`, or the
+word *invariant* — the things F7's hard constraint forbids removing.
+
+The distribution answers the question on its own: **the largest section carries
+the fewest rules.** `## Conventions` is 17% of the bytes and holds 17 of the 20
+markers; `## What it does` is 38% of the bytes and holds none.
+
+## The two bullets
+
+Inside `## What it does`, two bullets are 24% of the *entire file*:
+
+| Bullet | bytes | already documented in |
+|---|---|---|
+| **Agent-activity dots** | 6,691 | `docs/AGENT_ORCHESTRATION.md` (which the bullet itself links) |
+| **Lua scripting** | 3,491 | `docs/archive/LUA_SCRIPTING_PLAN.md`, `src/lua/`, CONFIGURATION.md |
+
+Both end by pointing at a dedicated document that covers the same ground in
+more depth. The bullet is a summary that grew into a duplicate.
+
+AGENTS.md's own header already states the intent: *"the full feature reference
+in [`FEATURES.md`](FEATURES.md)"* and *"**Keep this file slim** — it's always in
+context."* The file stopped honouring its own instruction.
+
+## Proposed cuts
+
+**Target: ~43KB → ~26KB (−40%), removing zero rules.**
+
+### 1. `## What it does` → one line per feature (−11KB)
+
+The section header already promises "One line per feature; see FEATURES.md for
+the full reference." Make that true. Concretely:
+
+- **Agent-activity dots** — 6,691 → ~250 bytes. Keep: what the dot shapes and
+  colours mean, that status comes from self-report and not screen-scraping, and
+  the pointer to `docs/AGENT_ORCHESTRATION.md`. Drop: the P0/P1/P1-2/P1-3
+  tier mechanics, per-agent hook wiring, `idle_prompt` downgrade, notification
+  channel gating. None of it changes what an agent may or may not do.
+- **Lua scripting** — 3,491 → ~250. Keep: `$HOME`-only, off-thread, the
+  `map KEY lua` entry point, engine location. Drop: the API enumeration,
+  event-tier taxonomy, re-entrancy guard narrative.
+- **Installable agent skill** (1,172), **Leader/global menu** (538),
+  **`:` command line** (498), **Session save/restore** (481) — halve each,
+  keep the pointer.
+- The remaining ~17 bullets are already one-liners. Leave them.
+
+**Why safe:** zero load-bearing markers in this section. It describes what spyc
+*does*, not what a contributor *must not do*.
+
+### 2. `## Architecture` module index → keep, trim prose (−3KB)
+
+The per-module index is genuinely useful for navigation and is **guard-checked**
+(`every_app_module_is_in_the_agents_index`). Keep every module line.
+
+Trim only the multi-sentence explanations attached to some entries where
+ARCHITECTURE.md already carries the reasoning. Target the entry text, never the
+entry itself — deleting a module line breaks the guard, which is the correct
+outcome and a useful backstop.
+
+### 3. `## MCP tools` → tighten (−1.5KB)
+
+Overlaps the MCP server's own `SERVER_INSTRUCTIONS`, which agents already
+receive at `initialize`. Keep the tool list and the "prefer these over shell
+equivalents" framing; drop the per-tool parameter detail that the tool schemas
+already carry.
+
+### 4. Leave entirely alone
+
+- **`## Conventions`** (17 of 20 markers) — every rule here is exactly what the
+  hard constraint protects. Not one byte.
+- **`## MVU invariants (don't erode)`** — the name says it.
+- **`### Commits, merges, CHANGELOG`** — the conventional-commit rule is
+  load-bearing: `filter_unconventional` silently drops an untyped subject from
+  the CHANGELOG, unrecoverable after a squash-merge.
+- **`## Building`**, **`## Working directory continuity`** — small and
+  operational.
+
+## Verification before landing
+
+Mechanical check rather than judgement: extract every sentence containing a
+guard name, `SPYC-TRAP`, or *invariant* from the current file, and assert each
+still appears in the trimmed one. If a section's cut drops such a sentence, the
+cut is wrong, not the sentence.
+
+## Recommendation
+
+Do **1** and **3**; they are 12.5KB of the 17KB and carry no rules. Treat **2**
+as optional — the module index is the part agents actually navigate by, and the
+guard means an over-eager trim fails the build rather than silently degrading.
+
+Worth being honest about the payoff: 40% of a 43KB file is ~17KB, which is real
+but not transformative, and AGENTS.md is a large part of why agents don't wreck
+this repo. If the choice is between a slightly smaller file and a slightly
+riskier one, keep the file. The cuts above are the ones where that trade doesn't
+arise — duplicated prose whose authoritative copy lives one link away.

--- a/docs/archive/engagements/mouse-rs-decomposition-proposal.md
+++ b/docs/archive/engagements/mouse-rs-decomposition-proposal.md
@@ -1,0 +1,98 @@
+# `src/app/mouse.rs` decomposition — proposal (F4 Part B)
+
+**Status:** proposal awaiting approval. No code moved.
+**Measured at:** `72d3ae7`.
+
+## Why this file and not the others
+
+The review said "twenty-plus production files exceed 800 lines." That count —
+and the 35 I first reproduced — comes from `wc -l`, which includes inline test
+modules. The house convention keeps tests at the bottom of the same file, so a
+1,250-line file can hold 830 production lines and be perfectly well factored.
+
+Counting only lines outside `#[cfg(test)]` modules (brace-matched, not
+split-on-first-occurrence — that naive version is fooled by a *comment*
+mentioning the attribute, which is exactly how `render/mod.rs` reads as 22
+production lines when it has 827):
+
+| File | production | total |
+|---|---|---|
+| **`src/app/mouse.rs`** | **1,529** | 3,038 |
+| `src/app/mod.rs` | 1,438 | 1,443 |
+| `src/mcp/protocol.rs` | 1,076 | 1,147 |
+| `src/app/state/mod.rs` | 1,028 | 1,029 |
+| `src/app/pane_tabs.rs` | 1,005 | 1,004 |
+| `src/app/pager_handler/mod.rs` | 992 | 991 |
+
+Sixteen files exceed 800 production lines, so the rule has genuinely drifted —
+but far less than a raw `wc -l` suggests, and `app/mod.rs` is deliberately
+ceiling-guarded at 1,500 and legitimately holds the module's type definitions
+(AGENTS.md allows exactly that).
+
+`mouse.rs` is the outlier: largest, and ~450 production lines clear of the next
+non-guarded file. It also grew ~1,000 lines in #233/#234, so the seams are
+recent and still legible rather than fossilised.
+
+## The seams
+
+The file is two things sharing a filename: a pure decision layer and an impure
+dispatch layer. That boundary is already explicit — it's the `route.rs` /
+`focus.rs` template the codebase applies elsewhere.
+
+| Lines | Cluster | Content |
+|---|---|---|
+| 50–615 | **pure decisions** | `MouseDragTarget`, `ListSelection`, `ChromeSelection`, `PaneScrollStreak`, `ChromeRow`, `MouseSnapshot`, timing constants, `scroll_streak_step`, `AgentViewAction` / `AgentViewInputs` / `decide_agent_view_action`, `route_mouse`, `hit`, `region_at`, `clamp_to_area` |
+| 629–808 | **dispatch** | `handle_mouse` — the one entry point |
+| 809–980 | **scroll** | `active_pane_wheel_scroll`, `send_scroll_keys`, `send_agent_view_scroll_keys`, `repeat_key_effect` |
+| 981–1357 | **selection** | pager / chrome / pane / list-row `begin`+`extend`+`finish` triples, plus `chrome_col_at`, `pane_cell_at`, `list_row_at` |
+| 1358–1483 | **forwarding** | `forward_to_child`, `forward_drag`, `forward_release`, `focus_pager_slot`, `focus_region` |
+| 1484–1528 | | `mouse_report` |
+| 1529–3038 | tests | move with their subjects |
+
+Four near-identical `begin`/`extend`/`finish` triples in one contiguous block is
+the strongest signal — that's a cohesive subsystem, not an arbitrary cut.
+
+## Proposed shape
+
+```
+src/app/mouse/
+  mod.rs        ~250   type defs + `handle_mouse` dispatch + re-exports
+  route.rs      ~400   MouseSnapshot, route_mouse, region_at, hit,
+                       scroll_streak_step, decide_agent_view_action, constants
+  selection.rs  ~375   the four begin/extend/finish clusters
+  scroll.rs     ~170   wheel + agent-view scroll, repeat_key_effect
+  forward.rs    ~170   forward_to_child/drag/release, focus_*, mouse_report
+```
+
+Every file lands well under 800 production lines. Tests move beside their
+subjects, which also splits the ~1,500-line test block along the same seams.
+
+`mod.rs` keeping the type definitions matches AGENTS.md ("a module root holding
+its own type defs is a legit reason") and mirrors `app/mod.rs`.
+
+## What would make this a bad idea
+
+State me wrong before doing it:
+
+- **If the impure clusters share private `App` state heavily**, the split forces
+  cross-module reaching and is worse than a long file. The descendant-module
+  rule means child modules *can* read `App`'s private fields, so this is
+  probably fine — but verify per cluster rather than assuming.
+- **`handle_mouse` is a dispatcher.** The existing `too_many_lines` clippy-allow
+  rationale about dispatch functions applies; don't shred it to hit a number.
+- **Relocations must be verbatim.** Behaviour-preserving, no test-assertion
+  edits — the `project_mod_extraction_sweep` playbook. If a move needs a
+  behaviour change, that's a separate PR first.
+
+## Sequencing
+
+One PR per module, verbatim moves, gate green between each. `route.rs` first:
+it's pure, has the cleanest boundary, and carries its own tests — so it proves
+the seam before anything impure moves.
+
+## Not recommended
+
+Splitting the other fifteen. `app/mod.rs` is guarded and type-defs;
+`protocol.rs`, `state/mod.rs`, and `pane_tabs.rs` are 1,000–1,076 production
+lines with no comparably obvious seam. Chasing those is churn. Revisit
+individually if one crosses ~1,200.

--- a/docs/archive/engagements/review-remediation-deliverable.md
+++ b/docs/archive/engagements/review-remediation-deliverable.md
@@ -1,0 +1,158 @@
+# Code-review remediation — deliverable
+
+Engagement brief: `docs/drafts/spyc-review-remediation-prompt v4.md`.
+Baseline `208d3ba` → head `edc27b8`. Twelve PRs, all merged.
+
+## Summary
+
+| # | Finding | PR | Outcome |
+|---|---|---|---|
+| F1 | MCP `root` override bypasses the traversal guard | #235 (decision), #237 (impl) | fixed |
+| F2 | SECURITY.md contradicts the shipped distribution | #236 | fixed |
+| F3 | State writes bypass the atomic helper | #238 | fixed + guard |
+| F6 | Two divergent state-root resolvers | #239 | fixed |
+| F5 | Fuzz targets never run | #240, #242 | fixed, dispatch verified |
+| F4 | ROADMAP misstates the 800-LoC rule | #241 (docs), #244–#246 (mouse split) | fixed + executed |
+| F7 | AGENTS.md is 43KB of always-loaded context | #243 | executed |
+
+Every change gated with `make check`; no CI failure reached `main`.
+
+## Per finding
+
+**F1 — `d86dcb4`, `f851fcd`.** `effective_root` accepted any directory passing
+`is_dir()`, and `get_file_content` anchored its canonicalize + `starts_with`
+check on that same caller-supplied value, so `root: "/"` made the guard
+decorative across all six read tools. Now validated against a
+cursor-independent allowed set.
+*Tests:* `/` and an unrelated directory rejected; the agent's root survives
+`search_root`/`project_home`/`cwd` all moving elsewhere; a symlinked path is
+accepted.
+
+**F2 — `6abc6d7`.** SECURITY.md claimed "no prebuilt binary distribution" and
+that signing "would be theater", while the repo ships signed tarballs, a brew
+tap, a signed apt repo, and crates.io. Rewritten around release-pipeline
+compromise, the keyless chain, and the apt key as the one stored secret.
+*Tests:* n/a (docs); cross-checked against README, INSTALL, and the workflows.
+
+**F3 — `1265900`.** Eight persistent-state writes used `std::fs::write`, so a
+crash mid-write truncated the file and the health check's only recourse was to
+discard it. All now use the existing `write_atomic`.
+*Tests:* `state_writes_are_atomic` source-scan guard, **verified to fail** on an
+injected canary before being trusted.
+
+**F6 — `72d3ae7`.** `mcp::state_dir()` read `$HOME` directly and ignored
+`$XDG_STATE_HOME`, splitting state across two directories for anyone who sets
+it. Unified on `state::state_root()`; callers decline when there's no
+trustworthy location rather than falling back to a world-readable `/tmp`.
+*Tests:* socket and sidecar share the overridden root; the absent-dir branch
+asserted via an injected parameter (no `env::set_var`, which is unsafe in
+edition 2024).
+
+**F5 — `328477b`, `d19ab5a`.** Six libFuzzer targets had no scheduled runner.
+Weekly `schedule` + `workflow_dispatch`, 6-target matrix, accumulating corpus
+cache, pinned nightly.
+*Tests:* **a real `workflow_dispatch` run: all six targets green.** The first
+attempt failed on all six — `taiki-e` installs the musl build of cargo-fuzz,
+which defaults `--target` to its own host triple, and ASAN cannot work with
+static libc. Fixed in `d19ab5a`.
+
+**F4 — `7c9b042`, `6643a56`, `84c3ba8`, `edc27b8`.** ROADMAP listed the 800-LoC
+rule among finished foundations, reading as compliance. Corrected; and
+`src/app/mouse.rs` (1,529 production lines, the tree's largest) decomposed.
+*Tests:* 1,788 tests pass unchanged at each step — pure relocation.
+
+    mod.rs 307 · route.rs 526 · selection.rs 399 · forward.rs 193 · scroll.rs 182
+
+**F7 — `4b99400`.** 43,256 → 33,877 bytes (−22%), no rule removed. Chosen by
+measurement: `## Conventions` is 17% of the bytes and holds 17 of the 20
+load-bearing markers; `## What it does` was 38% and held none.
+*Tests:* every sentence naming a guard / SPYC-TRAP / invariant extracted from
+the old file and asserted against the new one.
+
+## The F1 decisions-log entry
+
+Recorded in ROADMAP.md, carrying the three things the brief required:
+
+1. **Harness asymmetry** — enforcement is justified not by "the agent could read
+   `~/.ssh`" (it has Bash) but because harnesses auto-approve MCP calls while
+   gating shell execution behind per-command prompts. There,
+   `search_content(root: "/")` bypasses a boundary the *user* believes exists.
+2. **Cursor-independence invariant** — the allowed set must never reject the
+   agent's own working root. Anchoring on `search_root` alone would reject it
+   the moment the user browses elsewhere, and a rejected call sends the agent to
+   unscoped `Bash rg`. Over-tight scoping produces bypass, not safety.
+3. **Pane-identity end state** — validating against the calling pane's cwd is the
+   target design, blocked on transport: `SPYC_PANE_ID` reaches the pane env, but
+   read-tool dispatch resolves through the context file, which carries no pane
+   identity.
+
+## What all four review passes missed
+
+Severity-framed. **Nothing below was fixed without asking.**
+
+### Fixed in passing (surfaced during the work)
+
+- **SECURITY.md *understated* the posture** — medium. The review caught the
+  stale distribution claim but not that the doc said signing "would be theater"
+  while `release.yml` has produced SLSA attestations and cosign signatures since
+  2.0.0. A reader was talked out of verification that already worked.
+- **The untrusted-input claim was false** — medium. "No untrusted-input parser
+  beyond TOML config files we already control" sat next to six fuzz targets.
+  The pager renders arbitrary files, vt100 parses arbitrary child output, gix
+  parses git objects. That sentence was the justification for not fuzzing.
+- **F3 was eight sites, not five** — low/medium. `inventory`, `harpoon`, and
+  `skill_prompt` appeared in neither the review nor the hand-audit after it.
+- **F6 was a resolver divergence, not a `/tmp` fallback** — medium. The `/tmp`
+  case needs an unset `$HOME`; the divergence bites anyone who sets
+  `$XDG_STATE_HOME`.
+- **F4's "twenty-plus oversized files" was a measurement artifact** — low. Raw
+  `wc -l` counts inline tests; the real figure is 16.
+- **No apt key-rotation procedure existed** — medium. Now written down,
+  including that every client must re-import because `signed-by` pins the old
+  key, and that it has never been rehearsed.
+- **Unsigned commits are the weakest link** — informational. Signing proves an
+  artifact came from the workflow, not that the source was authored by who you
+  think.
+
+### Open — needs your decision, not fixed
+
+**1. The guard-test idiom has a latent blind spot — medium.**
+`no_subprocess_git_in_production` and the new `state_writes_are_atomic` both
+split production from tests at the first `#[cfg(test)]` **substring**. A comment
+merely *mentioning* the attribute truncates the scan: under that heuristic
+`src/app/render/mod.rs` reads as 22 production lines when it has 827. No
+`src/state` file triggers it today, so neither guard is currently blinded — but
+a guard with a silent false negative is worse than no guard, because it reads as
+assurance. Fix is small (match at line start, or brace-match). Not done here
+because it changes a shared house idiom that predates this engagement.
+
+**2. Issue #230 is half-fixed, and its two proposed fixes don't compose —
+medium.** The pin-window timing bug is fixed. But `assign_codex_sessions`
+filters on `r.started_secs + START_SKEW_SECS >= *spawn`, and a resumed codex
+session appends to its original rollout with a frozen timestamp — so a resumed
+tab is *structurally unpinnable* and falls through to the mtime ranking. Fixing
+the ranking alone doesn't reach it. Commented on the issue and re-scoped; left
+open deliberately.
+
+**3. Agent-pane input deafness after a focus round-trip — high, unreproduced.**
+`docs/drafts/mutli-question-bug-investigation.md`. Two candidate mechanisms with
+opposite predictions (a latched `resolver_pending` vs. Ink dropping its handler
+on a SIGWINCH re-render), a one-second discriminating test (press `Esc` before
+`^c`), and a decisive one (`SPYC_KEY_TRACE=1`, whose RX line already logs
+`pane_focused=` and `pending=`).
+
+**4. mouse.rs tests did not move with their subjects — low.** `mod.rs` is 1,815
+total against 307 production. Relocating each test cluster is a natural
+follow-up; doing it inside the split would have turned a reviewable relocation
+into a rewrite.
+
+## Process notes
+
+- **A piped gate reports the pager's exit code.** `make check 2>&1 | tail -20`
+  returns *tail's* status, so a failed gate reads as green. F1 was pushed with a
+  failing `fmt-check` that CI then caught. Fixed by `set -o pipefail`; now in the
+  brief's don't-do list. Worth a `.PHONY` wrapper or a documented invocation.
+- **`gh pr merge` immediately after `gh pr update-branch` fails** with "2 of 2
+  required status checks are expected" — the update re-triggers checks and the
+  merge races their registration. Needs a wait-then-retry loop; bit every PR in
+  the sequence.

--- a/docs/archive/engagements/spyc-review-remediation-prompt v2.md
+++ b/docs/archive/engagements/spyc-review-remediation-prompt v2.md
@@ -1,0 +1,239 @@
+# spyc: code review remediation (v2)
+
+You are working in the spyc repository (Tripstack-Corp/spyc). An external code
+review was performed against commit `dbffd29`; its findings were then verified
+and corrected against `208d3ba` (current main at time of writing). The 15
+commits between the two are entirely mouse work — so treat `src/app/mouse.rs`
+and its neighbors as the one area where "verify the finding still holds" is
+more than a formality, and be aware mouse work may still be in flight (PR
+#234) — do not touch `src/app/mouse.rs` in this engagement.
+
+Read AGENTS.md first and follow every house convention it establishes —
+comment style, the documentation contract, SPYC-TRAP anchors, conventional
+commits, and the no-subprocess-git guard. Where a finding conflicts with an
+existing documented decision in ROADMAP.md's decisions log or docs/archive/,
+surface the conflict rather than silently overriding it.
+
+## Ground rules
+
+1. **Verify before fixing.** Confirm each finding on current `main` before
+   changing anything. If it no longer holds, say so and skip it — do not fix
+   things that aren't broken.
+2. **One finding, one PR-shaped change.** Keep each finding's work in its own
+   commit series with a conventional-commit message referencing the finding
+   number (e.g. `fix(mcp): validate root override against known roots (review
+   F1)`). Do not bundle unrelated cleanups.
+3. **Tests first-class.** Every behavioral change ships with a test that fails
+   before the change and passes after, placed per existing conventions.
+4. **Run the full gate** (`make check` or the CI-parity target) before
+   declaring any finding done. All work must pass with `--locked`.
+5. **Update documentation in the same change.** ARCHITECTURE.md's
+   "Documentation contract" applies: behavior change and its doc change land
+   in the same commit.
+
+## Order of work
+
+F1 decision (no code — record it first) → F2 → F1 implementation → F3 → F6 →
+F5 → F4 → F7.
+
+F2 jumps the queue because it is the only finding with an external-trust cost
+that compounds daily: SECURITY.md makes claims about the distribution model
+that a public repo's release artifacts visibly contradict, and it is the
+first document a security researcher reads.
+
+## Findings
+
+### F1 — MCP `root` override bypasses the path-traversal guard
+
+**Where:** `src/mcp/readers.rs::effective_root`, consumed by
+`get_file_content` (the canonicalize + `starts_with(canonical_root)` check
+around `src/mcp/protocol.rs:615`), and by `search_paths`, `search_content`,
+`git_status`, `git_log`, `git_diff`, and the worktree tools.
+
+**Defect:** the traversal guard is anchored to a value the caller picks.
+`effective_root` accepts any directory passing `is_dir()`; supply
+`root: "/"` and the `starts_with` check is decorative.
+
+**Why this justifies enforcement — get the rationale right.** The lazy
+threat ("the agent could read `~/.ssh`") argues for documentation instead:
+the connected agent typically has Bash, the socket is same-user 0600, and
+anything that can reach the socket can already `cat` the file. The case that
+actually matters is the **harness permission asymmetry**: agent harnesses
+commonly auto-approve MCP tool calls while gating shell execution behind
+per-command permission prompts. In that configuration,
+`search_content(root: "/", regex: "BEGIN OPENSSH PRIVATE KEY")` silently
+bypasses a boundary the user believes exists. That is not theater, and it is
+why the resolution is **(a) enforce**, not (b) document.
+
+**Do:** validate the `root` override against the set of legitimate roots
+spyc already knows — the worktrees `list_worktrees` reports for the current
+repo, plus the context file's `search_root`/`project_home`/`cwd` chain.
+Reject anything else with a clear tool error naming the allowed set.
+Canonicalize both sides before comparison (symlinked worktree paths must not
+false-reject). Apply the same validation everywhere `effective_root`'s
+override reaches — the git_* tools and worktree tools included, not just
+`get_file_content`.
+
+**Record the decision** in ROADMAP.md's decisions log, and include the
+harness-asymmetry sentence above as the stated rationale — it is the part a
+future maintainer will need when someone proposes relaxing the check.
+
+**Acceptance:** tests proving `root: "/"` and
+`root: "/tmp/not-a-worktree"` are rejected while a legitimate sibling
+worktree from `list_worktrees` is accepted (including via a symlinked path);
+SECURITY.md's threat model explicitly states what the MCP tool surface does
+and does not protect against with respect to the *connected agent*, not just
+other local processes.
+
+### F2 — SECURITY.md contradicts the shipped distribution model
+
+**Where:** `SECURITY.md` — line 60 ("There is no prebuilt binary
+distribution"), lines 82 and 132 ("if/when we start publishing prebuilt
+binaries"), and the license allow-list rationale pinned to v1.37.1.
+
+**Problem:** binary distribution shipped at 2.0.0 (signed apt repo, Homebrew
+tap, release tarballs, crates.io — see README.md and
+`.github/workflows/{release,apt,homebrew}.yml`). The release pipeline is now
+attack surface and the security document does not know it exists.
+
+**Do:** rewrite SECURITY.md to match reality. Cover: how release binaries
+are built and on what runner; how the apt signing key is generated, stored,
+and scoped; what a consumer can verify (checksums, signatures) and how; the
+key-compromise/rotation story; which GitHub Actions permissions the release
+workflows hold and why; the cargo-deny license allow-list refreshed against
+the current dep graph with the version reference updated; and the F1
+decision folded into the threat model. Keep the existing register — "what we
+do, what we don't, and why" — no boilerplate padding.
+
+**Acceptance:** no claim in SECURITY.md contradicts README.md, INSTALL.md,
+or the workflow files; a reader learns the actual release-signing chain from
+SECURITY.md alone.
+
+### F3 — Five state writes still bypass the existing atomic helper
+
+**Correction to the original finding:** `src/fs/atomic.rs::write_atomic`
+already exists and is already used by `state/sessions/mod.rs`,
+`state/marks.rs`, `mcp/config.rs`, and `mcp/hooks.rs`. Do **not** build a
+new helper, and sessions are already covered. What remains is mechanical:
+convert the five straggler call sites that still `std::fs::write` persistent
+state directly:
+
+- `src/state/frecency.rs:117`
+- `src/state/pager_positions.rs:112`
+- `src/state/history.rs:147`
+- `src/state/hook_consent.rs:47`
+- `src/state/graveyard.rs:202`
+
+(Line numbers as of `208d3ba`; re-locate if drifted. Ignore `fs::write`
+inside `#[cfg(test)]` blocks — those are fixture setup, not state
+persistence.)
+
+**Acceptance:** after conversion, a grep shows no remaining direct
+`fs::write` to files under the XDG state root from production code paths.
+If `write_atomic`'s existing tests don't already cover the
+interrupted-write-preserves-prior-file property, add one; otherwise no new
+test machinery is needed.
+
+### F6 — Two divergent state-root resolvers; MCP's ignores XDG
+
+**Correction to the original finding:** the bare-`/tmp` fallback is a
+symptom, not the defect. The defect is that spyc has two resolvers:
+
+- `state::state_root()` — honors `$XDG_STATE_HOME`, returns `Option`
+  (no HOME → `None`, callers skip persistence safely)
+- `mcp::state_dir()` — ignores `$XDG_STATE_HOME` entirely, falls back to
+  bare `/tmp`
+
+With `XDG_STATE_HOME` set — a common configuration, unlike an unset HOME —
+the MCP socket and trusted-root sidecar land in `~/.local/state/spyc` while
+all other state goes to `$XDG_STATE_HOME/spyc`: state splits across two
+directories, and the sidecar's "owner-private, attacker can't forge it"
+trust argument is being made about a path the rest of the program isn't
+using.
+
+**Do:** unify on one resolver — `mcp` consumes `state::state_root()` (or
+both consume one shared function). Decide and document the policy for the
+`None` case on the MCP side: refusing to start the socket server (with a
+logged reason) is preferable to inventing a world-readable fallback
+location. The `/tmp` branch and any need for `/tmp`-squat hardening
+disappear with it.
+
+**Acceptance:** one resolver; a test that sets `XDG_STATE_HOME` and
+verifies the socket path and, e.g., the frecency path share a root; the
+no-HOME behavior on the MCP side is explicit and tested.
+
+### F5 — Fuzz targets exist but never run in CI
+
+**Where:** `fuzz/fuzz_targets/` (dsl_parse, expand_path, expand_percent,
+highlight, render_markdown, word_wrap); `.github/workflows/`.
+
+**Do:** add a workflow triggered on **both** `schedule` (weekly) and
+`workflow_dispatch`, running each target for a bounded time (5–10 min each)
+with the corpus cached between runs, failing loudly on a crash and uploading
+the reproducer as an artifact. Keep it off the PR path — background
+insurance, not a merge gate. Pin the nightly toolchain explicitly rather
+than floating.
+
+**Acceptance:** a manual `workflow_dispatch` run completes with corpora
+cached and artifacts uploaded — that dispatch run is the evidence the
+failure path is wired, since a scheduled run can't be demonstrated on
+demand.
+
+### F4 — ROADMAP.md misstates what the ceiling guard enforces
+
+**Correction to the original finding:** there is no 800-LoC guard. The only
+ceiling guard in the tree is `mod_rs_stays_decomposed`
+(`src/app/mod_tests.rs:25`), which caps `src/app/mod.rs` alone at 1,500
+lines. AGENTS.md states the 800-LoC rule correctly as a convention with an
+escape hatch; the misleading text is ROADMAP.md:33, which jams
+"ceiling-guard-enforced" and "the 800-LoC file rule" into one clause.
+Meanwhile twenty-plus production files exceed 800 lines, the largest being
+`src/app/mouse.rs` at ~2,035 (excluded from this engagement per the header —
+it is actively being worked).
+
+**Do:** fix the ROADMAP.md:33 wording so the documented claim matches the
+enforced reality (a one-line change). Then, separately and only if natural
+seams exist, propose — do not execute without approval — splits for the two
+or three worst offenders outside the mouse area. Do NOT force artificial
+splits; the existing `too_many_lines` rationale about dispatch functions
+applies to files too.
+
+**Acceptance:** the documented rule and the enforced rule are the same
+rule; any proposed splits are presented as a plan, not landed code.
+
+### F7 — AGENTS.md is 43KB of always-loaded agent context (lowest priority)
+
+**Do:** propose — do not execute without approval — a trim of AGENTS.md
+toward a pointer document: keep invariants, guards, and conventions an agent
+must never violate; move depth (worktree lifecycle narratives, extended
+rationale) into the installable skill and the docs it already references.
+
+**Hard constraint:** the proposed trim may not remove any sentence naming a
+guard, a SPYC-TRAP slug, or an invariant. AGENTS.md is a large part of why
+agents don't wreck this repo; when in doubt, keep the sentence and flag it.
+
+**Acceptance:** a cut list with per-section justification, awaiting
+approval. No edits landed in this engagement.
+
+## What NOT to do
+
+- Do not touch `src/app/mouse.rs` or the in-flight mouse work.
+- Do not touch the MVU structure, the sync-only concurrency model, the
+  pager_stream seam, or the gix facade — these were reviewed favorably.
+- Do not add dependencies. std plus the existing tree is sufficient for
+  every finding here.
+- Do not build a new atomic-write helper (see F3 — it exists).
+- Do not add `/tmp`-squat hardening (see F6 — the path it defends should
+  not exist after unification).
+- Do not reformat, rename, or "improve" code adjacent to your changes.
+- Do not regenerate CHANGELOG.md by hand; the git-cliff flow owns it.
+- If any finding turns out to be wrong on current main, document why in
+  your summary instead of manufacturing a fix.
+
+## Deliverable
+
+For each finding: the commits, the test evidence, and a two-line summary of
+what changed and why. For F1, the decisions-log entry containing the
+harness-asymmetry rationale. For F4 and F7, proposals awaiting approval, not
+landed changes. Finish with anything you found along the way that both
+reviews missed — same severity framing, no fixes without asking.

--- a/docs/archive/engagements/spyc-review-remediation-prompt v3.md
+++ b/docs/archive/engagements/spyc-review-remediation-prompt v3.md
@@ -1,0 +1,289 @@
+# spyc: code review remediation (v3)
+
+You are working in the spyc repository (Tripstack-Corp/spyc). An external code
+review was performed against commit `dbffd29`; its findings were verified and
+corrected against `208d3ba`, then hardened against runtime knowledge from an
+agent working inside the repo. The commits between the review baseline and
+main are entirely mouse work — treat `src/app/mouse.rs` and neighbors as the
+one area where "verify the finding still holds" is more than a formality, and
+do not touch `src/app/mouse.rs` in this engagement (mouse work is in flight).
+
+Read AGENTS.md first and follow every house convention it establishes —
+comment style, the documentation contract, SPYC-TRAP anchors, conventional
+commits, and the no-subprocess-git guard. Where a finding conflicts with an
+existing documented decision in ROADMAP.md's decisions log or docs/archive/,
+surface the conflict rather than silently overriding it.
+
+## Setup (do this before anything else)
+
+1. `git pull --ff-only` in the main checkout. `create_worktree` branches off
+   local `main`; a stale local main silently omits recently-merged PRs.
+2. Do NOT edit in the main checkout — a PreToolUse hook blocks edits there
+   and you will burn turns on denied writes before diagnosing why. Create a
+   worktree via the spyc MCP `create_worktree` tool and do all work in it.
+3. Never `git commit --no-verify`. The pre-commit hook runs git-touching
+   tests; if a hook run flakes, that flake is a bug to fix (see the F1 test
+   note), never a reason to bypass the hook or re-run until green.
+
+## Ground rules
+
+1. **Verify before fixing.** Confirm each finding on current `main` before
+   changing anything. If it no longer holds, say so and skip it.
+2. **One finding, one PR-shaped change**, conventional-commit messages
+   referencing the finding number (e.g. `fix(mcp): validate root override
+   against session roots (review F1)`). No bundled cleanups.
+3. **Tests first-class.** Every behavioral change ships with a test that
+   fails before and passes after, placed per existing conventions.
+4. **Run the full gate** (`make check` / CI-parity target) before declaring
+   any finding done. All work passes with `--locked`.
+5. **Docs in the same change.** ARCHITECTURE.md's "Documentation contract"
+   applies: behavior change and its doc change land together.
+
+## Order of work
+
+F1 decision (no code — record it first) → F2 → F1 implementation → F3 → F6 →
+F5 → F4 → F7.
+
+F2 jumps the queue because it is the only finding with an external-trust
+cost that compounds daily: SECURITY.md's distribution claims are visibly
+contradicted by the repo's own release artifacts, and it is the first
+document a security researcher reads.
+
+## Findings
+
+### F1 — MCP `root` override bypasses the path-traversal guard
+
+**Where:** `src/mcp/readers.rs::effective_root`, consumed by
+`get_file_content` (the canonicalize + `starts_with(canonical_root)` check
+around `src/mcp/protocol.rs:615`), and by `search_paths`, `search_content`,
+`git_status`, `git_log`, `git_diff`, and the worktree tools.
+
+**Defect:** the traversal guard is anchored to a value the caller picks.
+`effective_root` accepts any directory passing `is_dir()`; supply
+`root: "/"` and the `starts_with` check is decorative.
+
+**Why enforcement (not documentation) — get the rationale right.** The lazy
+threat ("the agent could read `~/.ssh`") argues for documenting instead: the
+agent typically has Bash and the socket is same-user 0600. The case that
+matters is the **harness permission asymmetry**: agent harnesses commonly
+auto-approve MCP tool calls while gating shell execution behind per-command
+permission prompts. In that configuration,
+`search_content(root: "/", regex: "BEGIN OPENSSH PRIVATE KEY")` silently
+bypasses a boundary the user believes exists. That is why the resolution is
+enforce.
+
+**Design constraint — the allowed set must be cursor-independent.** Do NOT
+anchor validation to the focused column. `search_root`, `project_home`, and
+`list_worktrees` all track the column the *user* is browsing, which moves
+independently of where the *agent* is working. Anchor to those alone and
+this daily workflow breaks: agent works in `spyc.worktrees/feat/foo`, user
+navigates the focused column to an unrelated project, and the agent's
+`root: <its own worktree>` is rejected mid-task. The failure mode is worse
+than the defect: a rejected MCP call doesn't stop the agent, it makes the
+agent fall back to unscoped, unlogged `Bash rg` — over-tight scoping
+produces bypass, not safety. The invariant: **the allow-list must never
+reject the agent's own working root during a session.**
+
+Cursor-independent anchors to build the allowed set from (implementer picks
+the combination; all three are legitimate):
+
+- all worktrees of the repo spyc was launched in — stable for the session,
+  not merely the currently-focused one;
+- any worktree created via `create_worktree` during this session;
+- the focused column's chain (`search_root`/`project_home`/`cwd`) may be
+  *included* — it just can't be the whole set.
+
+**Known-ideal end state, out of scope here:** validating against the calling
+pane's own cwd. `SPYC_PANE_ID` is already injected into every agent pane's
+environment (`src/app/pane_tabs.rs:~126`) and the `spyc --mcp` proxy runs
+inside that pane — but read-tool dispatch resolves through the context file
+(`src/context.rs`), which carries no pane identity; `report_status` receives
+pane_id as a tool *argument*, not from the transport. Per-pane root
+attribution therefore needs transport plumbing that doesn't exist. Record it
+in the decisions log as the target design; do not build it in this
+engagement.
+
+**Do:** validate the `root` override against the cursor-independent allowed
+set. Reject anything else with a clear tool error naming the allowed set.
+Canonicalize both sides (symlinked worktree paths must not false-reject).
+Apply the validation everywhere `effective_root`'s override reaches — the
+git_* tools and worktree tools included.
+
+**Record the decision** in ROADMAP.md's decisions log with the
+harness-asymmetry rationale and the pane-identity end state — the two things
+a future maintainer needs when someone proposes relaxing or tightening the
+check.
+
+**Test note:** these tests exercise worktree creation/removal, which has
+documented CI-flake history (gix index-lock contention under parallel
+`cargo test`). Reuse the existing infrastructure —
+`serialize_worktree_mutation` (`src/git/worktree.rs:~129`),
+`write_index_with_lock_retry`, and the `src/git/test_support.rs` retry
+helpers — rather than rolling new worktree scaffolding.
+
+**Acceptance:** tests proving `root: "/"` and `root: "/tmp/not-a-worktree"`
+are rejected; a legitimate sibling worktree is accepted, including via a
+symlinked path; and the cursor-independence case specifically — the agent's
+worktree root remains accepted after the context file's `search_root` moves
+to an unrelated directory. For documentation: F2 will already have written
+the agent-facing threat-model section from the recorded decision — verify
+that section matches what F1 actually shipped and amend only if the
+implementation diverged; do not write it twice.
+
+### F2 — SECURITY.md contradicts the shipped distribution model
+
+**Where:** `SECURITY.md` — line 60 ("There is no prebuilt binary
+distribution"), lines 82 and 132 ("if/when we start publishing prebuilt
+binaries"), and the license allow-list rationale pinned to v1.37.1.
+
+**Problem:** binary distribution shipped at 2.0.0 (signed apt repo, Homebrew
+tap, release tarballs, crates.io — see README.md and
+`.github/workflows/{release,apt,homebrew}.yml`). The release pipeline is now
+attack surface the security document doesn't know exists.
+
+**Do:** rewrite SECURITY.md to match reality: how release binaries are built
+and on what runner; how the apt signing key is generated, stored, and
+scoped; what a consumer can verify (checksums, signatures) and how; the
+key-compromise/rotation story; which GitHub Actions permissions the release
+workflows hold and why; the cargo-deny license allow-list refreshed against
+the current dep graph with the version reference updated; and the F1
+decision folded into the threat model (state what the MCP tool surface does
+and does not protect against with respect to the *connected agent*, not just
+other local processes). Keep the existing register — "what we do, what we
+don't, and why" — no boilerplate.
+
+**Acceptance:** no claim in SECURITY.md contradicts README.md, INSTALL.md,
+or the workflow files; a reader learns the actual release-signing chain from
+SECURITY.md alone.
+
+### F3 — Five state writes still bypass the existing atomic helper
+
+**Correction to the original finding:** `src/fs/atomic.rs::write_atomic`
+already exists and is used by `state/sessions/mod.rs`, `state/marks.rs`,
+`mcp/config.rs`, and `mcp/hooks.rs`. Do **not** build a new helper; sessions
+are already covered. What remains is mechanical — convert the five straggler
+call sites that still `std::fs::write` persistent state directly:
+
+- `src/state/frecency.rs:117`
+- `src/state/pager_positions.rs:112`
+- `src/state/history.rs:147`
+- `src/state/hook_consent.rs:47`
+- `src/state/graveyard.rs:202`
+
+(Line numbers as of `208d3ba`; re-locate if drifted. Ignore `fs::write`
+inside `#[cfg(test)]` blocks — fixture setup, not state persistence.)
+
+**Acceptance:** not a one-time grep — add a source-scan **guard test** in
+the house idiom (`no_subprocess_git_in_production`,
+`traps_resolve_against_architecture_anchors`, etc.): a
+`state_writes_are_atomic` guard asserting no production code path under
+`src/state/` (and any other module writing under the XDG state root) calls
+`std::fs::write` directly, with an allow-list mechanism for any deliberate
+exception. The guard is what stops the sixth straggler appearing next month.
+If `write_atomic`'s existing tests don't already cover
+interrupted-write-preserves-prior-file, add that; otherwise no new write
+machinery.
+
+### F6 — Two divergent state-root resolvers; MCP's ignores XDG
+
+**Correction to the original finding:** the bare-`/tmp` fallback is a
+symptom. The defect is two resolvers:
+
+- `state::state_root()` — honors `$XDG_STATE_HOME`, returns `Option`
+  (no HOME → `None`, callers skip persistence safely)
+- `mcp::state_dir()` — ignores `$XDG_STATE_HOME`, falls back to bare `/tmp`
+
+With `XDG_STATE_HOME` set — common, unlike an unset HOME — the MCP socket
+and trusted-root sidecar land in `~/.local/state/spyc` while all other state
+goes to `$XDG_STATE_HOME/spyc`: state splits across two directories, and the
+sidecar's "owner-private, attacker can't forge it" trust argument is being
+made about a path the rest of the program isn't using.
+
+**Do:** unify on one resolver — `mcp` consumes `state::state_root()` (or
+both consume one shared function). For the `None` case on the MCP side,
+prefer refusing to start the socket server (with a logged reason) over
+inventing a world-readable fallback; document the choice. The `/tmp` branch
+and any `/tmp`-squat hardening disappear with it.
+
+**Acceptance:** one resolver; a test that sets `XDG_STATE_HOME` and verifies
+the socket path and (e.g.) the frecency path share a root; the no-HOME
+behavior on the MCP side is explicit and tested.
+
+### F5 — Fuzz targets exist but never run in CI
+
+**Where:** `fuzz/fuzz_targets/` (dsl_parse, expand_path, expand_percent,
+highlight, render_markdown, word_wrap); `.github/workflows/`.
+
+**Do:** add a workflow triggered on both `schedule` (weekly) and
+`workflow_dispatch`, running each target for a bounded time (5–10 min each)
+with corpora cached between runs, failing loudly on a crash and uploading
+the reproducer as an artifact. Off the PR path — background insurance, not a
+merge gate. Pin the nightly toolchain explicitly.
+
+**Acceptance:** a manual `workflow_dispatch` run completes with corpora
+cached and artifacts uploaded — the dispatch run is the evidence the wiring
+works, since a scheduled run can't be demonstrated on demand.
+
+### F4 — ROADMAP.md misstates what the ceiling guard enforces
+
+**Correction to the original finding:** there is no 800-LoC guard. The only
+ceiling guard is `mod_rs_stays_decomposed` (`src/app/mod_tests.rs:25`),
+capping `src/app/mod.rs` alone at 1,500 lines. AGENTS.md states the 800-LoC
+rule correctly as a convention with an escape hatch; the misleading text is
+ROADMAP.md:33, which jams "ceiling-guard-enforced" and "the 800-LoC file
+rule" into one clause. Twenty-plus production files exceed 800 lines; the
+largest, `src/app/mouse.rs` (~2,035), is excluded from this engagement — it
+is actively being worked.
+
+**Do:** fix ROADMAP.md:33 so the documented claim matches the enforced
+reality (a one-line change). Then, separately and only where natural seams
+exist, **propose — do not execute without approval —** splits for the two or
+three worst offenders outside the mouse area. Do NOT force artificial
+splits; the `too_many_lines` rationale about dispatch functions applies to
+files too.
+
+**Acceptance:** documented rule and enforced rule are the same rule; any
+splits are presented as a plan, not landed code.
+
+### F7 — AGENTS.md is 43KB of always-loaded agent context (lowest priority)
+
+**Do:** propose — do not execute without approval — a trim of AGENTS.md
+toward a pointer document: keep invariants, guards, and conventions an agent
+must never violate; move depth (worktree lifecycle narratives, extended
+rationale) into the installable skill and the docs it references.
+
+**Hard constraint:** the proposed trim may not remove any sentence naming a
+guard, a SPYC-TRAP slug, or an invariant. AGENTS.md is a large part of why
+agents don't wreck this repo; when in doubt, keep the sentence and flag it.
+
+**Acceptance:** a cut list with per-section justification, awaiting
+approval. No edits landed.
+
+## What NOT to do
+
+- Do not bump the version. `main` is the `N.M.0-CURRENT` stream; across a
+  seven-PR engagement a version bump is the most common cross-PR mistake and
+  stays invisible until release time.
+- Do not `git commit --no-verify`, ever (see Setup).
+- Do not touch `src/app/mouse.rs` or the in-flight mouse work.
+- Do not touch the MVU structure, the sync-only concurrency model, the
+  pager_stream seam, or the gix facade — reviewed favorably.
+- Do not add dependencies. std plus the existing tree covers every finding.
+- Do not build a new atomic-write helper (F3 — it exists).
+- Do not add `/tmp`-squat hardening (F6 — the path it defends should not
+  exist after unification).
+- Do not roll new worktree test scaffolding (F1 — reuse
+  `serialize_worktree_mutation` / `test_support` retry helpers).
+- Do not reformat, rename, or "improve" code adjacent to your changes.
+- Do not regenerate CHANGELOG.md by hand; git-cliff owns it.
+- If any finding turns out to be wrong on current main, document why in your
+  summary instead of manufacturing a fix.
+
+## Deliverable
+
+For each finding: the commits, the test evidence, and a two-line summary of
+what changed and why. For F1, the decisions-log entry containing the
+harness-asymmetry rationale, the cursor-independence invariant, and the
+pane-identity end state. For F4 and F7, proposals awaiting approval, not
+landed changes. Finish with anything you found along the way that all three
+review passes missed — same severity framing, no fixes without asking.

--- a/docs/archive/engagements/spyc-review-remediation-prompt v4.md
+++ b/docs/archive/engagements/spyc-review-remediation-prompt v4.md
@@ -1,0 +1,338 @@
+# spyc: code review remediation (v4)
+
+You are working in the spyc repository (Tripstack-Corp/spyc). An external code
+review was performed against commit `dbffd29`; its findings were verified and
+corrected against `208d3ba`, then hardened against runtime knowledge from an
+agent working inside the repo. The commits between the review baseline and
+main are entirely mouse work — treat `src/app/mouse.rs` and neighbors as the
+one area where "verify the finding still holds" is more than a formality.
+
+**Amended after PR #234 merged:** the earlier "do not touch `src/app/mouse.rs`"
+exclusion is lifted. It existed only because that work was in flight. The file
+is now **F4's primary subject** — still propose-only, but it is the point of
+F4 rather than a footnote excluded from it.
+
+Read AGENTS.md first and follow every house convention it establishes —
+comment style, the documentation contract, SPYC-TRAP anchors, conventional
+commits, and the no-subprocess-git guard. Where a finding conflicts with an
+existing documented decision in ROADMAP.md's decisions log or docs/archive/,
+surface the conflict rather than silently overriding it.
+
+## Setup (do this before anything else)
+
+1. `git pull --ff-only` in the main checkout. `create_worktree` branches off
+   local `main`; a stale local main silently omits recently-merged PRs.
+2. Do NOT edit in the main checkout — a PreToolUse hook blocks edits there
+   and you will burn turns on denied writes before diagnosing why. Create a
+   worktree via the spyc MCP `create_worktree` tool and do all work in it.
+3. **Gate before commit, don't gate *during* commit.** Run `make check`
+   explicitly, then `git commit --no-verify`. The pre-commit hook is
+   `exec make check`, and those tests touch git — run inside the hook they
+   race the commit's own `index.lock` and can corrupt the index. This is
+   especially acute here: F1's tests create and remove worktrees. Running the
+   gate separately is not bypassing it.
+
+   This is distinct from CI flakes. A *CI* failure is a bug to fix, never a
+   job to re-run. A local index-lock collision from running git-touching
+   tests concurrently with a commit is a known interaction, not a flake —
+   don't go root-cause it.
+
+## Ground rules
+
+1. **Verify before fixing.** Confirm each finding on current `main` before
+   changing anything. If it no longer holds, say so and skip it.
+2. **One finding, one PR-shaped change**, conventional-commit messages
+   referencing the finding number (e.g. `fix(mcp): validate root override
+   against session roots (review F1)`). No bundled cleanups.
+3. **Tests first-class.** Every behavioral change ships with a test that
+   fails before and passes after, placed per existing conventions.
+4. **Run the full gate** (`make check` / CI-parity target) before declaring
+   any finding done. All work passes with `--locked`.
+5. **Docs in the same change.** ARCHITECTURE.md's "Documentation contract"
+   applies: behavior change and its doc change land together.
+
+## Order of work
+
+F1 decision (no code — record it first) → F2 → F1 implementation → F3 → F6 →
+F5 → F4 → F7.
+
+F2 jumps the queue because it is the only finding with an external-trust
+cost that compounds daily: SECURITY.md's distribution claims are visibly
+contradicted by the repo's own release artifacts, and it is the first
+document a security researcher reads.
+
+## Findings
+
+### F1 — MCP `root` override bypasses the path-traversal guard
+
+**Where:** `src/mcp/readers.rs::effective_root`, consumed by
+`get_file_content` (the canonicalize + `starts_with(canonical_root)` check
+around `src/mcp/protocol.rs:615`), and by `search_paths`, `search_content`,
+`git_status`, `git_log`, `git_diff`, and the worktree tools.
+
+**Defect:** the traversal guard is anchored to a value the caller picks.
+`effective_root` accepts any directory passing `is_dir()`; supply
+`root: "/"` and the `starts_with` check is decorative.
+
+**Why enforcement (not documentation) — get the rationale right.** The lazy
+threat ("the agent could read `~/.ssh`") argues for documenting instead: the
+agent typically has Bash and the socket is same-user 0600. The case that
+matters is the **harness permission asymmetry**: agent harnesses commonly
+auto-approve MCP tool calls while gating shell execution behind per-command
+permission prompts. In that configuration,
+`search_content(root: "/", regex: "BEGIN OPENSSH PRIVATE KEY")` silently
+bypasses a boundary the user believes exists. That is why the resolution is
+enforce.
+
+**Design constraint — the allowed set must be cursor-independent.** Do NOT
+anchor validation to the focused column. `search_root`, `project_home`, and
+`list_worktrees` all track the column the *user* is browsing, which moves
+independently of where the *agent* is working. Anchor to those alone and
+this daily workflow breaks: agent works in `spyc.worktrees/feat/foo`, user
+navigates the focused column to an unrelated project, and the agent's
+`root: <its own worktree>` is rejected mid-task. The failure mode is worse
+than the defect: a rejected MCP call doesn't stop the agent, it makes the
+agent fall back to unscoped, unlogged `Bash rg` — over-tight scoping
+produces bypass, not safety. The invariant: **the allow-list must never
+reject the agent's own working root during a session.**
+
+Cursor-independent anchors to build the allowed set from (implementer picks
+the combination; all three are legitimate):
+
+- all worktrees of the repo spyc was launched in — stable for the session,
+  not merely the currently-focused one;
+- any worktree created via `create_worktree` during this session;
+- the focused column's chain (`search_root`/`project_home`/`cwd`) may be
+  *included* — it just can't be the whole set.
+
+Note the first anchor may not map to a field that exists yet. `PROJECT_HOME`
+is auto-set from `.git` and is sticky per session, but it is user-mutable
+(`gP` / `Space P`), so it is not a launch-repo record. You may need to add
+one — which changes this from "wire up existing data" to "add a session
+field." Scope accordingly rather than discovering it halfway.
+
+**Known-ideal end state, out of scope here:** validating against the calling
+pane's own cwd. `SPYC_PANE_ID` is already injected into every agent pane's
+environment (`src/app/pane_tabs.rs:~126`) and the `spyc --mcp` proxy runs
+inside that pane — but read-tool dispatch resolves through the context file
+(`src/context.rs`), which carries no pane identity; `report_status` receives
+pane_id as a tool *argument*, not from the transport. Per-pane root
+attribution therefore needs transport plumbing that doesn't exist. Record it
+in the decisions log as the target design; do not build it in this
+engagement.
+
+**Do:** validate the `root` override against the cursor-independent allowed
+set. Reject anything else with a clear tool error naming the allowed set.
+Canonicalize both sides (symlinked worktree paths must not false-reject).
+Apply the validation everywhere `effective_root`'s override reaches — the
+git_* tools and worktree tools included.
+
+**Record the decision** in ROADMAP.md's decisions log with the
+harness-asymmetry rationale and the pane-identity end state — the two things
+a future maintainer needs when someone proposes relaxing or tightening the
+check.
+
+**Test note:** these tests exercise worktree creation/removal, which has
+documented CI-flake history (gix index-lock contention under parallel
+`cargo test`). Reuse the existing infrastructure —
+`serialize_worktree_mutation` (`src/git/worktree.rs:~129`),
+`write_index_with_lock_retry` (`~304`), and the `src/git/test_support.rs`
+retry helpers — rather than rolling new worktree scaffolding.
+
+**Acceptance:** tests proving `root: "/"` and `root: "/tmp/not-a-worktree"`
+are rejected; a legitimate sibling worktree is accepted, including via a
+symlinked path; and the cursor-independence case specifically — the agent's
+worktree root remains accepted after the context file's `search_root` moves
+to an unrelated directory. For documentation: F2 will already have written
+the agent-facing threat-model section from the recorded decision — verify
+that section matches what F1 actually shipped and amend only if the
+implementation diverged; do not write it twice.
+
+### F2 — SECURITY.md contradicts the shipped distribution model
+
+**Where:** `SECURITY.md` — line 60 ("There is no prebuilt binary
+distribution"), lines 82 and 132 ("if/when we start publishing prebuilt
+binaries"), and the license allow-list rationale pinned to v1.37.1.
+
+**Problem:** binary distribution shipped at 2.0.0 (signed apt repo, Homebrew
+tap, release tarballs, crates.io — see README.md and
+`.github/workflows/{release,apt,homebrew}.yml`). The release pipeline is now
+attack surface the security document doesn't know exists.
+
+**Do:** rewrite SECURITY.md to match reality: how release binaries are built
+and on what runner; how the apt signing key is generated, stored, and
+scoped; what a consumer can verify (checksums, signatures) and how; the
+key-compromise/rotation story; which GitHub Actions permissions the release
+workflows hold and why; the cargo-deny license allow-list refreshed against
+the current dep graph with the version reference updated; and the F1
+decision folded into the threat model (state what the MCP tool surface does
+and does not protect against with respect to the *connected agent*, not just
+other local processes). Keep the existing register — "what we do, what we
+don't, and why" — no boilerplate.
+
+**Acceptance:** no claim in SECURITY.md contradicts README.md, INSTALL.md,
+or the workflow files; a reader learns the actual release-signing chain from
+SECURITY.md alone.
+
+### F3 — Five state writes still bypass the existing atomic helper
+
+**Correction to the original finding:** `src/fs/atomic.rs::write_atomic`
+already exists and is used by `state/sessions/mod.rs`, `state/marks.rs`,
+`mcp/config.rs`, and `mcp/hooks.rs`. Do **not** build a new helper; sessions
+are already covered. What remains is mechanical — convert the five straggler
+call sites that still `std::fs::write` persistent state directly:
+
+- `src/state/frecency.rs:117`
+- `src/state/pager_positions.rs:112`
+- `src/state/history.rs:147`
+- `src/state/hook_consent.rs:47`
+- `src/state/graveyard.rs:202`
+
+(Line numbers as of `208d3ba`; re-locate if drifted. Ignore `fs::write`
+inside `#[cfg(test)]` blocks — fixture setup, not state persistence.)
+
+**Acceptance:** not a one-time grep — add a source-scan **guard test** in
+the house idiom (`no_subprocess_git_in_production`,
+`traps_resolve_against_architecture_anchors`, etc.): a
+`state_writes_are_atomic` guard asserting no production code path under
+`src/state/` (and any other module writing under the XDG state root) calls
+`std::fs::write` directly, with an allow-list mechanism for any deliberate
+exception. The guard is what stops the sixth straggler appearing next month.
+If `write_atomic`'s existing tests don't already cover
+interrupted-write-preserves-prior-file, add that; otherwise no new write
+machinery.
+
+### F6 — Two divergent state-root resolvers; MCP's ignores XDG
+
+**Correction to the original finding:** the bare-`/tmp` fallback is a
+symptom. The defect is two resolvers:
+
+- `state::state_root()` — honors `$XDG_STATE_HOME`, returns `Option`
+  (no HOME → `None`, callers skip persistence safely)
+- `mcp::state_dir()` — ignores `$XDG_STATE_HOME`, falls back to bare `/tmp`
+
+With `XDG_STATE_HOME` set — common, unlike an unset HOME — the MCP socket
+and trusted-root sidecar land in `~/.local/state/spyc` while all other state
+goes to `$XDG_STATE_HOME/spyc`: state splits across two directories, and the
+sidecar's "owner-private, attacker can't forge it" trust argument is being
+made about a path the rest of the program isn't using.
+
+**Do:** unify on one resolver — `mcp` consumes `state::state_root()` (or
+both consume one shared function). For the `None` case on the MCP side,
+prefer refusing to start the socket server (with a logged reason) over
+inventing a world-readable fallback; document the choice. The `/tmp` branch
+and any `/tmp`-squat hardening disappear with it.
+
+**Acceptance:** one resolver; a test that sets `XDG_STATE_HOME` and verifies
+the socket path and (e.g.) the frecency path share a root; the no-HOME
+behavior on the MCP side is explicit and tested.
+
+### F5 — Fuzz targets exist but never run in CI
+
+**Where:** `fuzz/fuzz_targets/` (dsl_parse, expand_path, expand_percent,
+highlight, render_markdown, word_wrap); `.github/workflows/`.
+
+**Do:** add a workflow triggered on both `schedule` (weekly) and
+`workflow_dispatch`, running each target for a bounded time (5–10 min each)
+with corpora cached between runs, failing loudly on a crash and uploading
+the reproducer as an artifact. Off the PR path — background insurance, not a
+merge gate. Pin the nightly toolchain explicitly.
+
+**Acceptance:** a manual `workflow_dispatch` run completes with corpora
+cached and artifacts uploaded — the dispatch run is the evidence the wiring
+works, since a scheduled run can't be demonstrated on demand.
+
+### F4 — `src/app/mouse.rs`, and the rule that doesn't describe the tree
+
+**Correction to the original finding:** there is no 800-LoC guard. The only
+ceiling guard is `mod_rs_stays_decomposed` (`src/app/mod_tests.rs:25`),
+capping `src/app/mod.rs` alone at 1,500 lines. AGENTS.md states the 800-LoC
+rule correctly as a convention with an escape hatch; the misleading text is
+ROADMAP.md:33, which jams "ceiling-guard-enforced" and "the 800-LoC file
+rule" into one clause. Twenty-plus production files exceed 800 lines.
+
+**Part A — the doc fix.** Correct ROADMAP.md:33 so the documented claim
+matches the enforced reality. A one-line change; land it.
+
+**Part B — `src/app/mouse.rs` (the main event, propose only).** 3,038 lines
+total, of which **~1,528 are production** (tests run 1529–3038) — the largest
+file in the tree and roughly twice the convention. Grown ~1,000 lines by
+#233/#234, so this is recent, self-inflicted, and fresh enough that the seams
+are still legible. Measure before proposing; these numbers drift.
+
+The structure already suggests a split — the file is two distinct halves that
+happen to share a filename:
+
+- **Pure decision layer** (~lines 50–615): `MouseDragTarget`, `ListSelection`,
+  `ChromeSelection`, `PaneScrollStreak`, `ChromeRow`, `MouseSnapshot`, the
+  timing constants, `scroll_streak_step`, `AgentViewAction` /
+  `AgentViewInputs` / `decide_agent_view_action`, `route_mouse`, `hit` /
+  `region_at`, `clamp_to_area`. `Copy` snapshots and pure functions — the
+  route.rs/focus.rs template, and independently testable.
+- **Impure dispatch** (`impl App`, ~616–1483): selection machinery
+  (list/pane/chrome begin/extend/finish), agent-view scroll and `^T`
+  escalation, coordinate translation, `mouse_report`.
+
+A plausible shape is `mouse/mod.rs` (types + pure decisions),
+`mouse/selection.rs`, `mouse/scroll.rs`, with each test cluster moving beside
+its subject. **Propose it; do not execute.** Verify the seams hold before
+recommending — a split that forces callers to reach across modules for state
+is worse than a long file, and the `too_many_lines` rationale about dispatch
+functions applies to files too.
+
+**Part C — the rest.** Only where natural seams exist, propose splits for the
+next two or three worst offenders. Same propose-only rule. Do NOT force
+artificial splits.
+
+**Acceptance:** documented rule and enforced rule are the same rule (landed);
+a mouse.rs decomposition plan with named modules, line estimates, and the
+seams verified (proposed, not landed).
+
+### F7 — AGENTS.md is 43KB of always-loaded agent context (lowest priority)
+
+**Do:** propose — do not execute without approval — a trim of AGENTS.md
+toward a pointer document: keep invariants, guards, and conventions an agent
+must never violate; move depth (worktree lifecycle narratives, extended
+rationale) into the installable skill and the docs it references.
+
+**Hard constraint:** the proposed trim may not remove any sentence naming a
+guard, a SPYC-TRAP slug, or an invariant. AGENTS.md is a large part of why
+agents don't wreck this repo; when in doubt, keep the sentence and flag it.
+
+**Acceptance:** a cut list with per-section justification, awaiting
+approval. No edits landed.
+
+## What NOT to do
+
+- Do not bump the version. `main` is the `N.M.0-CURRENT` stream; across a
+  seven-PR engagement a version bump is the most common cross-PR mistake and
+  stays invisible until release time.
+- Do not run the gate from inside the pre-commit hook (see Setup) — and do
+  not treat a local index-lock collision as a CI-grade flake.
+- Do not pipe the gate into `tail`/`head`. `make check 2>&1 | tail -20`
+  reports the *pager's* exit status, not make's, so a failed gate reads as
+  green. Use `set -o pipefail`, or redirect to a file and check `$?`. This
+  bit once already in this engagement: F1 was pushed with a failing
+  `fmt-check` that CI then caught.
+- Do not land a `src/app/mouse.rs` split. F4 Part B is propose-only.
+- Do not touch the MVU structure, the sync-only concurrency model, the
+  pager_stream seam, or the gix facade — reviewed favorably.
+- Do not add dependencies. std plus the existing tree covers every finding.
+- Do not build a new atomic-write helper (F3 — it exists).
+- Do not add `/tmp`-squat hardening (F6 — the path it defends should not
+  exist after unification).
+- Do not roll new worktree test scaffolding (F1 — reuse
+  `serialize_worktree_mutation` / `test_support` retry helpers).
+- Do not reformat, rename, or "improve" code adjacent to your changes.
+- Do not regenerate CHANGELOG.md by hand; git-cliff owns it.
+- If any finding turns out to be wrong on current main, document why in your
+  summary instead of manufacturing a fix.
+
+## Deliverable
+
+For each finding: the commits, the test evidence, and a two-line summary of
+what changed and why. For F1, the decisions-log entry containing the
+harness-asymmetry rationale, the cursor-independence invariant, and the
+pane-identity end state. For F4 and F7, proposals awaiting approval, not
+landed changes. Finish with anything you found along the way that all four
+review passes missed — same severity framing, no fixes without asking.

--- a/docs/archive/engagements/spyc-review-remediation-prompt.md
+++ b/docs/archive/engagements/spyc-review-remediation-prompt.md
@@ -1,0 +1,208 @@
+# spyc: code review remediation
+
+You are working in the spyc repository (Tripstack-Corp/spyc). An external code
+review was performed against commit `dbffd29` (v2.1.0-CURRENT). Your job is to
+address the findings below. Read AGENTS.md first and follow every house
+convention it establishes — comment style, the documentation contract,
+SPYC-TRAP anchors, conventional commits, the 800-LoC guidance, and the
+no-subprocess-git guard. Where a finding conflicts with an existing documented
+decision in ROADMAP.md's decisions log or docs/archive/, surface the conflict
+rather than silently overriding it.
+
+## Ground rules
+
+1. **Verify before fixing.** Each finding was produced by static review at a
+   specific commit. Before changing anything, confirm the finding still holds
+   on current `main`. If it doesn't, say so and skip it — do not fix things
+   that aren't broken.
+2. **One finding, one PR-shaped change.** Keep each finding's work in its own
+   commit series with a conventional-commit message referencing the finding
+   number below (e.g. `fix(mcp): validate root override against worktree
+   registry (review F1)`). Do not bundle unrelated cleanups.
+3. **Tests first-class.** Every behavioral change ships with a test that fails
+   before the change and passes after. Follow the existing test placement
+   conventions (module `#[cfg(test)]` blocks, `harness_tests/`, or `tests/` as
+   appropriate to the layer).
+4. **Run the full gate** (`make check` or the equivalent CI-parity target)
+   before declaring any finding done. All work must pass with `--locked`.
+5. **Update documentation in the same change.** The docs contract in
+   ARCHITECTURE.md §"Documentation contract" applies: if behavior changes,
+   the doc that describes it changes in the same commit.
+
+## Findings
+
+### F1 — MCP `root` override bypasses the path-traversal guard (highest priority)
+
+**Where:** `src/mcp/readers.rs::effective_root`, consumed by
+`get_file_content`, `search_paths`, `search_content`, `git_status`, `git_log`,
+`git_diff` dispatch in `src/mcp/protocol.rs`.
+
+**Problem:** `get_file_content` canonicalizes and checks
+`starts_with(canonical_root)` — but `effective_root` accepts any
+caller-supplied directory with only an `is_dir()` check. An agent passing
+`root: "/"` (or `~/.ssh`, etc.) reads or greps anything the invoking user can
+read. The check is decorative whenever `root` is supplied. Tool descriptions
+say "a sibling worktree you're working in," implying a scoping that does not
+exist.
+
+**Decide, then implement.** Two acceptable resolutions; pick one and record
+the decision in ROADMAP.md's decisions log:
+
+- **(a) Enforce (recommended):** validate the `root` override against the set
+  of legitimate roots spyc already knows about — the worktrees returned by
+  `list_worktrees` for the current repo, plus the context file's
+  `search_root`/`project_home`/`cwd` chain. Reject anything else with a clear
+  tool error naming the allowed set. Canonicalize both sides before
+  comparison (symlinked worktree paths must not produce false rejections).
+- **(b) Document:** if enforcement is rejected (e.g. because the agent has
+  pane shell access anyway and the boundary is judged theater), state plainly
+  in SECURITY.md and in every affected tool description that the `root`
+  parameter is unscoped and MCP tools are **not** a privilege boundary against
+  the connected agent.
+
+If you choose (a), also audit whether the same unvalidated-`root` pattern
+reaches `git_diff`/`git_log`/`git_status` and the worktree tools, and cover
+those in the same enforcement.
+
+**Acceptance:** a test proving `root: "/tmp/definitely-not-a-worktree"` (and
+`root: "/"`) is rejected (option a) or updated docs + tool descriptions that
+no longer imply scoping (option b). Either way, SECURITY.md's threat model
+section explicitly states what the MCP socket does and does not protect
+against with respect to the *connected agent*, not just other local processes.
+
+### F2 — SECURITY.md is stale and no longer describes the distribution model
+
+**Where:** `SECURITY.md`.
+
+**Problem:** The doc states "There is no prebuilt binary distribution" while
+README.md documents Homebrew, a signed apt repo, release tarballs, and
+crates.io. The license allow-list rationale is pinned "as of v1.37.1" against
+a current version of 2.1.0-CURRENT. Binary distribution materially changes
+the threat model: the release pipeline (`.github/workflows/release.yml`,
+`apt.yml`, `homebrew.yml`) is now attack surface and is uncovered.
+
+**Do:** rewrite SECURITY.md to match reality. It must now cover: how release
+binaries are built and by what runner; how the apt repo signing key is
+generated, stored, and scoped; what a consumer can verify (checksums,
+signatures) and how; what happens on key compromise (rotation story); which
+GitHub Actions permissions the release workflows hold and why; and the
+`cargo-deny` license allow-list refreshed against the current dep graph with
+the version reference updated. Fold in the F1 decision. Keep the existing
+register — "what we do, what we don't, and why" — and do not pad it with
+boilerplate.
+
+**Acceptance:** no claim in SECURITY.md contradicts README.md, INSTALL.md, or
+the workflow files. A reviewer reading only SECURITY.md learns the actual
+release-signing chain.
+
+### F3 — Non-atomic state writes
+
+**Where:** confirmed in `src/state/frecency.rs::save` (`std::fs::write`
+directly); audit the whole `src/state/` family (harpoon, marks, inventory
+metadata, pager_positions, graveyard JSON sidecars) and
+`src/app/session.rs` snapshot writes for the same pattern.
+
+**Problem:** a crash or power loss mid-write leaves truncated JSON/TOML. The
+startup health check mitigates by detecting and discarding corrupt files, but
+the session autosave's entire purpose is crash survival — a crash *during*
+the save is exactly when the snapshot matters, and today it can destroy the
+previous good snapshot.
+
+**Do:** introduce one small write-atomic helper (temp file in the same
+directory + `rename`, with the temp name unlinkable on failure) in the
+appropriate shared module, and convert every persistent-state write site to
+use it. Do not add fsync-on-every-write unless a site genuinely needs
+durability over performance — atomicity (no torn files) is the requirement;
+note the distinction in the helper's doc comment. Sessions get priority.
+
+**Acceptance:** a test that simulates interruption (write the temp, don't
+rename, re-run load) proving the prior snapshot survives; grep shows no
+remaining direct `fs::write` to files under the XDG state root from
+production code paths.
+
+### F4 — The 800-LoC file rule no longer describes the tree
+
+**Where:** roughly ten production files between ~850 and ~1,400 lines:
+`app/mod.rs` (1,381), `app/agent_status.rs` (1,263), `app/render/mod.rs`
+(1,227), `app/effect.rs` (1,178), `app/state/mod.rs`, `app/pane_tabs.rs`,
+`mcp/protocol.rs`, `mcp/config.rs`, `mcp/hooks.rs`, others near the line.
+
+**Problem:** ROADMAP.md presents the 800-LoC rule as enforced by ceiling
+guards. Either the guards use per-file baselines (in which case the rule as
+documented is misleading) or the rule has eroded.
+
+**Do:** first, determine what the guard actually enforces (read the Makefile
+/ scripts). Then either (a) split the worst offenders where a natural seam
+exists — do NOT force artificial splits that hurt navigation; the existing
+`too_many_lines` clippy-allow rationale about dispatch functions applies to
+files too — or (b) amend the documented rule to what is actually enforced
+(e.g. "800 LoC for new files; legacy files ratcheted via baseline"). A mix is
+fine: split the two or three files with obvious seams, ratchet the rest.
+
+**Acceptance:** the documented rule and the enforced rule are the same rule.
+
+### F5 — Fuzz targets exist but never run in CI
+
+**Where:** `fuzz/fuzz_targets/` (dsl_parse, expand_path, expand_percent,
+highlight, render_markdown, word_wrap); `.github/workflows/`.
+
+**Do:** add a scheduled (weekly is fine) workflow that runs each fuzz target
+for a bounded time (e.g. 5–10 min each) with the corpus cached between runs,
+failing loudly on a crash and uploading the reproducer as an artifact. Keep
+it off the PR path — this is background insurance, not a merge gate. Pin the
+nightly toolchain it needs explicitly rather than floating.
+
+**Acceptance:** workflow exists, is schedule-triggered, caches corpora, and a
+deliberately-introduced panic in one target (verified locally, not
+committed) demonstrates the failure path works.
+
+### F6 — `state_dir()` falls back to bare `/tmp` when `$HOME` is unset
+
+**Where:** `src/mcp/mod.rs::state_dir` (and check for the same fallback in
+`src/state/`'s XDG resolution).
+
+**Problem:** sockets and trusted-root marker sidecars land directly in
+world-readable `/tmp`. The 0600 socket permission holds, but the `.root`
+sidecar's trust argument ("owner-private, attacker can't forge it") weakens
+in a shared directory, and predictable names invite squatting.
+
+**Do:** fall back to a per-user directory (`/tmp/spyc-<uid>`) created with
+0700, verifying ownership and mode on reuse (refuse a pre-existing dir owned
+by someone else — classic /tmp squat defense). Honor `$XDG_STATE_HOME` before
+`$HOME` if it isn't already consulted.
+
+**Acceptance:** test covering the no-`$HOME` path; the squat-refusal branch
+has a test.
+
+### F7 — AGENTS.md is 43KB of always-loaded agent context (lowest priority)
+
+**Do:** trim AGENTS.md toward a pointer document: keep the invariants, guards,
+and conventions an agent must never violate; move depth (worktree lifecycle
+narratives, extended rationale) into the installable skill and the docs it
+already references. Target is meaningful reduction without losing any
+load-bearing rule — if in doubt about whether a section is load-bearing,
+keep it and flag it. This is judgment work; do it last, and propose the cut
+list before executing it.
+
+## Order of work
+
+F1 → F2 (F2 folds in F1's decision) → F3 → F6 → F5 → F4 → F7.
+
+## What NOT to do
+
+- Do not touch the MVU structure, the sync-only concurrency model, the
+  pager_stream seam, or the gix facade — these were reviewed favorably.
+- Do not add dependencies for F3 or F6; std is sufficient. (tempfile is
+  already a dev-dependency; keep it out of the production graph unless it
+  already is one.)
+- Do not reformat, rename, or "improve" code adjacent to your changes.
+- Do not regenerate CHANGELOG.md by hand; the git-cliff flow owns it.
+- If any finding turns out to be wrong on current main, document why in your
+  summary instead of manufacturing a fix.
+
+## Deliverable
+
+For each finding: the commits, the test evidence, and a two-line summary of
+what changed and why. For F1 and F4, the decision recorded in ROADMAP.md's
+decisions log. Finish with anything you found along the way that the review
+missed — same severity framing, no fixes without asking.


### PR DESCRIPTION
Seven documents sitting untracked in `docs/drafts/` (dated 5–7 Aug, never committed) are the briefs, proposals and deliverables from the code-review and cleanup engagements that ran before the pre-2.1 review. They carry the finding→PR mapping, which doesn't exist anywhere else outside individual commit messages. This files them under `docs/archive/engagements/`.

Each was checked against the code rather than against its own status line.

## Archived — verified done

| Document | Verified |
|---|---|
| `mouse-rs-decomposition-proposal.md` | `src/app/mouse/` holds `route`/`selection`/`scroll`/`forward` as proposed (plus `tab_hit.rs`, added later); `mouse.rs` is gone. #244–#246 |
| `agents-md-trim-proposal.md` | `## What it does` 16,427 → 8,272 bytes; the two bullets it named dropped ~88% and ~81%. #243 |
| `review-remediation-deliverable.md` | Record of F1–F7, twelve PRs, all merged |
| `spyc-review-remediation-prompt.md` + `v2`/`v3`/`v4` | The brief; `v4` is the one the deliverable cites |

## Left in drafts — still live

Filing these would have marked unfinished work as done.

**`pane-identity-transport-proposal.md` (C7)** — recorded by its own engagement as *"proposal only"*, and nothing has been built. `pane_id` reaches the server only as an optional **tool argument** on `report_status` / `register_scope` / `release_scope` — which is precisely the option the proposal rejects, because attribution then fails silently whenever an agent forgets to send it. `readers.rs:44` still documents the cursor-independent session-wide allowed set that per-pane roots were meant to retire.

**`cleanup-engagement-deliverable.md`** — C1–C9 are merged, but its *"Found along the way — not fixed"* section lists seven items and they aren't all closed:

- item 1 (`git reset FETCH_HEAD`) — **done**, it's in AGENTS.md (#256)
- item 3 (DECCKM gap) — **done**, `encode_key(ev, app_cursor)` takes the mode
- item 2 — **open**: SECURITY.md still says nothing about pane attribution not being authorization, though an env-supplied pane id and a per-pane socket are both forgeable by an agent running as the same uid. `grep -i 'attribution|forge|authorization' SECURITY.md` returns nothing.
- items 4–7 not individually verified

The README in the new directory records both, with the reasoning, so this doesn't have to be rediscovered by reopening the commit.

## One thing worth knowing about F7

The approved cut was made and the section shrank. **The file didn't.** AGENTS.md was 43,256 bytes when the proposal called it too large and is 52,084 now — `## Architecture` grew 10,895 → 20,457 and is now the largest section, ahead of `## Conventions`. That's a new observation rather than an unclosed comment, so it's noted in the README instead of holding the archive open. Worth a decision separately: the file is 20% past the size that prompted the proposal.

Docs-only; no source touched.

Generated with [Claude Code](https://claude.com/claude-code)
