### PR TITLE
ci: lint the workflows in the PR gate

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -265,9 +265,12 @@ jobs:
           echo "index self-consistent: $(wc -l < /tmp/index-hashes.txt) hashed file(s)"
           test -s InRelease || { echo "::error::InRelease is empty"; exit 1; }
           gpg --verify InRelease >/dev/null 2>&1 || { echo "::error::InRelease does not verify"; exit 1; }
-          n=$(ls spyc_*.deb 2>/dev/null | wc -l)
-          [ "$n" -gt 0 ] || { echo "::error::no debs in the archive"; exit 1; }
-          echo "archive OK: $n deb(s), index verifies"
+          # Glob into an array rather than counting `ls` output: a filename
+          # with a newline would inflate the count, and the unmatched-glob case
+          # is explicit instead of riding on a suppressed `ls` error.
+          debs=(spyc_*.deb)
+          [ -e "${debs[0]}" ] || { echo "::error::no debs in the archive"; exit 1; }
+          echo "archive OK: ${#debs[@]} deb(s), index verifies"
 
       - name: Upload the archive as the Pages artifact
         if: steps.guard.outputs.enabled == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,15 @@ jobs:
       # verified present because actionlint SILENTLY skips every `run:` block
       # and exits 0 without it, so an image change would otherwise turn this
       # step into a no-op that still reports green.
+      # shellcheck is PINNED rather than taken from the runner image. Its
+      # findings differ by version -- 0.11.0 does not report an SC2015 that the
+      # image's build does -- so an unpinned one makes the gate drift under the
+      # image and fails PRs that touched nothing. Same reasoning that moved
+      # cargo-deny off this path. Keep in step with the version the Makefile
+      # names, so a local run and CI agree.
+      - uses: taiki-e/install-action@v2.87.0
+        with:
+          tool: shellcheck@0.11.0
       - name: Lint workflows (actionlint + shellcheck)
         run: |
           ACTIONLINT_VERSION=1.7.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,29 @@ jobs:
       # a PR that touched no dependencies.
       - run: make fmt-check lint
 
+      # Workflow linting rides in THIS job because `Lint (fmt, clippy)` is
+      # already a required status check. A separate job would need adding to
+      # branch protection as a second operation, and until that happened a
+      # broken workflow could still merge — which is the exact gap this closes.
+      # The job name is left alone: renaming a required context deadlocks every
+      # open PR (see the note on this job's `name`).
+      #
+      # Pinned + checksum-verified rather than floating, same as cargo-llvm-cov
+      # in `coverage`. shellcheck ships on the ubuntu-latest image; it is
+      # verified present because actionlint SILENTLY skips every `run:` block
+      # and exits 0 without it, so an image change would otherwise turn this
+      # step into a no-op that still reports green.
+      - name: Lint workflows (actionlint + shellcheck)
+        run: |
+          ACTIONLINT_VERSION=1.7.12
+          ACTIONLINT_SHA256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+          curl -sSLo /tmp/actionlint.tar.gz \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
+          install -m 0755 /tmp/actionlint "$HOME/.cargo/bin/actionlint"
+          make lint-workflows
+
   test:
     name: Tests (cargo test --all-targets)
     runs-on: ubuntu-latest

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -92,7 +92,9 @@ jobs:
           MAC=$(sha "spyc-v${V}-macos-universal.tar.gz")
           LX=$(sha "spyc-v${V}-linux-x86_64.tar.gz")
           LA=$(sha "spyc-v${V}-linux-aarch64.tar.gz")
-          [ -n "$MAC" ] && [ -n "$LX" ] && [ -n "$LA" ] || { echo "missing a checksum for v${V}"; exit 1; }
+          if [ -z "$MAC" ] || [ -z "$LX" ] || [ -z "$LA" ]; then
+            echo "missing a checksum for v${V}"; exit 1
+          fi
           f=tap/Formula/spyc.rb
           # Each sha256 is attributed to the artifact named by the url above it,
           # so the formula's arch-block shape is free to change — macOS points

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ spyc is Model-View-Update. Keep these — they're what make it reason-about-able
 cargo build / cargo build --release   # or: make release
 make install      # release build + copy to ~/.local/bin
 make check        # fmt + clippy + test (CI gate; supply-chain is audit.yml)
+make lint-workflows # actionlint + shellcheck over .github/workflows (in CI's lint job)
 make fuzz         # nightly + cargo-fuzz, on-demand (NOT in check)
 make changelog    # preview the pending CHANGELOG section
 make release-prep VERSION=x.y.z       # step 1, on a release branch: set version + changelog + commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,11 @@ We use GitHub pull requests. The target branch is `main`.
    which is the wrong thing to do on every commit. `audit.yml` owns
    them; run `make deny` by hand if you changed a dependency. If you touched
    `cfg(target_os = "linux")` code, also run `make lint-linux` —
