### PR TITLE
ci(apt): deploy the apt repo as a Pages artifact, not a gh-pages branch

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -1,15 +1,44 @@
 # Publish spyc's signed apt repository on a release (rc or stable).
 #
 # On any published GitHub Release (or manual dispatch) this:
-#   1. downloads the release's Linux tarballs,
-#   2. builds .deb packages via the Makefile (`make deb`),
-#   3. regenerates the flat apt index (apt-ftparchive) and GPG-signs `Release`,
-#   4. commits the tree to THIS repo's `gh-pages` branch, served via GitHub
-#      Pages at https://tripstack-corp.github.io/spyc (keeping older versions).
+#   1. works out which versions the archive should hold (the policy in
+#      `scripts/prune-apt-repo.sh`),
+#   2. downloads each one's Linux tarballs from its GitHub Release,
+#   3. builds .deb packages via the Makefile (`make deb`),
+#   4. regenerates the flat apt index (apt-ftparchive) and GPG-signs `Release`,
+#   5. deploys the whole archive to GitHub Pages as an ARTIFACT.
 #
-# Users then: `apt install spyc` (see INSTALL.md). The apt repo lives on this
-# repo's own gh-pages branch, so the push uses no personal token — the built-in,
-# org-owned GITHUB_TOKEN (contents:write) publishes it.
+# Users then: `apt install spyc` (see INSTALL.md), from the same URL as ever:
+# https://tripstack-corp.github.io/spyc
+#
+# ## Why there is no gh-pages branch
+#
+# There used to be, and it made a clone of the SOURCE repo 255 MiB against
+# 14 MiB of actual project. `git clone` fetches every branch, so everyone who
+# cloned spyc downloaded every .deb ever published — including 22 release
+# candidates already pruned from the index, which no apt client could ever
+# fetch. A user reported the checkout time.
+#
+# Pages deploys from a workflow artifact instead (`build_type: workflow`), so
+# the archive has no branch and never touches a clone. The URL is unchanged, so
+# no `sources.list` anywhere needed editing.
+#
+# ## Why the debs are rebuilt rather than stored
+#
+# They aren't kept anywhere. The archive is a pure function of the releases:
+# every version is rebuilt from its own release tarball on each publish, which
+# is what `make deb` already did for the triggering release (it just wraps a
+# prebuilt binary, so it is release-agnostic). Storing the debs as release
+# assets was the obvious alternative and is not possible retroactively — this
+# repo has immutable releases, so assets are frozen at creation and the ten
+# already-published debs could never have been backfilled.
+#
+# A rebuilt deb is not guaranteed byte-identical to the one it replaces
+# (`dpkg-deb` embeds mtimes and nothing here sets `SOURCE_DATE_EPOCH`). That is
+# harmless: the index is regenerated and re-signed over the exact files being
+# deployed, in the same deployment, so it always describes what is served. A
+# client that had cached an older build of a pinned version re-downloads it
+# once.
 #
 # The signing key lives in the `apt-publish` protected Environment (only this
 # job, on a `v*` tag or `main`, can read it); operator setup is in
@@ -17,11 +46,6 @@
 # stays green until then. Prereleases publish too — the deb version uses a
 # tilde (`2.0.0~rc.4`), which dpkg sorts BELOW the final `2.0.0`, so an rc never
 # blocks the stable upgrade (the Makefile's `DEB_VERSION` does the `-`→`~`).
-#
-# Because rc debs publish, they also accumulate: step 3 runs
-# `scripts/prune-apt-repo.sh` first, dropping prereleases whose final release
-# has shipped (and all but the 3 newest of an in-flight version) so the index
-# doesn't grow without bound. Stable versions are never pruned.
 name: apt
 
 on:
@@ -38,14 +62,18 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write # push the apt index to the gh-pages branch
+  contents: read # read release assets; nothing is pushed any more
+  pages: write # deploy the archive
+  id-token: write # OIDC, required by deploy-pages
 
 jobs:
-  publish:
-    name: Build .debs + publish signed apt repo
+  build:
+    name: Build .debs + sign the apt index
     runs-on: ubuntu-latest
     # Scopes the signing-key secrets to this job (and to `v*` / `main` refs).
     environment: apt-publish
+    outputs:
+      enabled: ${{ steps.guard.outputs.enabled }}
     env:
       APT_GPG_PRIVATE_KEY: ${{ secrets.APT_GPG_PRIVATE_KEY }}
       APT_GPG_PASSPHRASE: ${{ secrets.APT_GPG_PASSPHRASE }}
