### PR TITLE
fix(graveyard): make the size warning actionable, the purge work, and the status-line copy stable

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -734,6 +734,12 @@ end).
   take just a branch name, an agent session id, a custom tab name or an error
   message without the rest of the line. A click that doesn't move copies nothing,
   and copying part of a flash leaves the message intact.
+  **Double-click a chrome row to take the whole line** — a flashed error with its
+  whole `source()` chain, the status line, a divider. That's the copy you want
+  when the line is one thing rather than a list of them, and it doesn't ask you to
+  drag a full terminal width accurately. Copying the same row twice gives the same
+  text both times: the ` (copied)` confirmation is spyc's own marker and never
+  reaches the clipboard.
   **Drag in a pager to select text; release copies it** and the pager title
   reports the line count. Works the same full-screen or popped-up, and copies the
   content only — never the line-number gutter, the whitespace/line-break markers,

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -941,7 +941,8 @@ flag, etc.), mtime, and best-effort UID/GID; restore preserves all
 of them. xattrs / ACLs / macOS resource forks are NOT preserved
 (out of scope for v1).
 
-- **`gy`** / **`:graveyard`** — open the graveyard view (newest entries first)
+- **`:graveyard`** — open the graveyard view (newest entries first). No default
+  key since the keymap slim; bind one with `map <KEY> command graveyard`
 - **`:undo`** — restore the most-recent entry to its original path
 - Inside the graveyard view:
   - **`p`** — restore the cursor entry to the current dir (cwd)
@@ -951,7 +952,7 @@ of them. xattrs / ACLs / macOS resource forks are NOT preserved
     (out of spyc, into Finder / Files / etc.)
   - **`Z`** — purge ALL entries to the system trash (single-key
     confirm)
-  - **`Esc`** / **`gy`** — close
+  - **`Esc`** — close
 
 When the graveyard exceeds 500 MB at startup, the **oldest entries
 cascade to the system trash** (FIFO) until the total falls below

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -323,6 +323,7 @@ focus.
 | Left click | Focus that region — and click *through* to a mouse-aware child |
 | Left click on a pane tab | Switch to that tab |
 | Left drag | Select text: pager content, a non-mouse pane's grid, any chrome row, or file-list rows. Release copies |
+| Double click on a chrome row | Select and copy that whole row — the status line, the divider, a flashed error |
 | `Ctrl` + left drag (list) | Copy absolute paths instead of names |
 | Middle click | Paste the clipboard |
 | Right click | Open the leader menu |

--- a/src/app/effect.rs
+++ b/src/app/effect.rs
@@ -419,9 +419,30 @@ pub enum ClipMsg {
     ListNames { count: usize, paths: bool },
 }
 
