### PR TITLE
fix(apt): stop the signed index asserting a hash Release can never have

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -205,7 +205,14 @@ jobs:
             -o APT::FTPArchive::Release::Suite=stable \
             -o APT::FTPArchive::Release::Architectures="amd64 arm64" \
             -o APT::FTPArchive::Release::Components=main \
-            release . > Release
+            release . > ../Release.tmp
+          # Generated OUTSIDE the scanned directory, then moved in. `> Release`
+          # here truncates the file before `apt-ftparchive` walks the directory,
+          # so the hash it recorded for `Release` was of its own
+          # partially-written output — the signed index asserted 121 bytes for a
+          # 1287-byte file (#442). A `Release` that does not list itself is the
+          # correct outcome: the entry is unsatisfiable by construction.
+          mv ../Release.tmp Release
           rm -f InRelease Release.gpg
           gpg --batch --yes --pinentry-mode loopback --passphrase "$APT_GPG_PASSPHRASE" \
             --local-user "${{ steps.gpg.outputs.keyid }}" --clearsign -o InRelease Release
@@ -239,6 +246,23 @@ jobs:
           done < /tmp/advertised.txt
           [ "$missing" -eq 0 ] || { echo "::error::$missing advertised file(s) missing"; exit 1; }
           [ -s /tmp/advertised.txt ] || { echo "::error::Packages advertises nothing"; exit 1; }
+
+          # Every hash the signed Release asserts must match the bytes shipped
+          # beside it. This is the check that would have caught #442, where the
+          # index carried a hash for `Release` that could never be right — so it
+          # is a guard, not just a fix. Only the SHA256 block: start at the
+          # header, stop at the next unindented line (the following section, or
+          # the signature).
+          awk '/^SHA256:$/{f=1;next} f && /^[^ ]/{f=0} f && NF==3 {print $1" "$3}' \
+            Release > /tmp/index-hashes.txt
+          bad=0
+          while read -r want name; do
+            [ -e "$name" ] || { echo "::error::Release asserts $name, which is not here"; bad=$((bad + 1)); continue; }
+            got=$(sha256sum "$name" | awk '{print $1}')
+            [ "$got" = "$want" ] || { echo "::error::Release asserts a wrong hash for $name"; bad=$((bad + 1)); }
+          done < /tmp/index-hashes.txt
+          [ "$bad" -eq 0 ] || { echo "::error::$bad index hash(es) wrong"; exit 1; }
+          echo "index self-consistent: $(wc -l < /tmp/index-hashes.txt) hashed file(s)"
           test -s InRelease || { echo "::error::InRelease is empty"; exit 1; }
           gpg --verify InRelease >/dev/null 2>&1 || { echo "::error::InRelease does not verify"; exit 1; }
           n=$(ls spyc_*.deb 2>/dev/null | wc -l)


### PR DESCRIPTION
Closes #442.

## The bug

```sh
apt-ftparchive ... release . > Release
```

The shell's `>` truncates `Release` **before** `apt-ftparchive` walks the
directory, so the hash it records for `Release` is of its own partially-written
output. The published index asserted **121 bytes for a 1287-byte file**.

Reproduced in a Debian container — same shape at toy scale:

```
===== CURRENT: apt-ftparchive release . > Release =====
-- Release's SHA256 block --
 4abafede...  63  Packages
 187bec2b...  85  Packages.gz
 ee899433...  52  Release      <-- claims 52 bytes
-- actual --
  Release      9a802a5f  1218  <-- is 1218 bytes
```

52, not 0 — it isn't hashing an empty file, just however much had been flushed
by the time the scan reached it.

## The fix

Generate outside the scanned directory, then move it in:

```
===== FIXED =====
-- Release's SHA256 block --
 4abafede...  63  Packages
 187bec2b...  85  Packages.gz
                               <-- no self-entry
```

`Packages` / `Packages.gz` hashes are byte-identical across the change, so
nothing else moves. **A `Release` that doesn't list itself is the correct
outcome** — the entry is unsatisfiable by construction, since writing the hash
changes the file being hashed.

## Why it survived this long

Harmless in practice: apt fetches the signed `InRelease`, verifies the
signature, then verifies `Packages` / `Packages.gz` against the hashes inside
it. It never checks `Release` against its own entry. But a signed supply-chain
artifact asserting a false hash is worth not shipping, and a future apt could
reasonably start checking.

## Guard, not just a fix

The pre-deploy check now verifies **every hash the index asserts**, not just that
the advertised debs exist — this is the check that would have caught it.
Confirmed to bite:

```
=== guard against the OLD (broken) generation ===
  ::error:: Release asserts a wrong hash for Release
  FAIL — 1 index hash(es) wrong
=== guard against the NEW (fixed) generation ===
  PASS — index self-consistent: 2 hashed file(s)
```

## End-to-end

Built the archive the fixed way in a container, signed it with an ephemeral key,
pointed a real apt client at it:

```
Get:1 file:/srv/repo ./ InRelease [1434 B]
Get:2 file:/srv/repo ./ Packages [357 B]
Candidate: 9.9.9
Unpacking spyc (9.9.9) ... Setting up spyc (9.9.9) ...
installed binary says: hi
dpkg version: 9.9.9
```

(Two earlier attempts failed on my *fixture* — a control file missing
`Section`/`Priority`, then an amd64 deb on an arm64 VM. Both downstream of the
archive; apt had already fetched and hash-verified the package each time.)

## Not a regression from #441

The index published from the old `gh-pages` had the identical property, checked
against its last commit before the branch was removed. #441 changed where the
archive deploys from, not how the index is generated.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)