@@ -69,7 +97,7 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout spyc (for the Makefile)
+      - name: Checkout spyc (for the Makefile + the prune policy)
         if: steps.guard.outputs.enabled == 'true'
         # main, not the release tag: the .deb target just wraps the prebuilt
         # binary (release-agnostic), and older tags predate `make deb`.
@@ -81,27 +109,80 @@ jobs:
         if: steps.guard.outputs.enabled == 'true'
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends dpkg-dev apt-utils gnupg
 
-      - name: Download release Linux tarballs
+      - name: Decide which versions the archive holds
         if: steps.guard.outputs.enabled == 'true'
+        id: plan
         run: |
-          gh release download "${{ steps.ver.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --pattern 'spyc-*-linux-*.tar.gz'
+          set -euo pipefail
+          # Every published release, newest first. Drafts are not public, so an
+          # apt client could never fetch their assets — they are not candidates.
+          gh release list --repo "${{ github.repository }}" --limit 200 \
+            --json tagName,isDraft --jq '.[] | select(.isDraft | not) | .tagName' \
+            | grep -E '^v[0-9]' > tags.txt
 
-      - name: Unpack binaries into the paths the Makefile expects
+          # The retention policy lives in ONE place: scripts/prune-apt-repo.sh.
+          # It is purely filename-driven (it `ls`es `spyc_*_*.deb`, parses the
+          # version out of the name and `rm`s — it never opens a deb), so
+          # running it over empty placeholders yields exactly the set a real
+          # archive would keep. Deciding first means we only build what
+          # survives, instead of building every version and deleting most of it.
+          mkdir -p plan
+          # Held in a variable: `${ver//-/\~}` keeps the backslash (a tilde is
+          # not special in a replacement, so the escape is literal), which
+          # yielded names like `spyc_2.0.0\~rc.26_amd64.deb`. The policy then
+          # read the base version as `2.0.0\`, matched no stable release, and
+          # pruned nothing.
+          tilde='~'
+          while read -r tag; do
+            ver="${tag#v}"
+            # Same `-`→`~` the Makefile's DEB_VERSION applies, so the policy
+            # sees the versions it expects to sort.
+            deb_ver="${ver//-/$tilde}"
+            : > "plan/spyc_${deb_ver}_amd64.deb"
+            : > "plan/spyc_${deb_ver}_arm64.deb"
+          done < tags.txt
+
+          ./scripts/prune-apt-repo.sh plan
+
+          # Survivors → the tags to build. The tag is recoverable from the deb
+          # version by inverting the same substitution, so there is no lookup
+          # table to keep in step (and no `awk -v`, which would re-interpret a
+          # backslash in the version it was handed).
+          : > build-tags.txt
+          for f in plan/spyc_*_amd64.deb; do
+            dv=$(basename "$f" | sed -n 's/^spyc_\(.*\)_amd64\.deb$/\1/p')
+            echo "v${dv//$tilde/-}" >> build-tags.txt
+          done
+          echo "::notice::apt archive will hold $(wc -l < build-tags.txt) version(s)"
+          cat build-tags.txt
+
+      - name: Build every deb the archive holds
         if: steps.guard.outputs.enabled == 'true'
         run: |
           set -euo pipefail
-          mkdir -p target/x86_64-unknown-linux-musl/release \
-                   target/aarch64-unknown-linux-musl/release
-          tar xzf spyc-*-linux-x86_64.tar.gz spyc
-          mv spyc target/x86_64-unknown-linux-musl/release/spyc
-          tar xzf spyc-*-linux-aarch64.tar.gz spyc
-          mv spyc target/aarch64-unknown-linux-musl/release/spyc
-
-      - name: Build .debs
-        if: steps.guard.outputs.enabled == 'true'
-        run: make deb VERSION="${{ steps.ver.outputs.version }}"
+          mkdir -p aptrepo
+          while read -r tag; do
+            ver="${tag#v}"
+            rm -rf tarballs && mkdir -p tarballs
+            # A release with no Linux tarballs predates them; skip rather than
+            # fail the publish over history we cannot package.
+            if ! gh release download "$tag" --repo "${{ github.repository }}" \
+                 --pattern 'spyc-*-linux-*.tar.gz' --dir tarballs 2>/dev/null; then
+              echo "::warning::$tag has no Linux tarballs — omitted from the apt index"
+              continue
+            fi
+            rm -rf target/x86_64-unknown-linux-musl target/aarch64-unknown-linux-musl
+            mkdir -p target/x86_64-unknown-linux-musl/release \
+                     target/aarch64-unknown-linux-musl/release
+            tar xzf tarballs/spyc-*-linux-x86_64.tar.gz -C tarballs spyc
+            mv tarballs/spyc target/x86_64-unknown-linux-musl/release/spyc
+            tar xzf tarballs/spyc-*-linux-aarch64.tar.gz -C tarballs spyc
+            mv tarballs/spyc target/aarch64-unknown-linux-musl/release/spyc
+            make deb VERSION="$ver"
+            cp dist/spyc_*.deb aptrepo/
+            rm -f dist/spyc_*.deb
+          done < build-tags.txt
+          ls -la aptrepo
 
       - name: Import GPG signing key
         if: steps.guard.outputs.enabled == 'true'