-   host clippy compiles that code out. `make aislop` is an advisory
-   AI-slop scan (net-new findings vs the baseline).
+   host clippy compiles that code out. If you touched anything under
+   `.github/workflows/`, run `make lint-workflows` (actionlint +
+   shellcheck; `brew install actionlint shellcheck`) — CI runs it in
+   the lint job. `make aislop` is an advisory AI-slop scan (net-new
+   findings vs the baseline).
 
 4. **Push and open a PR** on GitHub:
    ```sh
@@ -241,6 +244,17 @@ GitHub Actions (`.github/workflows/ci.yml`) runs the quality gate on every PR
 (fmt + clippy as one job, tests in parallel) and adds a coverage gate on
 merges to `main`. All jobs must pass before merge. CI pins the toolchain via
 `rust-toolchain.toml`, so it matches your local `make check`.
+
+**The lint job also lints the workflows themselves** (`make lint-workflows`:
+actionlint, plus shellcheck over every `run:` block). Worth knowing why that
+earns a place in the gate: most workflows here never execute on a PR — `apt.yml`
+fires on release, `release.yml` on a tag — so a break in one is invisible until
+the moment it matters, and the apt channel deploys to Pages, which has no
+rollback. A dependabot bump of `upload-pages-artifact` passed a fully green
+check set while silently dropping a file from the published archive (#444).
+Invariants no linter can infer — like that action needing
+`include-hidden-files: true` — are pinned as guard tests in `src/lib.rs`
+instead.
 
 **Supply chain lives in `.github/workflows/audit.yml`**, not the PR gate: weekly
 plus `workflow_dispatch`, running the full `make deny` (advisories, bans,

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,8 @@ lint-workflows: ## Lint .github/workflows (actionlint + shellcheck over every `r
 		echo "  install with: brew install shellcheck  (CI pins 0.11.0 — findings differ by version)"; \
 		exit 1; \
 	}
+	@actionlint --version | head -1 | sed 's/^/actionlint /'
+	@shellcheck --version | sed -n 's/^version: /shellcheck /p'
 	actionlint -no-color
 
 .PHONY: fmt

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ lint-workflows: ## Lint .github/workflows (actionlint + shellcheck over every `r
 	}
 	@command -v shellcheck >/dev/null 2>&1 || { \
 		echo "shellcheck not found — actionlint would silently skip every run: block and exit 0."; \
-		echo "  install with: brew install shellcheck"; \
+		echo "  install with: brew install shellcheck  (CI pins 0.11.0 — findings differ by version)"; \
 		exit 1; \
 	}
 	actionlint -no-color

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,28 @@ lint-linux: ## Clippy for the Linux target (catches OS-gated lints; needs zig + 
 	CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="cargo-zigbuild zig cc --" \
 	cargo clippy --locked --all-targets --target $(LINUX_LINT_TARGET) -- -D warnings
 
