### PR TITLE
fix(markdown): render what the parser already knew — fences, front matter, alerts, table alignment

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -645,6 +645,13 @@ spyc.
   raw source view (with full syntect highlighting of the
   markdown source itself); press `m` again to flip back. Yank
   and save always emit the source.
+  Also rendered: **GFM alerts** (`> [!NOTE]`, `[!TIP]`, `[!IMPORTANT]`,
+  `[!WARNING]`, `[!CAUTION]`) as coloured labels; **YAML front matter** as its
+  own dim block, line for line, so a `SKILL.md` or agent memory file reads
+  correctly; **table alignment** from the delimiter row (`|--:|:--|`); and
+  ` ```mermaid ` blocks as diagrams (`o` / `i`). Code fences resolve the
+  language by name or extension, so ` ```rust ` and ` ```rs ` highlight alike,
+  and an attribute suffix (` ```rust,ignore `) doesn't defeat it.
 - Page-up/down, half-page, and vi-style scrolling
 
 ## Shell integration

--- a/src/ui/markdown/mod.rs
+++ b/src/ui/markdown/mod.rs
@@ -86,6 +86,15 @@ pub fn render_doc(source: &str, theme: &Theme, table_width_hint: Option<usize>) 
     opts.insert(Options::ENABLE_TASKLISTS);
     opts.insert(Options::ENABLE_FOOTNOTES);
     opts.insert(Options::ENABLE_TABLES);
+    // Alert blockquotes (`> [!WARNING]`). The ONLY thing this flag turns on, so
+    // it can't perturb anything else; without it the tag is literal text in the
+    // quote, which is how spyc's own CONFIGURATION.md rendered.
+    opts.insert(Options::ENABLE_GFM);
+    // YAML front matter. Without it the opening `---` is a thematic break and
+    // the closing one a setext underline, so the whole block collapsed into an
+    // H2 of run-together fields — which is what `SKILL.md`, the file spyc
+    // itself installs, looked like in spyc's own pager.
+    opts.insert(Options::ENABLE_YAML_STYLE_METADATA_BLOCKS);
     let prepared = force_hard_breaks_before_keyed_lines(source);
     let parser = Parser::new_ext(&prepared, opts);
     let mut r = Renderer::new(theme, table_width_hint);
@@ -173,6 +182,10 @@ struct Renderer<'t> {
     /// True while inside any blockquote (single level — nested
     /// blockquotes render with the same `┃ ` prefix).
     in_blockquote: bool,
+    /// True while inside a YAML front-matter block. Its text is emitted
+    /// verbatim, line for line: it is a data header, and reflowing it into a
+    /// paragraph destroys the one thing that makes it readable.
+    in_metadata: bool,
     /// When inside a fenced code block, accumulate body here so we
     /// can hand the whole thing to syntect (or render plain) on End.
     code_block: Option<CodeBlockState>,