@@ -111,23 +192,10 @@ jobs:
           KEYID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
           echo "keyid=$KEYID" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout the gh-pages branch (the apt repo)
-        if: steps.guard.outputs.enabled == 'true'
-        uses: actions/checkout@v7
-        with:
-          ref: gh-pages
-          path: aptrepo
-
       - name: Regenerate + sign the flat apt index
         if: steps.guard.outputs.enabled == 'true'
         run: |
           set -euo pipefail
-          cp dist/spyc_*.deb aptrepo/
-          # Prune BEFORE indexing, in this same step: the index and its GPG
-          # signature must describe the pruned set. Deleting debs without
-          # reindexing would leave the signed Packages advertising files that
-          # are gone, which fails apt's hash check on every client.
-          ./scripts/prune-apt-repo.sh aptrepo
           cd aptrepo
           apt-ftparchive packages . > Packages
           gzip -kf Packages
@@ -146,16 +214,52 @@ jobs:
           gpg --armor --export "${{ steps.gpg.outputs.keyid }}" > KEY.gpg
           # GitHub Pages skips files/dirs starting with '_' and needs no Jekyll.
           touch .nojekyll
+          cp ../docs/apt-README.md README.md
 
-      - name: Commit + push to gh-pages
+      - name: Sanity-check the archive before deploying it
         if: steps.guard.outputs.enabled == 'true'
         run: |
           set -euo pipefail
           cd aptrepo
