### PR TITLE
chore(release): v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to spyc. Entries from v1.57.0 onward are generated from the conventional-commit history by [git-cliff](https://git-cliff.org) (config in `cliff.toml`); regenerate the pending section with `make changelog` and cut a release with `make release-prep` then `make release-tag` (see `docs/RELEASE_ENGINEERING.md`). Entries at v1.56.0 and earlier are the original hand-written log, kept verbatim.
 
+## [2.1.1] - 2026-08-18
+
+### Bug Fixes
+- **package**: Ship docs/ABOUT.md, which the binary compiles in (#426)
+
+### Miscellaneous
+- **ci**: Bump taiki-e/install-action from 2.85.10 to 2.85.13 in the github-actions group (#419)
+
 ## [2.1.0] - 2026-08-18
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4356,7 +4356,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.2.0-CURRENT"
+version = "2.1.1"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.2.0-CURRENT"
+version = "2.1.1"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Step 1 of 2 of the v2.1.1 patch release. Produced entirely by `make release-prep VERSION=2.1.1` — no hand edits.

**Why this release exists:** `cargo publish` failed during v2.1.0. The GitHub release published cleanly (all three tarballs, cosign-signed) but crates.io never received 2.1.0 — `Cargo.toml` excluded `/docs` while `src/app/about.rs` `include_str!`s `docs/ABOUT.md`, so the packaged tarball couldn't compile. Fixed in #426, which also adds `every_bundled_file_survives_cargo_package` so the next bundled file can't repeat it.

| Change | |
|---|---|
| `Cargo.toml` | `2.2.0-CURRENT` → `2.1.1` |
| `Cargo.lock` | `cargo update -p spyc`, version line only |
| `CHANGELOG.md` | the `[2.1.1]` section — one entry |

## What ships

```
### Bug Fixes
- **package**: Ship docs/ABOUT.md, which the binary compiles in (#426)
```

One fix, which is what a patch release should be. No source behaviour changes: the binaries built from this tag are identical in function to v2.1.0's.

## Also on main since v2.1.0

**#419** — `taiki-e/install-action` 2.85.10 → 2.85.13, which `release.yml` uses to install `cargo-zigbuild` and `git-cliff`. It was deliberately held out of v2.1.0 because no PR-triggered workflow exercises that file, so a release would have been its first execution. Before merging it, `fuzz.yml` was dispatched on dependabot's own branch (`workflow_dispatch` runs a workflow as it exists on the given ref) with `seconds=60` — all eight fuzz targets passed with the new action version, so it is no longer unexercised.

That validates the **action**, not `cargo-zigbuild` / `git-cliff` specifically — those two installs still first run during this release.

Generated with [Claude Code](https://claude.com/claude-code)
