### PR TITLE
chore(release): main becomes 2.2.0-CURRENT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4356,7 +4356,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "spyc"
-version = "2.1.1"
+version = "2.2.0-CURRENT"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spyc"
-version = "2.1.1"
+version = "2.2.0-CURRENT"
 edition = "2024"
 description = "A Rust TUI file commander where the AI agent in the side pane can query the file commander itself"
 license = "BSD-3-Clause"


### PR DESCRIPTION
v2.1.1 is tagged and published — and unlike v2.1.0 it **reached crates.io**, which is the whole reason the patch existed. `main` reopens as the CURRENT stream for the next minor.

Same reasoning as #425 after v2.1.0: until this lands, `main` claims to *be* the released version. `--version` bakes the git SHA so build identity is unambiguous either way, but the semver string would read `2.1.1` for every commit after the release. It also re-freezes the version line, so no PR touches it and concurrent PRs can't collide on it.

`Cargo.toml` + `Cargo.lock` only, via `cargo update -p spyc`:

```
-version = "2.1.1"
+version = "2.2.0-CURRENT"
```

## v2.1.1 outcome, for the record

```
success  Build macOS universal
success  Build Linux musl (x86_64 + aarch64)
success  Sign + publish release
success  Publish to crates.io      ← the job that failed on v2.1.0
```

`install-action@v2.85.13` (#419) also had its first release-path execution here, installing `cargo-zigbuild` and `git-cliff` — the two installs the fuzz dispatch could not cover — and both worked.

Generated with [Claude Code](https://claude.com/claude-code)