-          git config user.name "spyc-release-bot"
-          git config user.email "noreply@tripstack.com"
-          git add -A
-          git commit -m "apt: publish spyc ${{ steps.ver.outputs.version }}" || {
-            echo "nothing to publish"; exit 0;
-          }
-          git push origin gh-pages
+          # A signed index that advertises a file which is not there fails apt's
+          # hash check on every client, and Pages has no rollback. Cheaper to
+          # catch here than in the field.
+          # Read from a FILE, not a pipe. `awk ... | while read` runs the loop
+          # in a subshell, so an `exit 1` inside it only fails the step by way
+          # of `pipefail` — the same fail-open shape that once let a broken gate
+          # report green here (AGENTS.md, "Never pipe the gate"). A redirect
+          # keeps the loop in this shell, where `set -e` is unambiguous.
+          awk '/^Filename: /{print $2}' Packages > /tmp/advertised.txt
+          missing=0
+          while read -r f; do
+            if [ ! -e "$f" ]; then
+              echo "::error::Packages advertises $f, which is not in the archive"
+              missing=$((missing + 1))
+            fi
+          done < /tmp/advertised.txt
+          [ "$missing" -eq 0 ] || { echo "::error::$missing advertised file(s) missing"; exit 1; }
+          [ -s /tmp/advertised.txt ] || { echo "::error::Packages advertises nothing"; exit 1; }
+          test -s InRelease || { echo "::error::InRelease is empty"; exit 1; }
+          gpg --verify InRelease >/dev/null 2>&1 || { echo "::error::InRelease does not verify"; exit 1; }
+          n=$(ls spyc_*.deb 2>/dev/null | wc -l)
+          [ "$n" -gt 0 ] || { echo "::error::no debs in the archive"; exit 1; }
+          echo "archive OK: $n deb(s), index verifies"
+
+      - name: Upload the archive as the Pages artifact
+        if: steps.guard.outputs.enabled == 'true'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: aptrepo
+
+  deploy:
+    name: Deploy the apt repo to Pages
+    needs: build
+    if: needs.build.outputs.enabled == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,7 @@ workflow, standards, and conventions for the project.
 ## Getting started
 
 ```sh
-# Use single-branch to avoid downloading the heavy gh-pages branch
-git clone --single-branch --branch main git@github.com:Tripstack-Corp/spyc.git
+git clone git@github.com:Tripstack-Corp/spyc.git
 cd spyc
 make doctor         # check prerequisites (rustc, cargo, zig, etc.)
 make install-hooks  # pre-commit hook — see below

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -189,11 +189,18 @@ The prune runs in the same step as the reindex on purpose: `Packages` /
 `Release` / `InRelease` are GPG-signed over the file set, so deleting debs
 without regenerating and re-signing would leave the signed index advertising
 files that are gone, failing apt's hash check on every client. That is also why
-this can't be done by hand-editing `gh-pages` — the signing key only exists
+the archive can't be edited by hand — there is nowhere to edit it (it exists
+only as a Pages artifact, rebuilt per publish), and the signing key only exists
 inside the `apt-publish` environment. To purge retroactively, dispatch `apt.yml`
 with any recent tag; the prune runs on the way through.
 
-Inspect the policy against a local gh-pages checkout without publishing:
+The policy also decides what gets BUILT. `apt.yml` materializes one empty
+placeholder per candidate version, runs this same script over them, and builds
+only the survivors — the script is purely filename-driven, so it yields the same
+answer against placeholders as against real debs, and the retention rule stays
+in one file rather than being restated in the workflow.
+
+Inspect the policy against a directory of debs without publishing:
 `make apt-prune-check APT_REPO=<dir>`.
 
 ## 6. Maintenance: Errata & Security (EN / SA)
@@ -326,19 +333,31 @@ are the source of truth — Actions *call them* so local and CI never drift.
 - On any publish (prereleases included — apt tracks the rc stream): download the
   release's Linux tarballs, build
   `.deb`s (`make deb`), regenerate the apt index (`apt-ftparchive`), sign the
-  `Release` file with the signing key, and commit the tree to this repo's
-  **`gh-pages`** branch — served via GitHub Pages at
-  `https://tripstack-corp.github.io/spyc`, so users `apt install spyc` /
-  `apt upgrade`. Because the apt repo lives on this repo's own branch, the push
-  uses the built-in **`GITHUB_TOKEN`** (org-owned, `contents:write`) — no
-  personal/cross-repo token. The job self-skips when the signing key is absent.
+  `Release` file with the signing key, and deploy the archive to GitHub Pages as
+  a **workflow artifact** — served at `https://tripstack-corp.github.io/spyc`,
+  so users `apt install spyc` / `apt upgrade`. The job self-skips when the
+  signing key is absent.
+- **No `gh-pages` branch, by design.** It used to hold the archive, and because
+  `git clone` fetches every branch that made a clone of the SOURCE repo 255 MiB
+  against 14 MiB of project — every `.deb` ever published, including 22 already
+  pruned from the index and unfetchable by any client. A user reported the
+  checkout time. Pages now deploys from an artifact (`build_type: workflow`),
+  which needs no branch and keeps the URL, so no `sources.list` had to change.
+- **The archive is a pure function of the releases.** Nothing stores debs:
+  every version in the index is rebuilt from its own release tarball on each
+  publish. Attaching them as release assets was the obvious alternative and is
+  impossible retroactively — this repo has immutable releases, so assets freeze
+  at creation. A rebuilt deb may not be byte-identical to the one it replaces
+  (`dpkg-deb` embeds mtimes); harmless, since the index is re-signed over
+  exactly what is deployed, in the same deployment.
 - **Signing key** — a dedicated RSA-4096 key signs `Release`; its public half is
   published as `KEY.gpg` (what users pin via `signed-by`). The private key +
   passphrase live in the **`apt-publish` protected Environment** (secrets
   `APT_GPG_PRIVATE_KEY` + `APT_GPG_PASSPHRASE`), scoped so only this job — on a
   `v*` tag or `main` — can read them.
 - **Operator setup — DONE** (kept for reference / rebuild):
