### PR TITLE
docs(release): finalize the 2.1 notes — drop the draft banner, lead with the gallery

### DIFF
--- a/docs/drafts/2.1-release-notes.md
+++ b/docs/drafts/2.1-release-notes.md
@@ -1,13 +1,4 @@
-# spyc 2.1 — release notes (DRAFT)
-
-> **Draft for the owner to edit and use at tag time.** Nothing here is
-> generated: `CHANGELOG.md` is git-cliff's job (from commit subjects), and this
-> is the narrative layer on top of it — what a user would notice, in their
-> words. Numbers in `#nnn` are PRs unless marked "issue".
->
-> **Verified against `git log v2.0.3..6ee04b2`** — 177 commits. Every item below
-> is merged; there are no pending entries. All 15 issues in the 2.1 milestone are
-> closed.
+# spyc 2.1 — release notes
 
 ## The short version
 
@@ -20,6 +11,29 @@ fifteen minutes — with particular attention to Linux, where most of them were
 hiding.
 
 ## Added
+
+### You can see the images you pasted
+
+An agent renders a pasted image as an opaque token — `[Image #3]` — so you can't
+check what you actually attached, and neither can you a day later. **`^a g`** (or
+`:images`) lists them, read back out of the agent's own transcript, so the list
+survives a spyc restart and a `claude --resume`. Images you've pasted but not sent
+yet lead it, marked 📎: spyc keeps its own copy at the moment your paste key goes
+through, because that keystroke is the only signal it gets — the agent reads the
+system clipboard itself, the terminal never carries the bytes — and that moment is
+the only one where the same image is still there.
+
+It's a popup over whatever you were doing rather than a view the file list
+switches into, since checking an attachment is a glance and not a destination.
+`j`/`k` move, `1`-`9` jump, `Enter` shows one full-screen with the usual image
+verbs, and `q` closes. (#302, #304, #308)
+
+**Image files open full-screen from the list too.** `Enter` on a PNG / JPEG / GIF /
+WebP draws the picture at the size your terminal can take, on the same image path
+the mermaid preview already used — `s` saves, `y` copies the image, `Y` the path,
+`o` hands it to your OS viewer. Detection is by magic bytes, so an extensionless
+screenshot previews and a misnamed `.png` full of text still hex-dumps. Needs a
+terminal with a graphics protocol; without one, `o` still works. (#300)
 
 ### Archives are directories now
 
@@ -128,29 +142,6 @@ that half is read off the pane; between them the two cover both ways agy waits o
 you. Worth knowing: the "turn finished" half of agy's dot needs **agy ≥ 1.1.10**,
 which is where agy made `Stop` hooks reachable at all — on an older agy that half
 quietly falls back to guessing from output timing. (#285, #287)
-
-### You can see the images you pasted
-
-An agent renders a pasted image as an opaque token — `[Image #3]` — so you can't
-check what you actually attached, and neither can you a day later. **`^a g`** (or
-`:images`) lists them, read back out of the agent's own transcript, so the list
-survives a spyc restart and a `claude --resume`. Images you've pasted but not sent
-yet lead it, marked 📎: spyc keeps its own copy at the moment your paste key goes
-through, because that keystroke is the only signal it gets — the agent reads the
-system clipboard itself, the terminal never carries the bytes — and that moment is
-the only one where the same image is still there.
-
-It's a popup over whatever you were doing rather than a view the file list
-switches into, since checking an attachment is a glance and not a destination.
-`j`/`k` move, `1`-`9` jump, `Enter` shows one full-screen with the usual image
-verbs, and `q` closes. (#302, #304, #308)
-
-**Image files open full-screen from the list too.** `Enter` on a PNG / JPEG / GIF /
-WebP draws the picture at the size your terminal can take, on the same image path
-the mermaid preview already used — `s` saves, `y` copies the image, `Y` the path,
-`o` hands it to your OS viewer. Detection is by magic bytes, so an extensionless
-screenshot previews and a misnamed `.png` full of text still hex-dumps. Needs a
-terminal with a graphics protocol; without one, `o` still works. (#300)
 
 ### Smaller additions
 

--- a/docs/drafts/cleanup-engagement-deliverable.md
+++ b/docs/drafts/cleanup-engagement-deliverable.md
@@ -1,0 +1,217 @@
+# Post-remediation cleanup — deliverable
+
+Brief: the C1–C7 cleanup engagement, plus C8 and C9 added mid-flight.
+Baseline `edc27b8`. Eleven PRs: #247–#250, #252, #253, #255, #256.
+
+## Summary
+
+All merged.
+
+| Item | PR | Commit | Outcome |
+|---|---|---|---|
+| C1 | #247 | `0e30e5b` | **parked** — did not reproduce; instrumented so the next occurrence is decisive |
+| C2 | #249 | `6e087b3` | fixed — one shared splitter + a spawn-hygiene guard |
+| C3 | #250 | `c8a3c0c` | **fixed** (not the dead-end the brief allowed for) |
+| C4 | #252 | `1103cfe` | done — 61 tests relocated, count preserved exactly |
+| C5 | #253 | `bddb28f` | delivered the achievable part; **acceptance criterion was impossible** |
+| C6 | #253 | `bddb28f` | documented |
+| C7 | — | draft doc | proposal only, **recommendation differs from the brief's framing** |
+| C8 | #255 | `b258afb` | fixed — but **the stated mechanism was wrong** |
+| C9 | #248 | `9aefbb4` | fixed — a repo-corrupting bug, added mid-engagement |
+| — | #256 | `7530145` | the `FETCH_HEAD` warning, documented on request |
+
+## Per item
+
+**C1 — agent-pane input deafness.** Did not reproduce under a deliberate attempt
+(instrumented build, `SPYC_KEY_TRACE=1`, Claude pane + shell pane, unanswered
+multi-question, repeated pane switches). No speculative fix. Landed the one trace
+field that makes the next occurrence decisive: `app_cursor=` on the send line.
+*Evidence:* reproduction matrix and untried variations recorded in
+`docs/drafts/mutli-question-bug-investigation.md`.
+
+What it did establish: **candidate A (a latched `resolver_pending`) is ruled
+out.** Every pending state resets on an unmatched key; `route_input` with
+`pending` set still reaches `feed`, which resets; the only pre-`feed` swallow is
+60 ms, same-key, and requires `!resolver_pending`. The live trace confirmed it —
+`g` armed the chord, the next key cleared it. And **a new candidate C is
+confirmed to exist**: spyc never reads the child's DECCKM state, so a child in
+application-cursor mode receives `ESC [ A` where it waits for `ESC O A`. It is
+the only candidate that predicts the reported asymmetry — arrows dying while a
+bare `^c` survives.
+
+**C2 — guard splitter.** Three guards each carried
+`src.split("#[cfg(test)]").next()`, which fails open twice: a comment
+*mentioning* the attribute truncated `render/mod.rs` to 22 production lines of
+827, and a mid-file `#[cfg(test)] mod x;` hid 90% of `git/worktree.rs`. Replaced
+with one shared `guard_support::production_half` that removes guarded items
+rather than truncating.
+*Evidence:* four canaries; verified three go red against the old heuristic. All
+four existing guards still pass under the wider scan — the blind spot was real
+but wasn't hiding violations. Plus a new guard asserting every test-side git
+spawn resists an inherited `GIT_DIR`.
+
+**C3 — resumed codex sessions.** Fixed, and narrower than stated: Signal 1
+already covers `codex resume <UUID>`, including spyc's own restore. Only
+`resume --last`, an id-less restore, and codex's in-app picker are unpinnable.
+For those, added `mtime_secs` to `RolloutMeta` and a fallback taking the most
+recently written matching rollout that has grown since the pane spawned.
+*Evidence:* four new tests (fix, gate, claimed-set on the fallback, staleness);
+seven pre-existing pinning tests unchanged; the original #230 regression test
+`pick_prefers_resumed_session_over_a_fresh_unrelated_one` stays green. mtime
+remains a liveness *filter* and never becomes a ranking key.
+
+**C4 — mouse test relocation.** `mod.rs` 1,815 → 303 lines, zero tests left.
+61 `#[test]` before, 61 after.
+*Evidence:* count asserted both sides; `make check` green. Five tests filed under
+the *selection* headings turned out to assert `route_mouse`'s decision, not the
+selection machinery — the headings had grouped by feature rather than by function
+under test, visible only once the two lived in different files.
+
+**C5 — the gate.** The acceptance criterion — `make check-ci 2>&1 | tail -5`
+exiting nonzero — **is not achievable**. A pipeline's status is its last
+command's in `sh`, `bash` and `zsh`, and the pipe is built in the caller's shell.
+Verified, not assumed. Delivered what a target can do: `check-ci` ends in
+`=== GATE: PASS ===` / `=== GATE: FAIL ===`, so the verdict survives a tail even
+though the exit code cannot.
+*Evidence:* demonstrated with a deliberate type-error canary piped through
+`tail -3`; canary reverted, only the passing state committed.
+
+**C6 — the merge race.** Documented in AGENTS.md's merges section with the
+wait-then-retry loop actually used. It bit all twelve PRs of the previous
+engagement and every one of this one.
+
+**C7 — pane identity.** `docs/drafts/pane-identity-transport-proposal.md`.
+Recommends the `initialize` handshake over a per-pane socket, and reaches a
+conclusion the brief's framing did not anticipate — see findings below.
+
+**C8 — status cache key.** Git config decides what `status` reports and moves
+neither `index` nor `HEAD`, so the poll short-circuits on a stale answer
+indefinitely. Folded the shared config's mtime into the key, resolved once per
+chdir beside the gitdir (following `commondir` for linked worktrees, which have
+no config of their own). One extra `stat` per poll.
+*Evidence:* `a_config_change_moves_the_status_cache_key`, verified red-before /
+green-after. Also fixes `core.excludesFile` and `status.showUntrackedFiles`
+changes, which previously needed an unrelated index write to take effect.
+
+**C9 — `GIT_DIR` leak.** `GIT_DIR` overrides `-C`, and git exports it into hook
+processes, so a hook-launched `cargo test` retargets every scratch-repo command
+at the developer's real repository. One shared `git_command()` builder strips the
+nine redirect variables; the nine ad-hoc spawn sites drop the three that bite.
+*Evidence:* `git_dir_really_does_beat_dash_c` characterizes the hazard;
+`git_command_strips_the_ambient_repo_redirect` asserts the fix. `make check`
+green with `core.bare` confirmed unchanged after the run.
+
+## Corrections to the brief
+
+Four items were premised on something that turned out not to hold. Recording
+them because in each case the wrong premise would have produced the wrong work.
+
+- **C5's acceptance criterion was impossible** — medium. No callee can control a
+  caller-side pipeline's exit status. Building to it would have meant shipping
+  something that looked like a fix and wasn't.
+- **C8's stated mechanism was wrong** — medium. "A failed walk is cached
+  indistinguishably from a clean repo" is false: `apply_git_worker_result`
+  already discards `entries: None`, and the sync path nulls before refilling.
+  The real defect is that a *structurally* clean answer is a legitimate success
+  the mtime key cannot invalidate.
+- **C3's scope was too broad** — low. Resumed sessions are not generally
+  unpinnable; Signal 1 covers the common path.
+- **C7's trust framing was incomplete** — see below.
+
+## Found along the way — not fixed, no unrequested changes
+
+### 1. `git reset FETCH_HEAD` starves the alphabetically-later branch — high
+
+A bare `git fetch` writes **every** fetched branch into `FETCH_HEAD`;
+`git reset FETCH_HEAD` consumes only the **first line**, which is alphabetical.
+Every line is marked `not-for-merge`, and `reset` ignores that.
+
+Observed live: another session's worktree on `feat/about-action` was reset three
+times to `2fd45e6` — the tip of this engagement's `docs/gate-and-merge-race-…`
+branch — because `docs/` sorts before `feat/`. It cost that session four
+commits. `FETCH_HEAD` is per-worktree, so the file was its own; the *content*
+was wrong.
+
+spyc is a multi-worktree, multi-agent tool that encourages exactly this layout,
+so the idiom deserves a warning even though it isn't spyc's. **Documented in
+AGENTS.md at the owner's request (#256)**, beside the `update-branch` merge-race
+note — which is where someone looks when trying to get a branch current, exactly
+when they reach for `reset FETCH_HEAD`. The safe forms are named there:
+`git fetch origin <branch> && git reset origin/<branch>`, or
+`gh pr update-branch`, which is server-side and races nothing local.
+
+The diagnosis was slow *because* `FETCH_HEAD` is per-worktree: the file was that
+session's own, so it read as another session writing into its worktree rather
+than a local idiom resolving the wrong ref. Worth remembering as a shape — "the
+file is mine, the content is wrong" is not where suspicion goes first.
+
+### 2. No pane-attribution mechanism gives authorization — medium
+
+C7's proposal covers this, but it belongs here too because it bears on F1's
+shipped decision. Env-supplied pane ids are forgeable by the agent, and so is
+the per-pane socket: the sockets are listable and 0600-owned by the same user the
+agent runs as. Per-pane roots would stop an accident, not an attempt. F1's threat
+model is prompt injection through an auto-approved MCP surface — precisely the
+actor who would forge. SECURITY.md should say so in the same paragraph that
+describes what attribution enables.
+
+### 3. spyc's DECCKM gap — medium
+
+`encode_key` emits the CSI form unconditionally; `vt100::application_cursor()`
+exists and is never read. Any child that sets DECCKM and parses strictly loses
+its arrow keys. Confirmed empirically. Usually benign because most parsers accept
+both forms. **Not fixed** — it is C1's leading candidate and fixing it without a
+trace would be the speculative fix the brief forbids.
+
+### 4. Worktree build caches fill the disk — medium
+
+Each worktree carries its own ~3 GB `target/`. Thirteen of them took this
+machine to 153 MB free and failed a build mid-engagement. `create_worktree` is
+deliberately frictionless and nothing prunes or warns. Freed 32 GB by removing
+eleven merged worktrees. Worth considering a low-disk warning on
+`create_worktree`, or a `:worktree prune` for merged ones. **Not built.**
+
+### 5. The 2026-07-02 retry widening treated a symptom — informational
+
+`RUN_GIT_MAX_ATTEMPTS`' comment records a hook-time `index.lock: Not a
+directory` failure attributed to "genuine transient contention" and fixed by
+widening the budget 3 → 6. That was the C9 leak. The budget is now belt to
+C9's braces; nothing needs changing, but the comment overstates what was
+understood at the time.
+
+### 6. `cargo deny` segfaulted in CI — informational, undecided
+
+`deny` crashed with `Segmentation fault (core dumped)` on #255 after `fmt` and
+`clippy` passed. cargo-deny is pinned and sha256-verified (0.19.4), so the binary
+is deterministic — but `cargo deny check` **refetches the RUSTSEC advisory
+database every run**, so the non-deterministic input is the database, not our
+config, and #255 touches no dependencies. A re-run was therefore the correct
+response rather than a stopgap: there is nothing in our control to fix. It passed
+on the re-run (51s), so a single crash on freshly-fetched external input.
+
+If it recurs, the resolution is pinning the advisory-DB snapshot — but that
+trades away the fresh-advisory detection `audit.yml` exists for, so it should not
+be changed on one data point. **Undecided, deliberately.**
+
+### 7. `pick_best_rollout` residual — low
+
+Two concurrent codex panes in one cwd where *neither* is resuming can still
+resolve to the same rollout. Needs a claimed-rollout exclusion set threaded
+through `TranscriptQuery`. Unchanged; still noted on #230.
+
+## Process notes on my own conduct
+
+- **I filled the disk** (item 4) and only noticed when a build failed. Cleaning
+  worktrees as they merge, not at the end, would have avoided it.
+- **A scripted regex edit across four files mangled brace/paren delimiters**,
+  caught by `cargo check`, reverted, redone as an anchored insert. Second time
+  this session a clever script was worse than a careful one.
+- **I bundled C6's AGENTS.md rule into C5's commit** and had to lift it out and
+  amend. The split is visible only in the history, not the diff.
+- **My push cadence is what surfaced item 1.** The other session's idiom was
+  already unsafe; frequent pushes to an alphabetically-earlier branch made it
+  fire. Pausing pushes on request was the right call and worth offering sooner.
+- **I followed the brief's Setup rule 3** (`never --no-verify`) against my own
+  flagged objection, and it corrupted the repo within one commit. Flagging a
+  concern and then complying is correct; the value was in having flagged it, so
+  the cause was identified in minutes rather than hours.

--- a/docs/drafts/pane-identity-transport-proposal.md
+++ b/docs/drafts/pane-identity-transport-proposal.md
@@ -1,0 +1,148 @@
+# Pane identity for MCP tool dispatch — design proposal (C7)
+
+**Status:** proposal. No code written.
+**Measured against:** `6e087b3`.
+
+## What's missing and why it matters
+
+The F1 decisions-log entry names per-pane root validation as the target design:
+check an MCP `root` override against *the calling pane's own worktree* rather
+than a session-wide allowed set. It can't be built today because **read-tool
+dispatch has no idea which pane is calling**.
+
+Three facts define the gap:
+
+- `SPYC_PANE_ID` reaches the agent pane's environment at spawn
+  (`app/pane_tabs.rs`), and the `spyc --mcp` proxy is re-exec'd *by the agent*,
+  so the proxy already inherits it.
+- The proxy forwards JSONL **verbatim** (`mcp::run` → `run_proxy`). It reads the
+  env only to find the socket; it adds nothing to the stream.
+- Read tools resolve context from the `.spyc-context-<pid>.json` file, which
+  carries `cwd` / `project_home` / `search_root` and **no pane identity**.
+
+`report_status` looks like a counter-example but isn't: it takes `pane_id` as a
+*tool argument*, supplied by the status hook from `$SPYC_PANE_ID`. That's
+agent-asserted data travelling in the payload, not identity derived from the
+transport.
+
+The cost of the gap is visible in F1's own shape. Its **cursor-independence
+invariant** — the allowed set must never reject the agent's own working root —
+exists *only* because there is nothing to attribute a call to. With attribution
+the rule collapses to "the pane's own worktree", which is both tighter and
+obvious.
+
+## Candidates
+
+### A. One socket per pane
+
+spyc listens on `mcp-<pid>-<paneid>.sock` per agent pane; each pane's
+`SPYC_MCP_SOCK` points at its own.
+
+Identity becomes structural: whichever socket accepted the connection *is* the
+answer, with nothing to assert.
+
+- **Cost:** high. N listeners per instance, lifecycle bound to tab open/close,
+  and the orphan-sweep / takeover / trusted-root-sidecar logic all multiply by
+  pane. The socket-per-PID model is load-bearing in `mcp/config.rs`'s takeover
+  detection and `server.rs`'s discovery.
+- **Migration:** breaking. `SPYC_MCP_SOCK` changes meaning; existing `.mcp.json`
+  / `.codex/config.toml` files point at the instance socket and must keep
+  working (accepted as "unattributed") through at least one release.
+
+### B. Pane id in the `initialize` handshake
+
+The proxy reads `$SPYC_PANE_ID` from its own environment and sends it in
+`initialize` (`clientInfo` or `_meta`); the server binds it to that connection
+for the connection's lifetime.
+
+- **Cost:** low. One handshake field, one per-connection field server-side, zero
+  change to tool schemas or to what agents must remember.
+- **Migration:** trivial and non-breaking. An older proxy omits the field; the
+  server treats that connection as unattributed and behaves exactly as today.
+
+### C. Pane id on every tool call
+
+Generalize the `report_status` pattern: add an optional `pane_id` to every tool.
+
+- **Cost:** every schema grows a parameter, and correctness depends on the agent
+  *remembering* to send it. A forgetful agent silently loses attribution, which
+  is the worst failure mode of the three — it degrades quietly.
+- **Migration:** trivial, but it makes attribution a per-call agent
+  responsibility forever.
+
+## The trust question, stated plainly
+
+The brief asks what an env-supplied pane id does to the trust model. The honest
+answer is broader than that, and it changes the recommendation:
+
+**No pane-attribution mechanism can be an authorization boundary against a
+same-user agent — including option A.**
+
+- B and C are forgeable directly: the agent controls its own environment, so it
+  can set `SPYC_PANE_ID` to a sibling's value before the proxy starts.
+- A is forgeable too, just less obviously: the sockets live in a directory the
+  agent can list, and they are 0600 owned by *the same user the agent runs as*.
+  Nothing stops it connecting to another pane's socket.
+
+This is the same conclusion SECURITY.md already reaches about the MCP surface,
+and it is worth not quietly forgetting when per-pane roots make the boundary
+*look* stronger. F1's threat model is the harness permission asymmetry — MCP
+auto-approved while shell execution is gated — and a prompt-injected agent under
+that model is exactly the actor who would forge an id. Per-pane roots built on
+any of these three would stop an *accident*, not an *attempt*.
+
+Real containment needs OS-level isolation (a separate uid, a container). That's
+outside spyc's scope, and pretending otherwise in a doc is how F1's original
+"the check is decorative" problem happened in the first place.
+
+So the mechanism should be chosen for **cost and correctness**, not for
+strength — because none of them buys strength.
+
+## What attribution unlocks
+
+1. **Per-pane roots (F1's target).** Validate `root` against the calling pane's
+   own worktree. Retires the cursor-independence workaround.
+2. **`get_spyc_context` answers for the caller.** Today it returns the focused
+   column's cwd, so an agent in worktree X gets told about worktree Y whenever
+   the user browses. That's the single most confusing thing about the current
+   tool surface.
+3. **Scope-registry ownership (P2).** `register_scope` claims are advisory and
+   owner-labelled by convention. Attribution lets a claim bind to a pane, and
+   `release_scope` refuse a claim the caller doesn't own.
+4. **Audit.** "Which pane read that file" is currently unanswerable. One
+   connection-scoped field makes the existing `mcp_log` useful for it.
+
+(2) is the one users would notice tomorrow; (1) is the one F1 asked for.
+
+## Recommendation
+
+**Option B — pane id in the `initialize` handshake.**
+
+It is the cheapest by a wide margin, non-breaking, requires nothing of agents,
+and unlocks all four capabilities above. Since no option provides authorization,
+paying option A's cost — multiplying the socket lifecycle, takeover detection,
+and orphan sweeping by pane count — buys ergonomics only, and buys them worse
+than B does.
+
+Reject C: making every call carry its own identity means attribution fails
+silently whenever an agent forgets, and it spreads the concern across every
+schema instead of confining it to one handshake.
+
+**Conditions on B, if it is built:**
+
+- Bind the id to the *connection*, never re-read it per call. A per-call field
+  reintroduces C's failure mode.
+- Validate the id against live tabs on receipt and drop it if unknown, so a
+  stale id from a closed tab degrades to unattributed rather than mis-attributing.
+- Keep every unattributed path working. The session-wide allowed set from F1
+  stays as the fallback — per-pane roots *narrow* it, and must never be the only
+  thing standing between an agent and its own worktree.
+- Say in SECURITY.md that this is attribution, not authorization, in the same
+  paragraph that describes what it enables.
+
+## Not recommended
+
+Threading identity through the context file. It is PID-scoped, one per spyc
+instance, and rewritten on every state change — making it per-pane would either
+multiply the files or add a pane table that every reader has to index, for no
+gain over a handshake field.


### PR DESCRIPTION
Owner's finalization of the 2.1 release notes for launch: drops the DRAFT preamble and moves **"You can see the images you pasted"** to the head of `## Added`, ahead of archives.

## One thing worth knowing before you post from it

The removed banner carried a verification claim — *"verified against `git log v2.0.3..6ee04b2`, 177 commits"* — that had gone stale. **47 PRs merged after that baseline** (#374–#422). Removing the claim rather than restating it is the right call, since what follows is narrative and doesn't track a commit range.

Almost all of that range is the review-remediation campaign — guards, tests, docs, and internal fixes to features the notes already describe — which correctly doesn't belong in user-facing notes. **Four user-visible items in it are not described:**

| PR | What a user would notice |
|---|---|
| **#391** `feat(pane)` | An inline agent's transcript is reachable, and `T` swaps between capture and transcript. The notes mention transcripts only for the image gallery and codex's `^T` overlay. |
| **#413** | A down-scroll past the end of a `^a v` scrollback returns you to the live pane instead of parking at `[EOF]`. |
| **#402** | A text yank's done-wake panicked the event loop rather than coalescing — a crash. |
| **#394** | A vsplit whose column was inside an archive comes back on restore. |

**Not added in this PR** — it's the owner's copy in the owner's voice, and adding four entries to launch prose is an editorial call, not a mechanical one.

**They aren't lost from the published release, either.** `release.yml` runs `git cliff --config cliff.toml --latest --strip header > RELEASE_NOTES.md` and passes *that* to `gh release create --notes-file`. The GitHub release body is generated from commit subjects, so all four reach it through their own conventional commits. This document is the narrative layer used by hand — the Show HN post being the obvious place — and that's the only context where the gap shows.

Docs-only; no source touched.

Generated with [Claude Code](https://claude.com/claude-code)