+/// The suffix [`ClipMsg::StatusLine`] appends to its echo.
+///
+/// A const shared with [`strip_copy_marker`] so the two cannot drift: the echo is
+/// written onto the very row a later copy reads back, and a stripper that guessed
+/// at the spelling would let the marker accumulate.
+pub const COPY_MARKER: &str = " (copied)";
+
+/// Drop a trailing [`COPY_MARKER`] from a chrome row's text.
+///
+/// spyc's own annotation, never content: copying a row that already carries one
+/// must not put it on the clipboard, and must not nest a second marker into the
+/// next echo.
+pub fn strip_copy_marker(text: &str) -> &str {
+    text.strip_suffix(COPY_MARKER).unwrap_or(text)
+}
+
 impl ClipMsg {
     /// Render the success flash for a completed copy of `text`.
-    fn success(&self, text: &str) -> String {
+    ///
+    /// Reachable across the app layer so a test of the surface that PRODUCES the
+    /// copy can round-trip through the real formatter — the echo lands back on the
+    /// row a second copy reads, so a hand-written stand-in would test a string the
+    /// user never sees.
+    pub(in crate::app) fn success(&self, text: &str) -> String {
         match self {
             Self::PaneLines => format!("yanked {} lines from pane", text.lines().count()),
             Self::Scrollback => format!("yanked {} lines (full scrollback)", text.lines().count()),
@@ -434,14 +455,19 @@ impl ClipMsg {
             Self::StatusLine { whole_row } => {
                 // Show the whole row when the echo would otherwise eat it; the
                 // drag highlight still marks which part went to the clipboard.
-                let shown = whole_row.as_deref().unwrap_or(text);
-                let preview: String = shown.chars().take(60).collect();
-                let ellipsis = if shown.chars().count() > 60 {
-                    "…"
-                } else {
-                    ""
+                //
+                // Uncapped in that case, unlike the fragment below. The cap exists
+                // so a long selection doesn't bury the marker, but a whole row is
+                // already one screen row wide and the renderer clips it — capping
+                // it at 60 chars REWROTE the message shorter each time it was
+                // copied, and once the marker itself fell past the cut the row
+                // read `…to clear (c… (copied)`.
+                let Some(row) = whole_row else {
+                    let preview: String = text.chars().take(60).collect();
+                    let ellipsis = if text.chars().count() > 60 { "…" } else { "" };
+                    return format!("{preview}{ellipsis}{COPY_MARKER}");
                 };
-                format!("{preview}{ellipsis} (copied)")
+                format!("{row}{COPY_MARKER}")
             }
             Self::ListNames { count, paths } => {
                 let unit = if *paths { "path" } else { "name" };

--- a/src/app/graveyard_ops.rs
+++ b/src/app/graveyard_ops.rs
@@ -166,9 +166,9 @@ impl App {
                     }
                     self.state.refresh_listing();
                 }
-                Err(e) => self
-                    .state
-                    .flash_error(format!("undo: {e:#} — try `gy` then `p` to restore to cwd")),
+                Err(e) => self.state.flash_error(format!(
+                    "undo: {e:#} — try `:graveyard` then `p` to restore to cwd"
+                )),
             },
             GraveyardOutcome::Purged { trashed, errors } => {
                 if errors > 0 {

--- a/src/app/key_dispatch/confirms.rs
+++ b/src/app/key_dispatch/confirms.rs
@@ -87,7 +87,7 @@ impl App {
     /// runs here; the un-tar runs OFF-thread via `Effect::Graveyard` and
     /// reports via `apply_graveyard_outcomes` (which surfaces a tar
     /// `set_overwrite(false)` error if the original path is now occupied —
-    /// the user can then `gy` + `p` to restore-to-cwd instead).
+    /// the user can then `:graveyard` + `p` to restore-to-cwd instead).
     pub fn undo_last_remove(&mut self) -> Vec<Effect> {
         let g = crate::state::graveyard::Graveyard::load();
         let Some(latest) = g.entries.into_iter().next() else {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -210,7 +210,7 @@ pub enum View {
     /// Graveyard view: list of soft-deleted entries (most recent
     /// first). Bindings inside: `p` restore-to-cwd, `P`
     /// restore-to-original, `dd`/`x` purge entry to system trash,
-    /// `Z` purge all (with confirm), `Esc`/`gy` close.
+    /// `Z` purge all (with confirm), `Esc` closes.
     Graveyard,
 }
 

--- a/src/app/mouse/mod.rs
+++ b/src/app/mouse/mod.rs
@@ -129,17 +129,48 @@ pub struct ChromeSelection {
     pub y: u16,
     pub anchor_col: u16,
     pub focus_col: u16,
+    /// Set by a double-click: the whole row is selected, and the pointer no
+    /// longer moves either end. Carried on the selection rather than resolved
+    /// into `anchor_col`/`focus_col` at press time so [`Self::range`] stays the
+    /// one authority on which columns are lit, and the paint cannot disagree
+    /// with what the release copies.
+    pub whole_row: bool,
 }
 
 impl ChromeSelection {
     /// Inclusive `(low, high)` columns, relative to the row's own left edge.
     pub const fn range(self) -> (u16, u16) {
+        if self.whole_row {
+            return (0, u16::MAX);
+        }
         if self.anchor_col <= self.focus_col {
             (self.anchor_col, self.focus_col)
         } else {
             (self.focus_col, self.anchor_col)
         }
     }
+}
+
+/// How close together two presses on one chrome row have to be to read as a
+/// double-click. The interval every desktop toolkit settles near; spyc cannot
+/// read the host's own setting through a pty, so it picks the same number.
+pub const DOUBLE_CLICK: std::time::Duration = std::time::Duration::from_millis(400);
+
+/// Is a press on chrome row `y` at `now` the second half of a double-click?
+///
+/// `prev` is the previous chrome press — its row and when it happened. Only the
+/// ROW has to match, not the column: a double-click drifts a cell or two, and the
+/// gesture selects the whole row anyway, so requiring the same column would fail
+/// exactly the presses it is meant to catch.
+///
+/// Pure, and takes `now` rather than reading the clock, so the boundary is
+/// testable — see this module's tests.
+pub fn is_double_click(
+    prev: Option<(u16, std::time::Instant)>,
+    y: u16,
+    now: std::time::Instant,
+) -> bool {
+    prev.is_some_and(|(prev_y, at)| prev_y == y && now.duration_since(at) <= DOUBLE_CLICK)
 }
 
 /// A sustained same-direction wheel-scroll gesture over an agent's own view. See

--- a/src/app/mouse/selection.rs
+++ b/src/app/mouse/selection.rs
@@ -134,14 +134,24 @@ impl super::super::App {
     }
 
     /// Anchor a chrome-line selection where the pointer pressed.
+    ///
+    /// A press that lands on the row a previous press just left, inside
+    /// [`DOUBLE_CLICK`](super::DOUBLE_CLICK), is a double-click: it selects the
+    /// whole row instead of anchoring a drag. Status lines are one atomic string —
+    /// an error with its `source()` chain, a path, a git summary — and picking the
+    /// whole thing up is the common case that a drag makes fiddly.
     pub(super) fn begin_chrome_selection(&mut self, ev: MouseEvent) -> Vec<Effect> {
         let Some((y, col)) = self.chrome_col_at(ev) else {
             return Vec::new();
         };
+        let now = std::time::Instant::now();
+        let whole_row = super::is_double_click(self.view.last_chrome_click, y, now);
+        self.view.last_chrome_click = Some((y, now));
         self.view.chrome_selection = Some(ChromeSelection {
             y,
             anchor_col: col,
             focus_col: col,
+            whole_row,
         });
         self.view.mouse_selection = Some(MouseDragTarget::Chrome);
         Vec::new()
@@ -179,7 +189,7 @@ impl super::super::App {
         let Some(sel) = self.view.chrome_selection else {
             return Vec::new();
         };
-        if sel.anchor_col == sel.focus_col {
+        if sel.anchor_col == sel.focus_col && !sel.whole_row {
             self.view.chrome_selection = None;
             return Vec::new();
         }
@@ -757,6 +767,7 @@ mod tests {
                 y: 0,
                 anchor_col: 2,
                 focus_col: 8,
+                whole_row: false,
             });
 
             let mut pager = PagerView::new_plain("p", vec!["a".into(), "b".into()]);
@@ -981,6 +992,106 @@ mod tests {
             );
             assert!(!second.contains('…'), "nothing is truncated: {second}");
         });
+    }
+
+    /// Double-click on a chrome row selects and copies the whole row. Status lines
+    /// are one atomic string — an error with its `source()` chain, a path, a git
+    /// summary — and dragging column-perfectly across one is fiddly.
+    #[test]
+    fn a_double_click_copies_the_whole_chrome_row() {
+        use crossterm::event::KeyModifiers;
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        crate::state::with_state_root(&tmp, || {
+            let mut app = App::test_app(tmp.clone());
+            app.view
+                .chrome_rows
+                .borrow_mut()
+                .push(crate::app::mouse::ChromeRow {
+                    y: 0,
+                    x: 0,
+                    width: 80,
+                    line: ratatui::text::Line::from(vec![
+                        ratatui::text::Span::raw("spyc"),
+                        ratatui::text::Span::raw("|"),
+                        ratatui::text::Span::raw("main*"),
+                    ]),
+                });
+            let at = |kind, col| MouseEvent {
+                kind,
+                column: col,
+                row: 0,
+                modifiers: KeyModifiers::NONE,
+            };
+            // First click: a plain press-and-release on one column. It selects
+            // nothing (a click, not a drag) and copies nothing.
+            app.begin_chrome_selection(at(MouseEventKind::Down(MouseButton::Left), 6));
+            assert!(
+                app.finish_chrome_selection(at(MouseEventKind::Up(MouseButton::Left), 6))
+                    .is_empty(),
+                "a single click still copies nothing"
+            );
+
+            // Second click, same row, immediately after — and no motion between
+            // press and release, which is what a real double-click looks like.
+            // That leaves anchor == focus, the shape the release otherwise
+            // discards as an empty click.
+            app.begin_chrome_selection(at(MouseEventKind::Down(MouseButton::Left), 6));
+            assert!(
+                app.view.chrome_selection.is_some_and(|s| s.whole_row),
+                "the second press claims the row"
+            );
+            let effects = app.finish_chrome_selection(at(MouseEventKind::Up(MouseButton::Left), 6));
+
+            let [Effect::CopyToClipboard { text, .. }] = effects.as_slice() else {
+                panic!("expected one clipboard copy, got {effects:?}");
+            };
+            assert_eq!(text, "spyc|main*", "the whole row, not the clicked column");
+            assert_eq!(
+                app.view.chrome_selection.map(super::ChromeSelection::range),
+                Some((0, u16::MAX)),
+                "the highlight lights the whole row, matching what was copied"
+            );
+
+            // A cell of pointer drift between the second press and its release is
+            // normal and must not narrow the row back down to those columns.
+            app.begin_chrome_selection(at(MouseEventKind::Down(MouseButton::Left), 6));
+            app.extend_chrome_selection(at(MouseEventKind::Drag(MouseButton::Left), 7));
+            let effects = app.finish_chrome_selection(at(MouseEventKind::Up(MouseButton::Left), 7));
+            let [Effect::CopyToClipboard { text, .. }] = effects.as_slice() else {
+                panic!("expected one clipboard copy, got {effects:?}");
+            };
+            assert_eq!(text, "spyc|main*", "drift leaves the whole row selected");
+        });
+    }
+
+    /// Two presses far apart in time are two clicks, not a double-click — the
+    /// second must anchor a fresh drag rather than grab the row.
+    #[test]
+    fn presses_outside_the_double_click_window_stay_separate_clicks() {
+        use super::super::{DOUBLE_CLICK, is_double_click};
+        use std::time::Instant;
+
+        let t0 = Instant::now();
+        assert!(
+            !is_double_click(None, 3, t0),
+            "nothing precedes the first press"
+        );
+        assert!(
+            is_double_click(Some((3, t0)), 3, t0 + DOUBLE_CLICK),
+            "the boundary itself counts, so a slow-but-deliberate pair still works"
+        );
+        assert!(
+            !is_double_click(
+                Some((3, t0)),
+                3,
+                t0 + DOUBLE_CLICK + std::time::Duration::from_millis(1)
+            ),
+            "one tick past the window is two clicks"
+        );
+        assert!(
+            !is_double_click(Some((3, t0)), 4, t0),
+            "a different row is a different surface, however fast"
+        );
     }
 
     /// The same drag on the STATUS BAR carries no whole-row echo: that row is not

--- a/src/app/mouse/selection.rs
+++ b/src/app/mouse/selection.rs
@@ -202,7 +202,12 @@ impl super::super::App {
                 .then(|| crate::ui::line_select::text_between_columns(&row.line, 0, usize::MAX));
             (selected, whole_row)
         };
-        let text = text.trim().to_string();
+        // A row copied from twice already carries the marker the first copy
+        // echoed onto it. It is spyc's annotation, not the line's content — it
+        // belongs on neither the clipboard nor the front of a second marker.
+        let text = crate::app::effect::strip_copy_marker(text.trim()).to_string();
+        let whole_row =
+            whole_row.map(|row| crate::app::effect::strip_copy_marker(row.trim_end()).to_string());
         if text.is_empty() {
             return Vec::new();
         }
@@ -895,6 +900,86 @@ mod tests {
                 Some(whole),
                 "the echo carries the whole message, so copying from it doesn't erase it"
             );
+        });
+    }
+
+    /// Reported: copying the flash row a second time produced
+    /// `…then confirm to clear (c… (copied)` — the message rewritten shorter, with
+    /// the first copy's marker chopped mid-word and a second one stacked behind it.
+    ///
+    /// Two compounding causes, both pinned here: the echo capped the whole row at
+    /// 60 chars (so it re-truncated the very line it was preserving), and nothing
+    /// stripped the marker the previous copy had written onto that row.
+    ///
+    /// Round-trips through the real `success` formatter, because the bug only
+    /// exists across the two copies — each one alone looks correct.
+    #[test]
+    fn copying_a_flash_twice_neither_nests_the_marker_nor_truncates_it() {
+        use crossterm::event::KeyModifiers;
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let tmp = tempfile::tempdir().expect("tempdir").keep();
+        crate::state::with_state_root(&tmp, || {
+            let mut app = App::test_app(tmp.clone());
+            // The reported message, longer than the 60-char preview cap so a
+            // capped echo would visibly eat it.
+            let whole = "graveyard is using 100 MB of 500 MB — oldest entries auto-move to the system trash";
+            assert!(whole.chars().count() > 60, "or the cap is never exercised");
+            app.state.flash_info(whole);
+            app.view.term_size = (120, 24);
+
+            let mut terminal = Terminal::new(TestBackend::new(120, 24)).expect("backend");
+            let copy_once = |app: &mut App, terminal: &mut Terminal<TestBackend>| -> String {
+                terminal.draw(|f| app.render(f)).expect("draw");
+                let flash_y = {
+                    let rows = app.view.chrome_rows.borrow();
+                    rows.iter()
+                        .find(|r| {
+                            crate::ui::line_select::text_between_columns(&r.line, 0, usize::MAX)
+                                .contains("graveyard is using")
+                        })
+                        .map(|r| r.y)
+                        .expect("the flash row was recorded")
+                };
+                let at = |kind, col| MouseEvent {
+                    kind,
+                    column: col,
+                    row: flash_y,
+                    modifiers: KeyModifiers::NONE,
+                };
+                app.begin_chrome_selection(at(MouseEventKind::Down(MouseButton::Left), 0));
+                app.extend_chrome_selection(at(MouseEventKind::Drag(MouseButton::Left), 18));
+                let effects =
+                    app.finish_chrome_selection(at(MouseEventKind::Up(MouseButton::Left), 18));
+                let [Effect::CopyToClipboard { text, ok }] = effects.as_slice() else {
+                    panic!("expected one clipboard copy, got {effects:?}");
+                };
+                // What `run_effects` does on a successful write — the echo becomes
+                // the flash, which is the row the NEXT copy reads back.
+                let echo = ok.success(text);
+                app.state.flash_info(echo.clone());
+                echo
+            };
+
+            let first = copy_once(&mut app, &mut terminal);
+            assert_eq!(
+                first,
+                format!("{whole}{}", crate::app::effect::COPY_MARKER),
+                "the whole row is echoed intact — capping it here is what shortened \
+                 the message every time it was copied"
+            );
+
+            let second = copy_once(&mut app, &mut terminal);
+            assert_eq!(
+                second, first,
+                "copying the echo again is idempotent: one marker, same message"
+            );
+            assert_eq!(
+                second.matches(crate::app::effect::COPY_MARKER).count(),
+                1,
+                "the marker must not stack"
+            );
+            assert!(!second.contains('…'), "nothing is truncated: {second}");
         });
     }
 

--- a/src/app/view_state.rs
+++ b/src/app/view_state.rs
@@ -362,6 +362,10 @@ pub struct ViewState {
     /// A charwise selection over one of the single-line chrome surfaces (the status
     /// bar, the pane divider/tab line) — the row and an unordered column pair.
     pub(super) chrome_selection: Option<mouse::ChromeSelection>,
+    /// The last press on a chrome row: which row, and when. The whole state a
+    /// double-click needs — see [`mouse::is_double_click`]. Not reset on release,
+    /// because the second press of the pair arrives after one.
+    pub(super) last_chrome_click: Option<(u16, std::time::Instant)>,
     /// What each chrome row actually rendered this frame, for a mouse copy.
     ///
     /// `RefCell` because the draw pass is `&self` and this is the renderer recording
@@ -492,6 +496,7 @@ impl ViewState {
             pane_selection: None,
             chrome_selection: None,
             chrome_rows: std::cell::RefCell::new(Vec::new()),
+            last_chrome_click: None,
             pane_scroll_streak: None,
             pane_view_sent: None,
             transcript_show_tool_calls: true,

--- a/src/app/worktree_clean.rs
+++ b/src/app/worktree_clean.rs
@@ -4,7 +4,7 @@
 //! Strict `worktree::remove` refuses a dirty worktree (like `git worktree
 //! remove`). Safe-remove instead **preserves** the work and tears the tree
 //! down: it archives the worktree's untracked *and* uncommitted-tracked file
-//! contents into the graveyard (recoverable via `gy` / `:undo`), force-removes
+//! contents into the graveyard (recoverable via `:graveyard` / `:undo`), force-removes
 //! the worktree, and then deletes its branch **iff that branch is merged** into
 //! the repo's integration base (`delete_branch: auto`) — an unmerged branch's
 //! ref is kept, since the ref itself is the commit backup (owner decisions,

--- a/src/config/default.spycrc.toml
+++ b/src/config/default.spycrc.toml
@@ -181,7 +181,7 @@
 # `confirm` (default true) shows a `y/N` prompt with a warning-color
 # highlight on the targeted rows before anything happens. Set to
 # false for "yolo mode" — deletions fire immediately, no prompt, no
-# highlight. The graveyard (`gy`) is still the destination either
+# highlight. The graveyard (`:graveyard`) is still the destination either
 # way, so accidental yolo deletions are still recoverable.
 [delete]
 # confirm = true

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -449,7 +449,7 @@ pub struct DeleteConfig {
     /// prompt before moving anything to the graveyard. Setting to
     /// false enables "yolo mode" — deletions fire immediately on
     /// `dd` / `R`, no prompt, no warning highlight. The graveyard
-    /// is still the destination either way, so `gy` can recover.
+    /// is still the destination either way, so `:graveyard` can recover.
     pub confirm: bool,
 }
 

--- a/src/state/graveyard.rs
+++ b/src/state/graveyard.rs
@@ -26,7 +26,7 @@
 //! ## Cascade
 //!
 //! Cap defaults to 500 MB. On `App::new`, while `total > cap`, the oldest entry
-//! is unpacked and its paths handed to `trash::delete`, then the spyc artifacts
+//! is unpacked and its paths handed to the system trash, then the spyc artifacts
 //! removed (flash: "N items moved to system trash"). Legacy pre-v1.41.0 entries
 //! the new reader can't unpack are cascaded the same way.
 //!
@@ -243,7 +243,7 @@ impl Graveyard {
 
     /// Push `entry` into the system trash by unpacking the tarball
     /// into a temp dir and handing each top-level path to
-    /// `trash::delete`. This is what the cascade calls per entry,
+    /// [`trash_all`]. This is what the cascade calls per entry,
     /// and what the viewer's `dd`/`x` purge also calls.
     ///
     /// On success, the spyc artifacts are removed. On failure, the
@@ -257,7 +257,7 @@ impl Graveyard {
         for entry_dir in std::fs::read_dir(temp.path())?.flatten() {
             to_trash.push(entry_dir.path());
         }
-        if let Err(e) = trash::delete_all(&to_trash) {
+        if let Err(e) = trash_all(&to_trash) {
             return Err(std::io::Error::other(format!("trash: {e}")));
         }
         Self::delete_entry(entry);
@@ -307,6 +307,56 @@ impl Graveyard {
         }
         (trashed, errors)
     }
+}
+
+/// Hand `paths` to the system trash.
+///
+/// On macOS the `trash` crate defaults to driving Finder over AppleScript, which
+/// requires the host terminal to hold Automation permission for Finder. A TUI has
+/// no way to raise that grant dialog, so a denial reaches the user as a bare
+/// `-1743` and the graveyard becomes impossible to empty. `NSFileManager`'s
+/// `trashItemAtURL` needs no such permission, so a Finder failure retries there.
+///
+/// Finder stays the FIRST attempt because it is the only method that records the
+/// "Put Back" origin, and the retry is sticky for the rest of the process: a
+/// cascade evicting hundreds of entries must not pay an `osascript` round-trip
+/// each time to relearn the same denial.
+#[cfg(target_os = "macos")]
+fn trash_all(paths: &[PathBuf]) -> Result<(), trash::Error> {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use trash::macos::{DeleteMethod, TrashContextExtMacos};
+
+    static USE_FILE_MANAGER: AtomicBool = AtomicBool::new(false);
+
+    fn with_method(method: DeleteMethod, paths: &[PathBuf]) -> Result<(), trash::Error> {
+        let mut ctx = trash::TrashContext::default();
+        ctx.set_delete_method(method);
+        ctx.delete_all(paths)
+    }
+
+    if USE_FILE_MANAGER.load(Ordering::Relaxed) {
+        return with_method(DeleteMethod::NsFileManager, paths);
+    }
+    let Err(finder_err) = with_method(DeleteMethod::Finder, paths) else {
+        return Ok(());
+    };
+    // `delete_using_finder` builds ONE osascript for the whole batch, so a
+    // failure trashed nothing and every path is still there to retry.
+    match with_method(DeleteMethod::NsFileManager, paths) {
+        Ok(()) => {
+            USE_FILE_MANAGER.store(true, Ordering::Relaxed);
+            Ok(())
+        }
+        // Report Finder's error, not the fallback's: the first one names the
+        // cause, the second is a consequence of retrying after it.
+        Err(_) => Err(finder_err),
+    }
+}
+
+/// Hand `paths` to the system trash. Everywhere but macOS there is one method.
+#[cfg(not(target_os = "macos"))]
+fn trash_all(paths: &[PathBuf]) -> Result<(), trash::Error> {
+    trash::delete_all(paths)
 }
 
 fn graveyard_dir() -> Option<PathBuf> {
@@ -559,6 +609,33 @@ mod tests {
             let g = Graveyard::load();
             assert!(g.entries.is_empty());
         });
+    }
+
+    // ── the system-trash seam ─────────────────────────────────────
+
+    /// Live check that [`trash_all`] can actually empty the graveyard on this
+    /// machine. Ignored by default: it puts a real file in the real Trash, which
+    /// no CI run and no `make check` should do as a side effect.
+    ///
+    /// Run it after touching the trash seam, on a mac where Automation access to
+    /// Finder is DENIED — that denial is the whole reason the fallback exists, and
+    /// it is invisible to a machine that has granted it:
+    ///
+    /// ```sh
+    /// cargo test --lib trash_all_reaches_the_system_trash -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "moves a real file to the real system Trash"]
+    fn trash_all_reaches_the_system_trash() {
+        let dir = tempfile::tempdir().unwrap();
+        let victim = dir.path().join("spyc-trash-seam-check.txt");
+        std::fs::write(&victim, b"spyc trash seam check").unwrap();
+
+        super::trash_all(std::slice::from_ref(&victim)).expect("the file reached the trash");
+        assert!(
+            !victim.exists(),
+            "trash_all returned Ok but left the file behind"
+        );
     }
 
     // ── cascade cost ──────────────────────────────────────────────

--- a/src/state/health.rs
+++ b/src/state/health.rs
@@ -6,6 +6,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::state::graveyard::GRAVEYARD_CAP_BYTES;
+
 /// Result of a startup health scan.
 pub struct HealthReport {
     /// Human-readable warnings to flash to the user.
@@ -198,20 +200,37 @@ fn check_sessions(dir: &Path, warnings: &mut Vec<String>) {
     }
 }
 
-/// Warn if the graveyard is consuming significant disk space.
+/// Warn if the graveyard is approaching the cap its own FIFO cascade enforces.
 ///
 /// Takes the total rather than deriving it, because [`check_paired_dir`] has
 /// already walked the directory and stat'd every entry — this used to be a
 /// second full walk for the same number.
+///
+/// The threshold is derived from [`GRAVEYARD_CAP_BYTES`] rather than set
+/// independently. A fixed 100 MB against a 500 MB cap told the user to act on a
+/// state spyc considers entirely healthy — the cascade evicts nothing until the
+/// cap — so the warning read as a chore that never went away no matter what was
+/// cleared.
 fn warn_on_graveyard_size(total_bytes: u64, warnings: &mut Vec<String>) {
-    // Warn above 100 MB.
-    if total_bytes > 100 * 1024 * 1024 {
-        let mb = total_bytes / (1024 * 1024);
-        warnings.push(format!(
-            "graveyard is using {mb} MB — run `z` then confirm to clear"
-        ));
+    if total_bytes <= WARN_ABOVE_BYTES {
+        return;
     }
+    let mb = total_bytes / (1024 * 1024);
+    let cap_mb = GRAVEYARD_CAP_BYTES / (1024 * 1024);
+    // Names the way in that exists. This used to say "run `z`" — which is bound,
+    // but to `EmptyInventory`: following the advice moves the inventory INTO the
+    // graveyard, growing the thing the warning is about. `Z` (purge all) is the
+    // key meant, and it only exists once you are inside the view.
+    warnings.push(format!(
+        "graveyard is using {mb} MB of {cap_mb} MB — oldest entries auto-move to \
+         the system trash above the cap; `:graveyard` then `Z` clears it now"
+    ));
 }
+
+/// Warn once the graveyard passes 80% of the cap: close enough that the next few
+/// deletions start silently evicting the oldest, which is worth a heads-up, and
+/// far enough that an ordinary working graveyard never trips it.
+const WARN_ABOVE_BYTES: u64 = GRAVEYARD_CAP_BYTES / 5 * 4;
 
 /// Validate the frecency database (JSON).
 fn check_frecency(path: &Path, warnings: &mut Vec<String>) {
@@ -233,6 +252,49 @@ pub fn state_dir() -> Option<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The warning must name a way in that exists. It said "run `z`" long after
+    /// the keymap slimming demoted the graveyard to a `:` command, so following it
+    /// landed the user in `^a z`'s pane zoom with no idea what they were looking
+    /// at — and `Z`, the purge-all, is only reachable once inside the view.
+    #[test]
+    fn the_graveyard_warning_names_the_command_that_opens_it() {
+        let mut warnings = Vec::new();
+        warn_on_graveyard_size(GRAVEYARD_CAP_BYTES, &mut warnings);
+        let [msg] = warnings.as_slice() else {
+            panic!("expected one warning, got {warnings:?}");
+        };
+        assert!(msg.contains(":graveyard"), "names the view: {msg}");
+        assert!(
+            msg.contains("`Z`"),
+            "names the purge-all key you press once inside: {msg}"
+        );
+    }
+
+    /// Derived from the cap, not set independently. A fixed 100 MB against a
+    /// 500 MB cascade cap nagged about a graveyard spyc considers entirely
+    /// healthy — nothing is evicted until the cap, so the warning asked for work
+    /// that changed nothing and came back every launch.
+    #[test]
+    fn the_graveyard_warning_stays_quiet_well_under_the_cap() {
+        // The reported graveyard: a hair over the old fixed 100 MB threshold, and
+        // a fifth of the cap. Sized past that old number on purpose — at exactly
+        // 100 MB the old code was silent too, so this would prove nothing.
+        let mut warnings = Vec::new();
+        warn_on_graveyard_size(101 * 1024 * 1024, &mut warnings);
+        assert!(
+            warnings.is_empty(),
+            "a fifth of the cap warrants nothing: {warnings:?}"
+        );
+
+        // It does still fire as the cap comes into range, where the next few
+        // deletions start silently evicting the oldest entries.
+        let mut warnings = Vec::new();
+        warn_on_graveyard_size(WARN_ABOVE_BYTES + 1, &mut warnings);
+        assert_eq!(warnings.len(), 1, "got: {warnings:?}");
+        // The heads-up has to land before the cascade, not after.
+        const { assert!(WARN_ABOVE_BYTES < GRAVEYARD_CAP_BYTES) };
+    }
 
     #[test]
     fn empty_state_dir_is_healthy() {
@@ -327,10 +389,13 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let grave = tmp.path().join("graveyard");
         std::fs::create_dir_all(&grave).unwrap();
-        // One valid pair, payload just over the 100 MB warn threshold.
+        // One valid pair, payload just over the warn threshold. Sized from the
+        // constant, not a literal, so moving the threshold can't leave this test
+        // asserting against a number it no longer means. Sparse — `set_len`
+        // allocates nothing.
         std::fs::write(grave.join("big.json"), br#"{"id":"big"}"#).unwrap();
         let f = std::fs::File::create(grave.join("big.tar.zst")).unwrap();
-        f.set_len(101 * 1024 * 1024).unwrap();
+        f.set_len(WARN_ABOVE_BYTES + 1).unwrap();
         drop(f);
 
         let report = check(tmp.path());


### PR DESCRIPTION
One dogfooding report, four separate defects.

## 1. The size warning named a key that grows the graveyard

`health.rs` flashed `graveyard is using 100 MB — run \`z\` then confirm to clear`.
`z` **is** bound — to `EmptyInventory`, which moves the inventory *into* the
graveyard. Following the advice grows the thing the warning is about. The view it
meant lost its default key in the keymap slim: it is `:graveyard`, and `Z` (purge
all) only exists once you are inside it.

The threshold was independently wrong. A fixed 100 MB sat against a 500 MB cascade
cap, so the warning fired about a graveyard spyc considers entirely healthy —
nothing is evicted until the cap, so it asked for work that changed nothing and
came back every launch. Now derived from `GRAVEYARD_CAP_BYTES` at 80%, and the
message says what happens automatically:

```
graveyard is using 420 MB of 500 MB — oldest entries auto-move to the system
trash above the cap; `:graveyard` then `Z` clears it now
```

The same retired `gy` key was still in the `:undo` failure flash and five doc
comments — cleaned up separately.

## 2. Purge to trash failed on macOS, and so did the automatic cascade

`dd` in the viewer reported:

```
purge failed: trash: Os { code: 1, description: "The AppleScript exited with
error. stderr: execution error: Not authorized to send Apple events to Finder.
(-1743)" }
```

The `trash` crate drives Finder over AppleScript by default, which needs the host
terminal to hold Automation permission for Finder — a grant a TUI has no way to
raise a dialog for. The startup FIFO cascade calls the same seam, so on such a
machine it was failing silently too.

Probed on a mac where the grant is denied:

```
PROBE Finder:        ERR ... Not authorized to send Apple events to Finder. (-1743)
PROBE NsFileManager: OK (gone=true)
```

Finder stays the first attempt — the only method that records the "Put Back"
origin. A failure retries via `NSFileManager`, which needs no permission, and the
retry is sticky for the rest of the process so a cascade evicting hundreds of
entries doesn't pay an `osascript` round-trip each time to relearn the same
denial. Finder's error is the one reported if both fail; it names the cause.

`trash_all_reaches_the_system_trash` is the live re-check, `#[ignore]`d because it
puts a real file in the real Trash.

## 3. The chrome copy echo rewrote the row it had just copied

Copying the flash row twice produced ``…then confirm to clear (c… (copied)``.

The echo is written back onto the very row a later copy reads, so it compounds
with itself. It capped the whole row at 60 chars — right for a fragment (the
marker must not get buried), wrong for a row already one screen wide and clipped
by the renderer: it re-truncated the message it was there to preserve, a little
more each time. And nothing stripped the previous marker, so it nested.

Whole-row echoes are now uncapped, and ` (copied)` is stripped from what a chrome
copy reads — spyc's annotation, never the line's content. The marker is a const
shared with the stripper; they sit on opposite ends of a round-trip through the
screen and cannot drift.

## 4. Double-click a chrome row to copy the whole line

A flashed error with its whole `source()` chain is the most copy-worthy string
spyc produces, and taking it meant dragging accurately across a terminal width.
Two presses on the same chrome row inside 400ms now select and copy all of it.
Drag-select is unchanged, for picking a branch name or session id out of a line.

The row has to match, not the column — a double-click drifts a cell or two and the
gesture takes the whole row anyway. `whole_row` rides on the selection rather than
being resolved into anchor/focus at press time, so `range()` stays the one
authority on which columns are lit and the paint cannot disagree with what the
release copies.

## Verification

`make check-ci` → `=== GATE: PASS ===`, plus `make lint-linux` for the
`cfg(not(target_os = "macos"))` half of the trash seam.

Every fix was bite-checked — each half reverted, the test watched to fail, put
back. That caught one dead branch I had written (a short-circuit in
`extend_chrome_selection` that could not bite, because `range()` already ignores
anchor/focus for a whole-row selection); removed rather than left as defensive
noise.

Driven live in spyc before opening.

Generated with [Claude Code](https://claude.com/claude-code)