-  1. `gh-pages` on `spyc` holds the apt tree; Pages serves it from `/` root.
+  1. Pages on `spyc` is set to **GitHub Actions** as its source
+     (`build_type: workflow`), not a branch.
   2. The `apt-publish` Environment (deployment policy: `v*` tag + `main` branch)
      holds the two `APT_GPG_*` secrets.
   3. The signing key is backed up off-repo (owner's password manager) with a

--- a/docs/apt-README.md
+++ b/docs/apt-README.md
@@ -1,0 +1,25 @@
+# spyc apt repository
+
+Signed Debian/Ubuntu packages for
+[spyc](https://github.com/Tripstack-Corp/spyc) — a keyboard-driven,
+MCP-native terminal file commander. Served via GitHub Pages at
+<https://tripstack-corp.github.io/spyc>.
+
+## Install
+
+```sh
+sudo install -d -m 0755 /etc/apt/keyrings
+curl -fsSL https://tripstack-corp.github.io/spyc/KEY.gpg \
+  | sudo tee /etc/apt/keyrings/spyc.asc >/dev/null
+echo "deb [signed-by=/etc/apt/keyrings/spyc.asc] https://tripstack-corp.github.io/spyc ./" \
+  | sudo tee /etc/apt/sources.list.d/spyc.list >/dev/null
+sudo apt update
+sudo apt install spyc
+```
+
+`apt upgrade` picks up new releases from then on. Both `amd64` and `arm64`
+are published. Packages are built and signed automatically on each stable
+spyc release by the `apt.yml` workflow. `KEY.gpg` is the repository signing
+key's public half (fingerprint `6039 1763 40F9 215E 2756 AFE9 D57E 3D74 C8FC 6618`).
+
+This branch is machine-managed — the source lives on `main`.


### PR DESCRIPTION
Your user's slow-checkout complaint, fixed at the root.

## The problem

A clone transfers **255 MiB for a 14 MiB project**. `git clone` fetches every
branch, and `gh-pages` held every `.deb` ever published — 245 MiB of binaries,
**22 of them release candidates already pruned from the index** and unfetchable
by any apt client. CONTRIBUTING.md had been papering over it with a
`--single-branch` workaround.

Already done ahead of this PR (approved separately): `gh-pages` squashed to a
single commit, dropping the dead debs. Clone **255 → 97 MiB**, apt index verified
byte-identical before/after, all 10 debs serving. This PR takes it to **14.4 MiB**
and keeps it there.

## The fix

GitHub Pages can deploy from a **workflow artifact** (`build_type: workflow`)
instead of a branch. Same URL, so **no `sources.list` anywhere changes** — which
is why this beats moving the archive to a second repo.

Nothing stores the debs. The archive is a pure function of the releases: each
version is rebuilt from its own release tarball on publish. `make deb` already
did exactly that for the triggering release — it wraps a prebuilt binary, so it
was always release-agnostic.

> Attaching debs as release assets was the obvious alternative and is
> **impossible retroactively**: this repo has immutable releases, so assets
> freeze at creation. I found this by trying — all ten backfill uploads were
> rejected with `422 Cannot upload assets to an immutable release`.

## Retention stays in one place

`scripts/prune-apt-repo.sh` remains the only statement of the policy. The
workflow materializes one empty placeholder per candidate version and runs that
script over them, then builds only the survivors — the script is purely
filename-driven (it `ls`es, parses the version out of the name, and `rm`s; it
never opens a deb), so placeholders give the same answer as real debs.

Verified against the live release list:

```
prune: removed 6 file(s); kept 10
=== archive contents ===
v2.0.0  v2.0.2  v2.0.3  v2.1.0  v2.1.1
```

Exactly today's published index.

## Two bugs the dry run caught

1. **`${ver//-/\~}` keeps the backslash.** A tilde isn't special in a
   replacement, so the escape is literal: placeholders came out as
   `spyc_2.0.0\~rc.26_amd64.deb`, the policy read the base version as `2.0.0\`,
   matched no stable release, and pruned nothing.
2. **The tag lookup used `awk -v`**, which re-interprets a backslash in the value
   it's handed — so those same versions then vanished from the build list.

The two cancelled out to a coincidentally-correct answer. The tag is now
recovered by inverting the substitution, with no lookup table at all.

## Safety

- A pre-deploy check refuses to publish an index advertising a file that isn't
  there, or one that doesn't `gpg --verify` — Pages has no rollback.
- That check reads from a **file, not a pipe**: `awk | while read` runs the loop
  in a subshell, the same fail-open shape as the piped gate in AGENTS.md.
- Permissions drop from `contents: write` to `contents: read` — nothing is pushed
  any more.

## Landing sequence (not done yet — flagging before I touch the live channel)

1. Merge this.
2. Switch the repo's Pages source to GitHub Actions.
3. Dispatch `apt.yml` against `v2.1.1`.
4. Diff the live `InRelease` / `Release` / `Packages` / every deb against the
   fingerprints I captured before any of this started.
5. Only once that's byte-identical: delete `gh-pages`.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)
