### PR TITLE
chore(release): main becomes 2.2.0-CURRENT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4356,7 +4356,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.1.0"
+version = "2.2.0-CURRENT"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.1.0"
+version = "2.2.0-CURRENT"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
v2.1.0 is tagged and published, so `main` reopens as the CURRENT stream for the next minor.

Until this lands, `main` claims to **be** the released version — `--version` bakes the git SHA so build identity is still unambiguous, but the semver string would read `2.1.0` for every commit after the release. That drift is what the `-CURRENT` suffix exists to prevent (`CONTRIBUTING.md` → Versioning).

It also makes the version line collision-free again: while `main` carries `N.M.0-CURRENT` no PR touches that line, so concurrent PRs can't conflict on it, and the `spyc-semver` merge driver goes back to sitting dormant until the next release branch.

`Cargo.toml` + `Cargo.lock` only, via `cargo update -p spyc`:

```
-version = "2.1.0"
+version = "2.2.0-CURRENT"
```

No changelog change — the `[2.2.0]` section is git-cliff's to generate when that minor ships.

Follows the convention set by #186 (`chore(release): main becomes 2.1.0-CURRENT`).

Generated with [Claude Code](https://claude.com/claude-code)