+# actionlint parses every workflow and runs shellcheck over each `run:` block —
+# the half that matters here, since the release-critical workflows are mostly
+# bash and CI never executes them (apt.yml fires on release, not on a PR).
+#
+# The shellcheck probe below is load-bearing, not politeness: with no shellcheck
+# on PATH actionlint does not warn, it silently drops the integration and exits
+# 0. Measured on this tree — the one real finding vanished and the run went
+# green. A gate that checks almost nothing while reporting success is the
+# failure mode src/guard_support.rs exists to document.
+.PHONY: lint-workflows
+lint-workflows: ## Lint .github/workflows (actionlint + shellcheck over every `run:` block)
+	@command -v actionlint >/dev/null 2>&1 || { \
+		echo "actionlint not found — install with: brew install actionlint"; \
+		exit 1; \
+	}
+	@command -v shellcheck >/dev/null 2>&1 || { \
+		echo "shellcheck not found — actionlint would silently skip every run: block and exit 0."; \
+		echo "  install with: brew install shellcheck"; \
+		exit 1; \
+	}
+	actionlint -no-color
+
 .PHONY: fmt
 fmt: ## Format code
 	cargo fmt --all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1509,3 +1509,106 @@ mod fuzz_target_registration_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod pages_artifact_guards {
+    use std::path::{Path, PathBuf};
+
+    fn repo() -> &'static Path {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+    }
+
+    fn workflows() -> Vec<PathBuf> {
+        let mut found: Vec<PathBuf> = std::fs::read_dir(repo().join(".github/workflows"))
+            .expect("read .github/workflows")
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|e| e == "yml" || e == "yaml"))
+            .collect();
+        found.sort();
+        found
+    }
+
+    /// Line range of the workflow step containing `uses_idx`, as `[start, end)`.
+    ///
+    /// A step is its `- ` bullet plus every line indented past it, so the span
+    /// ends at the next bullet at the same indent or at any dedent.
+    fn step_span(lines: &[&str], uses_idx: usize) -> (usize, usize) {
+        let indent_of = |l: &str| l.len() - l.trim_start().len();
+        let mut start = uses_idx;
+        while start > 0 && !lines[start].trim_start().starts_with("- ") {
+            start -= 1;
+        }
+        let indent = indent_of(lines[start]);
+        let mut end = start + 1;
+        while end < lines.len() {
+            let line = lines[end];
+            if !line.trim().is_empty() && indent_of(line) <= indent {
+                break;
+            }
+            end += 1;
+        }
+        (start, end)
+    }
+
+    /// `actions/upload-pages-artifact` v4 began excluding dotfiles from the
+    /// tarball (`--exclude=.[^/]*`), so the archive's `.nojekyll` reaches Pages
+    /// only while the step opts back in with `include-hidden-files: true`.
+    ///
+    /// No linter can see this: the workflow stays valid YAML, every action
+    /// input is legal, and `apt.yml` never runs on a PR — it fires on release.
+    /// The v3 -> v5 bump (#444) passed a fully green check set while silently
+    /// dropping the file, and Pages has no rollback.
+    #[test]
+    fn every_pages_upload_keeps_hidden_files() {
+        let mut checked = 0;
+        for path in workflows() {
+            let src = std::fs::read_to_string(&path).expect("read workflow");
+            let lines: Vec<&str> = src.lines().collect();
+            for (i, line) in lines.iter().enumerate() {
+                if !line.contains("uses:") || !line.contains("actions/upload-pages-artifact") {
+                    continue;
+                }
+                checked += 1;
+                let (start, end) = step_span(&lines, i);
+                let value = lines[start..end]
+                    .iter()
+                    .find_map(|l| l.trim().strip_prefix("include-hidden-files:"))
+                    .map(|v| v.trim().trim_matches(|c| c == '"' || c == '\''));
+                assert_eq!(
+                    value,
+                    Some("true"),
+                    "{}: the upload-pages-artifact step must set \
+                     `include-hidden-files: true` (found {value:?}). Without it the \
+                     action drops every dotfile from the artifact, which silently \
+                     removes the archive's .nojekyll from the deployed site.",
+                    path.display(),
+                );
+            }
+        }
+        // A rename of the action would otherwise leave this guard passing while
+        // inspecting nothing — the fail-open shape src/guard_support.rs exists
+        // to document.
+        assert!(
+            checked > 0,
+            "no upload-pages-artifact step found in any workflow — this guard \
+             is inspecting nothing; retarget it or delete it"
+        );
+    }
+
+    /// The other half of the pair above: the flag is only load-bearing while
+    /// something in the archive actually starts with a dot. If that write goes
+    /// away this fails, so the flag's continued value gets a human decision
+    /// rather than quietly becoming cargo cult.
+    #[test]
+    fn the_apt_archive_still_writes_the_dotfile_the_flag_protects() {
+        let apt = std::fs::read_to_string(repo().join(".github/workflows/apt.yml"))
+            .expect("read apt.yml");
+        assert!(
+            apt.lines().any(|l| l.trim() == "touch .nojekyll"),
+            "apt.yml no longer writes .nojekyll — decide whether \
+             `include-hidden-files: true` on the upload step is still needed, \
+             then update or drop this guard and its pair"
+        );
+    }
+}


### PR DESCRIPTION
## Why

Most workflows in this repo never execute on a PR — `apt.yml` fires on release, `release.yml` on a tag — so a break in one is invisible until the moment it matters. The apt channel deploys to Pages, which has no rollback.

#444 is the concrete case: it bumped `actions/upload-pages-artifact` across a major version that began excluding dotfiles from the artifact, which would have silently dropped the archive's `.nojekyll` from the published apt repo. Every required check reported green.

## What

**`actionlint` in the PR gate**, pinned and sha256-verified (same shape as `cargo-llvm-cov` in the `coverage` job), behind `make lint-workflows` so it runs locally too. It lints every workflow and runs shellcheck over each `run:` block.

It rides in the existing `lint` job rather than getting its own, because `Lint (fmt, clippy)` is already a required status check. A separate job would need a second branch-protection change, and until that landed a broken workflow could still merge — the exact gap being closed. The job name is deliberately untouched: renaming a required context deadlocks every open PR.

**The shellcheck probe in the make target is load-bearing, not politeness.** With no shellcheck on `PATH`, actionlint doesn't warn — it silently drops the integration and exits 0. Measured on this tree: the one real finding vanished and the run went green. That's the failure mode `src/guard_support.rs` exists to document, so the target fails loudly instead.

**Two guard tests in `src/lib.rs`** for the invariants no workflow linter can infer:

- every `upload-pages-artifact` step sets `include-hidden-files: true`
- `apt.yml` still writes the `.nojekyll` that flag protects — so removing one forces a decision about the other

Both are scoped to the step, so the flag sitting on a *neighbouring* step does not satisfy them. There's a precedent for workflow-reading guards here already (`fuzz_target_registration_tests`).

**One real fix.** The new lint's only finding across all six workflows was SC2012 in `apt.yml`: `ls spyc_*.deb | wc -l` miscounts a filename containing a newline — verified locally reporting `2` for one file. Now globs into an array, which also makes the unmatched-glob case explicit instead of riding on a suppressed `ls` error.

## Verification

- `make check` green; `make lint-workflows` clean across all six workflows
- Guard bite-checked five ways, each watched failing: flag removed; flag set to `false`; action renamed (so the guard would inspect nothing); `.nojekyll` write removed; **flag moved to the preceding step** — a naive `contains()` would have passed that one
- Both make-target error paths bite (no actionlint / no shellcheck)
- Pinned Linux checksum verified against a fresh download, and the tar member the step extracts confirmed present