@@ -237,6 +250,10 @@ struct TableBuilder {
     /// because tables only nest after a paragraph flush, but keeping
     /// the stash makes the swap symmetric.
     stashed_current: Vec<Span<'static>>,
+    /// Per-column alignment from the delimiter row (`|--:|:--|`). Author intent
+    /// spyc used to discard, so a numeric column that the source right-aligned
+    /// rendered ragged-left like everything else.
+    alignments: Vec<pulldown_cmark::Alignment>,
 }
 
 struct CodeBlockState {

--- a/src/ui/markdown/renderer.rs
+++ b/src/ui/markdown/renderer.rs
@@ -6,7 +6,7 @@
 //! feeds it events, and calls `finish`. Split out of `markdown.rs`
 //! verbatim during the 800-LoC decomposition — behavior-identical.
 
-use pulldown_cmark::{CodeBlockKind, Event, Tag, TagEnd};
+use pulldown_cmark::{BlockQuoteKind, CodeBlockKind, Event, Tag, TagEnd};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 
@@ -34,6 +34,7 @@ impl<'t> Renderer<'t> {
             style_mods: StyleMods::default(),
             list_indent: 0,
             in_blockquote: false,
+            in_metadata: false,
             code_block: None,
             pending_link_url: None,
             table: None,
@@ -179,6 +180,18 @@ impl<'t> Renderer<'t> {
         match event {
             Event::Start(tag) => self.start_tag(tag),
             Event::End(tag) => self.end_tag(tag),
+            // Front matter is a data header, not prose: emit it line for line
+            // rather than through `push_text`, which reflows to `prose_width`
+            // and would run every YAML field together.
+            Event::Text(t) if self.in_metadata => {
+                let dim = Style::default()
+                    .fg(self.theme.status_suffix)
+                    .add_modifier(Modifier::DIM);
+                for raw in t.lines() {
+                    self.lines
+                        .push(Line::from(Span::styled(raw.to_string(), dim)));
+                }
+            }
             Event::Text(t) => self.push_text(&t, Style::default()),
             Event::Code(t) => {
                 // Inline `code`: teal-on-default reads as "code" the
@@ -261,10 +274,33 @@ impl<'t> Renderer<'t> {
                 // Subsequent text in the heading inherits BOLD via style_mods.
                 self.style_mods.push(Modifier::BOLD);
             }
-            Tag::BlockQuote(_) => {
+            Tag::MetadataBlock(_) => {
+                if !self.current.is_empty() {
+                    self.flush_line();
+                }
+                self.in_metadata = true;
+            }
+            Tag::BlockQuote(kind) => {
                 self.in_blockquote = true;
                 if !self.current.is_empty() {
                     self.flush_line();
+                }
+                // A GFM alert (`> [!WARNING]`) is a blockquote with a kind.
+                // Emit the label as its own styled row: the tag is markup, and
+                // leaving it in the body renders it as the literal text
+                // `[!WARNING]`, which is what it did before `ENABLE_GFM`.
+                if let Some(kind) = kind {
+                    let (label, color) = self.alert_label(kind);
+                    self.lines.push(Line::from(vec![
+                        Span::styled(
+                            "\u{2503} ".to_string(),
+                            Style::default().fg(self.theme.status_suffix),
+                        ),
+                        Span::styled(
+                            label.to_string(),
+                            Style::default().fg(color).add_modifier(Modifier::BOLD),
+                        ),
+                    ]));
                 }
             }
             Tag::CodeBlock(kind) => {
@@ -331,7 +367,7 @@ impl<'t> Renderer<'t> {
                     Style::default().fg(self.theme.status_suffix),
                 ));
             }
-            Tag::Table(_alignments) => {
+            Tag::Table(alignments) => {
                 if !self.current.is_empty() {
                     self.flush_line();
                 }
@@ -341,6 +377,7 @@ impl<'t> Renderer<'t> {
                     in_head: false,
                     cur_row: Vec::new(),
                     stashed_current: Vec::new(),
+                    alignments,
                 });
             }
             Tag::TableHead => {
@@ -382,6 +419,10 @@ impl<'t> Renderer<'t> {
                 if !self.current.is_empty() {
                     self.flush_line();
                 }
+                self.lines.push(Line::from(Vec::<Span<'static>>::new()));
+            }
+            TagEnd::MetadataBlock(_) => {
+                self.in_metadata = false;
                 self.lines.push(Line::from(Vec::<Span<'static>>::new()));
             }
             TagEnd::BlockQuote(_) => {
@@ -535,8 +576,9 @@ impl<'t> Renderer<'t> {
         bot.push('\u{2518}'); // ┘
 
         self.lines.push(Line::from(Span::styled(top, frame_style)));
+        let aligns = t.alignments.clone();
         if let Some(h) = head {
-            self.render_table_row(h, &widths, true, frame_style);
+            self.render_table_row(h, &widths, &aligns, true, frame_style);
             self.lines
                 .push(Line::from(Span::styled(mid.clone(), frame_style)));
         }
@@ -550,7 +592,7 @@ impl<'t> Renderer<'t> {
                 self.lines
                     .push(Line::from(Span::styled(mid.clone(), frame_style)));
             }
-            self.render_table_row(row, &widths, false, frame_style);
+            self.render_table_row(row, &widths, &aligns, false, frame_style);
         }
         self.lines.push(Line::from(Span::styled(bot, frame_style)));
         self.lines.push(Line::from(Vec::<Span<'static>>::new()));
@@ -562,10 +604,27 @@ impl<'t> Renderer<'t> {
     /// hard-break fallback). The visual height of the row is the
     /// max wrap-rows across cells; cells that wrap to fewer rows
     /// are padded with blank cells for those visual rows.
+    /// Label and colour for a GFM alert blockquote.
+    ///
+    /// Colours reuse the theme's existing roles rather than adding five knobs:
+    /// the two that mean "act on this" borrow the warning/cursor colours the
+    /// rest of spyc already uses for that, so an alert reads the same way a
+    /// flashed error does.
+    const fn alert_label(&self, kind: BlockQuoteKind) -> (&'static str, ratatui::style::Color) {
+        match kind {
+            BlockQuoteKind::Note => ("NOTE", self.theme.status_path),
+            BlockQuoteKind::Tip => ("TIP", self.theme.take),
+            BlockQuoteKind::Important => ("IMPORTANT", self.theme.prompt_prefix),
+            BlockQuoteKind::Warning => ("WARNING", self.theme.delete_warning),
+            BlockQuoteKind::Caution => ("CAUTION", self.theme.cursor_bg),
+        }
+    }
+
     fn render_table_row(
         &mut self,
         row: &[Vec<Span<'static>>],
         widths: &[usize],
+        aligns: &[pulldown_cmark::Alignment],
         is_header: bool,
         frame_style: Style,
     ) {
@@ -594,6 +653,18 @@ impl<'t> Renderer<'t> {
             for (i, w) in widths.iter().enumerate() {
                 let cell_row = wrapped[i].get(vr).unwrap_or(&empty_row);
                 let used = spans_visual_width(cell_row);
+                // Split the slack according to the delimiter row's alignment.
+                // `Alignment::None` keeps everything on the right, which is the
+                // left-aligned default every cell used before.
+                let slack = w.saturating_sub(used);
+                let (pad_left, pad_right) = match aligns.get(i) {
+                    Some(pulldown_cmark::Alignment::Right) => (slack, 0),
+                    Some(pulldown_cmark::Alignment::Center) => (slack / 2, slack - slack / 2),
+                    _ => (0, slack),
+                };
+                if pad_left > 0 {
+                    line_spans.push(Span::raw(" ".repeat(pad_left)));
+                }
                 for s in cell_row {
                     let mut style = s.style;
                     if is_header {
@@ -601,8 +672,8 @@ impl<'t> Renderer<'t> {
                     }
                     line_spans.push(Span::styled(s.content.clone(), style));
                 }
-                if used < *w {
-                    line_spans.push(Span::raw(" ".repeat(*w - used)));
+                if pad_right > 0 {
+                    line_spans.push(Span::raw(" ".repeat(pad_right)));
                 }
                 if i + 1 < widths.len() {
                     line_spans.push(Span::styled(" \u{2502} ".to_string(), frame_style));
@@ -626,16 +697,10 @@ impl<'t> Renderer<'t> {
             self.emit_mermaid_block(body);
             return;
         }
-        // Try syntect highlighting if a language is given; fall
-        // back to plain dim text otherwise. We synthesize a fake
-        // filename for highlight_to_lines's extension-based lookup
-        // when the language tag matches a known extension.
-        let highlighted = if state.lang.is_empty() {
-            None
-        } else {
-            let fake_name = format!("snippet.{}", state.lang);
-            crate::ui::syntax::highlight_to_lines(&fake_name, body)
-        };
+        // Try syntect highlighting if a language is given; fall back to plain
+        // dim text otherwise. The fence tag is a LANGUAGE, so it goes through
+        // the language lookup — see `syntax::highlight_lang_to_lines`.
+        let highlighted = crate::ui::syntax::highlight_lang_to_lines(&state.lang, body);
         let dim = Style::default()
             .fg(self.theme.status_suffix)
             .add_modifier(Modifier::DIM);

--- a/src/ui/markdown/tests.rs
+++ b/src/ui/markdown/tests.rs
@@ -409,3 +409,146 @@ fn mermaid_range_stays_in_bounds_when_the_diagram_ends_the_doc() {
     assert!(block_text.contains("mermaid diagram"));
     assert!(block_text.contains("flowchart LR"));
 }
+
+// ── render fidelity: what the parser knows but the renderer used to drop ──
+
+/// A fence tag is a language, not a filename. Synthesizing `snippet.<lang>` and
+/// going through syntect's EXTENSION table meant the spellings people actually
+/// write missed entirely: spyc's own docs carry 28 ` ```rust ` blocks and zero
+/// ` ```rs `, and every one of them rendered unhighlighted.
+///
+/// Asserts on span COUNT, not colours: a highlighted line is split into many
+/// styled spans, a plain one is a single span. That distinguishes the two
+/// without pinning syntect's palette.
+#[test]
+fn full_language_names_in_a_fence_highlight_not_just_extensions() {
+    let theme = Theme::default();
+    let spans_for = |lang: &str| {
+        let src = format!("```{lang}\nfn main() {{ let x = 1; }}\n```\n");
+        render(&src, &theme, None)
+            .into_iter()
+            .map(|l| l.spans.len())
+            .max()
+            .unwrap_or(0)
+    };
+    // The extension spelling always worked — it's the control.
+    let by_ext = spans_for("rs");
+    assert!(by_ext > 1, "```rs should highlight (got {by_ext} spans)");
+    for lang in ["rust", "Rust", "RUST"] {
+        assert!(
+            spans_for(lang) > 1,
+            "```{lang} must highlight like ```rs does"
+        );
+    }
+    // mdBook and rustdoc write attributes into the info string; the language is
+    // the first word, and the rest must not defeat the lookup.
+    for lang in ["rust,ignore", "rust no_run"] {
+        assert!(
+            spans_for(lang) > 1,
+            "```{lang} must highlight — attributes aren't part of the name"
+        );
+    }
+    // An unknown language still falls back to plain rather than failing.
+    assert_eq!(
+        spans_for("nosuchlang"),
+        1,
+        "an unrecognized language renders plain, one span per line"
+    );
+}
+
+/// YAML front matter is a data header. Without the metadata option the opening
+/// `---` parsed as a thematic break and the closing one as a setext underline,
+/// so the fields collapsed into a single run-together H2 — which is how
+/// `SKILL.md`, the file spyc itself installs, looked in spyc's own pager.
+#[test]
+fn yaml_front_matter_renders_as_its_own_lines_not_a_heading() {
+    let lines = render_plain("---\nname: spyc\ndescription: a thing\n---\n\n# Real Heading\n");
+    assert!(
+        lines.iter().any(|l| l == "name: spyc"),
+        "each field keeps its own line: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l == "description: a thing"),
+        "fields are not reflowed together: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|l| l.starts_with("##")),
+        "the closing `---` must not become a setext underline: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|l| l.starts_with("\u{2500}\u{2500}")),
+        "the opening `---` must not become a thematic break: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l == "# Real Heading"),
+        "the document after the front matter still renders: {lines:?}"
+    );
+}
+
+/// GFM alerts. Without `ENABLE_GFM` the tag stayed in the quote body and
+/// rendered as the literal text `[!WARNING]` — which is how CONFIGURATION.md
+/// and four archive docs looked.
+#[test]
+fn gfm_alerts_render_as_a_label_not_literal_tag_text() {
+    for (tag, label) in [
+        ("NOTE", "NOTE"),
+        ("TIP", "TIP"),
+        ("IMPORTANT", "IMPORTANT"),
+        ("WARNING", "WARNING"),
+        ("CAUTION", "CAUTION"),
+    ] {
+        let lines = render_plain(&format!("> [!{tag}]\n> Body text.\n"));
+        assert!(
+            lines.iter().any(|l| l == &format!("\u{2503} {label}")),
+            "[!{tag}] should render as its own label row: {lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l.contains("[!")),
+            "the raw tag must not survive into the body: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("Body text.")),
+            "the quote body still renders: {lines:?}"
+        );
+    }
+    // A plain blockquote is unaffected — no label row, no leading blank.
+    let plain = render_plain("> just a quote\n");
+    assert!(
+        plain.iter().any(|l| l == "\u{2503} just a quote"),
+        "an ordinary blockquote keeps its shape: {plain:?}"
+    );
+}
+
+/// The delimiter row's alignment is author intent, and `Tag::Table` used to
+/// throw the whole vector away — so a right-aligned numeric column rendered
+/// ragged-left like everything else.
+#[test]
+fn table_columns_honor_the_delimiter_rows_alignment() {
+    let lines = render_plain("| left | mid | right |\n|:-----|:---:|------:|\n| a | b | c |\n");
+    let body = lines
+        .iter()
+        .find(|l| l.contains('a') && l.contains('b') && l.contains('c'))
+        .unwrap_or_else(|| panic!("no body row in {lines:?}"));
+
+    // Cell interiors, between the `│` separators and minus the framing spaces.
+    let cells: Vec<&str> = body.split('\u{2502}').filter(|c| !c.is_empty()).collect();
+    let [left, mid, right] = cells.as_slice() else {
+        panic!("expected three cells, got {cells:?}");
+    };
+    assert!(
+        left.starts_with(" a") && left.ends_with("  "),
+        "`:---` pads on the right: {left:?}"
+    );
+    assert!(
+        right.starts_with("  ") && right.trim_end().ends_with('c'),
+        "`---:` pads on the left: {right:?}"
+    );
+    let m = mid.trim_matches(' ');
+    assert_eq!(m, "b");
+    let lead = mid.len() - mid.trim_start_matches(' ').len();
+    let trail = mid.len() - mid.trim_end_matches(' ').len();
+    assert!(
+        lead > 1 && trail > 1 && lead.abs_diff(trail) <= 1,
+        "`:--:` splits the slack both sides: lead={lead} trail={trail} in {mid:?}"
+    );
+}

--- a/src/ui/syntax.rs
+++ b/src/ui/syntax.rs
@@ -81,7 +81,6 @@ const THEME_NAME: &str = "base16-eighties.dark";
 /// Returns `None` if the file type isn't recognized by syntect.
 pub fn highlight_to_lines(filename: &str, content: &str) -> Option<Vec<Line<'static>>> {
     let ss = &*SYNTAX_SET;
-    let ts = &*THEME_SET;
 
     // Detect syntax from file extension, then by bare filename (so
     // `Makefile` resolves — it has no extension but syntect's
@@ -105,6 +104,40 @@ pub fn highlight_to_lines(filename: &str, content: &str) -> Option<Vec<Line<'sta
                 .and_then(|first| ss.find_syntax_by_first_line(first))
         })?;
 
+    highlight_with(syntax, content)
+}
+
+/// Highlight `content` as `lang`, a Markdown fence's info string
+/// (` ```rust `, ` ```py `, ` ```Bash `).
+///
+/// A separate entry point from [`highlight_to_lines`] because a fence tag is a
+/// LANGUAGE, not a filename, and syntect looks the two up differently.
+/// Synthesizing `snippet.<lang>` and going through the extension table meant
+/// every full language name missed: ` ```rust `, ` ```python `, ` ```javascript `
+/// and ` ```typescript ` all rendered unhighlighted, while their extension
+/// spellings (`rs`, `py`, `js`, `ts`) worked. That is backwards from how people
+/// write Markdown — spyc's own docs carry 28 ` ```rust ` blocks and no ` ```rs `.
+///
+/// `find_syntax_by_token` tries the extension table first and then matches
+/// syntax names case-insensitively, so both spellings resolve and ` ```Rust `
+/// does too. Only the first whitespace- or comma-separated word is used: mdBook
+/// and rustdoc write attributes into the info string (` ```rust,ignore `,
+/// ` ```rust no_run `), and those are not part of the language name.
+pub fn highlight_lang_to_lines(lang: &str, content: &str) -> Option<Vec<Line<'static>>> {
+    let token = lang
+        .split(|c: char| c.is_whitespace() || c == ',')
+        .find(|t| !t.is_empty())?;
+    let ss = &*SYNTAX_SET;
+    highlight_with(ss.find_syntax_by_token(token)?, content)
+}
+
+/// The shared highlight loop: a resolved syntax + content -> styled lines.
+fn highlight_with(
+    syntax: &syntect::parsing::SyntaxReference,
+    content: &str,
+) -> Option<Vec<Line<'static>>> {
+    let ss = &*SYNTAX_SET;
+    let ts = &*THEME_SET;
     let theme = ts.themes.get(THEME_NAME)?;
     let mut highlighter = HighlightLines::new(syntax, theme);
 


### PR DESCRIPTION
Prompted by comparing spyc's markdown support to Emacs 31's `markdown-ts-mode`.
Four places the renderer dropped information pulldown-cmark or syntect was
already handing it — found by rendering spyc's **own** shipped markdown, and all
four are live in this repo.

## 1. Code fences resolved by extension only

`end_code_block` synthesized `snippet.<lang>` and went through syntect's
**extension** table. So the spellings people actually write all missed:

```
```rust        -> PLAIN          ```rs    -> highlighted
```python      -> PLAIN          ```py    -> highlighted
```javascript  -> PLAIN          ```js    -> highlighted
```typescript  -> PLAIN          ```ts    -> highlighted
```

spyc's own docs contain **28 ```rust blocks and zero ```rs**. Every one rendered
unhighlighted — the exact capability the Emacs post calls its "party trick".

A fence tag is a *language*, so it now goes through a sibling entry point
(`syntax::highlight_lang_to_lines`) built on `find_syntax_by_token`: extension
table first, then case-insensitive name match. Only the first word is used, so
mdBook/rustdoc attributes (` ```rust,ignore `, ` ```rust no_run `) still resolve.

## 2. YAML front matter parsed as a heading

Without `ENABLE_YAML_STYLE_METADATA_BLOCKS`, the opening `---` is a thematic
break and the closing one a setext underline. Before / after on
`src/skill/assets/SKILL.md`'s header — **the file spyc itself installs**:

```
  0 |────────────────────────────────|          0 |name: spyc|
  2 |## name: spyc description: a thing|   →     1 |description: a thing|
```

Rendered dim and verbatim: reflowing a data header destroys the one thing that
makes it readable. Also affects every Claude/codex skill file and agent memory
file.

## 3. GFM alerts were literal text

`ENABLE_GFM` turns on alert blockquotes and nothing else (checked upstream —
it is the flag's entire scope). `Tag::BlockQuote(_)` was discarding the kind, so
`> [!WARNING]` rendered as the characters `[!WARNING]` inside a plain quote — in
`CONFIGURATION.md:349` and four archive docs. Now a coloured label row:

```
┃ WARNING
┃ Careful here.
```

Colours borrow existing theme roles rather than adding five knobs.

## 4. Table alignment was discarded

`Tag::Table(_alignments)` threw the vector away, so `|--:|` rendered ragged-left:

```
│ a    │ 1    │       →      │ a    │    1 │
│ bb   │ 22   │              │ bb   │   22 │
```

## Verification

`make check-ci` → `=== GATE: PASS ===`; the 30 existing markdown tests still
pass unchanged.

Four new tests, one per fix, each bite-checked — reverted the fix, watched the
test fail, put it back:

```
--- BITE: fence lookup       ... FAILED
--- BITE: front matter option ... FAILED
--- BITE: gfm alerts          ... FAILED
--- BITE: table alignment     ... FAILED
```

The fence test asserts on span *count* rather than colours, so it distinguishes
highlighted from plain without pinning syntect's palette.

Generated with [Claude Code](https://claude.com/claude-code)
