### PR TITLE
docs(roadmap): reframe the thesis on the working set, open the 3.0 horizon

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ The agent asks spyc *what is the cursor on, what is staged, what is picked* —
 no copy-paste, no path description. Pick three files, ask a question, and it
 sees your selection. When it names a path in its answer, `gf` jumps you there.
 
-The file manager is the shared workspace where you and your agents actually
-work — not a file list bolted onto a chat window.
+Sharing a terminal with an agent usually means sharing a *screen* — cells and
+scrollback for it to scrape. What spyc shares is the working set: cursor,
+picks, filter, branch, worktree, as structured state it can query. The file
+manager is the shared workspace where you and your agents actually work — not a
+file list bolted onto a chat window.
 
 ## What it is
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # spyc roadmap
 
-The strategy layer — thesis, current state, the 2.2 and 2.3 arcs, non-goals, and
-the decisions log. The per-item **backlog lives in [GitHub Issues](https://github.com/Tripstack-Corp/spyc/issues)**
+The strategy layer — thesis, current state, the 2.2, 2.3 and 3.0 arcs,
+non-goals, and the decisions log. The per-item **backlog lives in [GitHub Issues](https://github.com/Tripstack-Corp/spyc/issues)**
 (organized on the [roadmap board](https://github.com/orgs/Tripstack-Corp/projects/1));
 `CHANGELOG.md` is the shipped history. Detailed designs for not-yet-started work
 live in `docs/drafts/*_PLAN.md`; shipped or parked plans are archived in
@@ -9,21 +9,22 @@ live in `docs/drafts/*_PLAN.md`; shipped or parked plans are archived in
 
 ## Thesis
 
-spyc is a vi-keyboard-driven file commander that exposes itself to an AI coding
-agent as a queryable context source. The target user is a developer who already
-thinks in vi motions and wants Claude Code living in the same workspace -- not
-one window over, not in a browser tab, in the same session, sharing context.
+spyc is the working set, shared. A vi-keyboard-driven file commander is the
+human's view of it; MCP is the agent's. A multiplexer shares a *screen* with an
+agent — cells, bytes, scrollback to scrape. spyc shares state that already
+means something: cursor, picks, inventory, filter, branch, worktree. The target
+user is a developer who thinks in vi motions and wants their agents in the same
+session, reading the same context — not one window over, not in a browser tab.
 
-The MCP server shifted the tool's nature: spyc isn't just "a file manager with
-Claude in a pane." It's a file manager that Claude can query -- current
-directory, cursor, picks, inventory, filter, git branch -- via a standard
-protocol. That bidirectional awareness is the positioning that differentiates
-spyc from `tmux` + `claude`.
+The arc follows from that sentence. 2.2 gives every participant an identity
+(pane-identity transport). 2.3 grows the session to everything you're working
+on (Projects: one process, many working sets, one attention signal). 3.0 makes
+the session outlive the terminal that started it.
 
-Every other feature -- picks, inventory, pager, status bar, sessions -- is
-supporting infrastructure that makes the split-pane workflow fast and
-comfortable. The roadmap is organized accordingly: the pane-and-agent
-integration is the defining work track, not the trailing milestone.
+The benchmark stays `tmux` + `claude` — better on context today, better on
+durability after 3.0, at which point the target user's stack simply no longer
+contains tmux. That is the full extent of the tmux claim: we don't replace it
+for anyone else; we remove the reason our user runs it.
 
 ## Where we are (v2.1.1)
 
@@ -165,10 +166,47 @@ per-process, so aggregating attention across projects costs little. And the
 pane-identity transport (2.2) gives every MCP connection an identity that
 extends to project attribution.
 
-Out of scope in 2.3 and after: frame mirroring, input forwarding, headless or
-`--detached` peers, cross-process discovery, and any CounterTop revival.
+Out of scope permanently: frame mirroring, input forwarding, cross-process
+discovery, and any CounterTop revival. Headless needs the finer distinction.
+Headless *peers* are dead with the rest of that list — a second spyc that
+another spyc discovers, mirrors or forwards to. The daemonized *monolith*
+returns in 3.0, and it is not a peer: one process, nothing mirrored, and the
+client is a renderer rather than an instance. See "The 3.0 horizon" below.
 `docs/drafts/PROJECTS_PLAN.md` — a 2.2 deliverable — is where the design gets
 argued. Tracked as [#99](https://github.com/Tripstack-Corp/spyc/issues/99).
+
+## The 3.0 horizon: Slow Cooker (durable sessions)
+
+The goal is that spyc stops needing tmux underneath it. Detach, close the
+laptop, let the agents keep working; `spyc -a` restores the client and
+everything is where you left it.
+
+The shape is the daemonized monolith. One headless spyc owns the PTYs, the
+agent children and the Model; a thin client attaches over the existing unix
+socket and renders. One attached client at a time. Explicitly not a
+general-purpose multiplexer, not multi-client, no cross-machine protocols, and
+no binary state-replication ambitions — that is Superlogical's fight and
+zellij's category, and neither is ours.
+
+The architecture already affords it. MVU's single message channel means every
+inter-message tick is a quiescent, mutation-safe snapshot boundary, so state
+capture falls out of the pre-2.0 migration rather than needing new machinery.
+The 2.3 Projects work supplies the rest: the per-project state inventory and
+the recovery manifest are the same inventory an attach snapshot needs, which is
+why `PROJECTS_PLAN.md` is asked to answer for each field whether it serializes
+or is rebuilt client-side.
+
+The user-facing words are **detach** and **attach**. "Session" stays an
+agent-conversation term — session forking, `/resume`, session pinning — and the
+durable thing gets no noun of its own: it is just spyc, still running.
+
+Scope does not commit until the VT-engine spike (`docs/drafts/VT_ENGINE_SPIKE.md`,
+a separate engagement) reports. Screen reconstruction fidelity becomes
+load-bearing the moment a client reattaches, and reattaching from a *different*
+terminal emulator — cell size, kitty/sixel capability and colour depth all
+changing mid-session — is the known-hard bug class to price before committing
+to it. Tracked as a `3.0` milestone once issues exist; none are created yet.
+
 
 ## Backlog & roadmap
 
@@ -183,8 +221,8 @@ labeled by `area:*` / `type:*` and organized on the **[roadmap board](https://gi
 - **`needs-repro`** — reported, not yet reproducible; evidence wanted before design.
 - **`good first issue`** — small, self-contained entry points.
 
-This file is the *strategy* layer — thesis, current state, the 2.2 and 2.3
-arcs, non-goals, and the decisions log. The per-item backlog lives in Issues;
+This file is the *strategy* layer — thesis, current state, the 2.2, 2.3 and
+3.0 arcs, non-goals, and the decisions log. The per-item backlog lives in Issues;
 detailed designs for not-yet-started work are in `docs/drafts/*_PLAN.md`;
 shipped or parked designs are archived under `docs/archive/`.
 
@@ -215,6 +253,10 @@ and the roadmap committing to that saves a lot of drift.
   longer a non-goal. What stays out of scope is mouse-first design —
   every action keeps a keybinding, and no affordance is reachable only
   by pointer. Keys remain the API.
+- **A general-purpose multiplexer.** Multi-client attach, cross-machine
+  session protocols, multiplayer, production-ops surfaces — the funded
+  players can have that category. The durability work in 3.0 is scoped to
+  one user, one machine, one attached client, and stops there.
 - **tmux command compatibility.** We have our own bindings.
 - **Persistent search index** (tantivy/ctags). Ripgrep on a 100K-file
   repo is sub-second cold; the maintenance burden isn't worth it.
@@ -301,12 +343,29 @@ so we don't re-litigate them. Full history in CHANGELOG.md.
   exists as the prep refactor. Depends on the pane-identity transport
   (2.2) for project attribution; `docs/drafts/PROJECTS_PLAN.md`, a 2.2
   deliverable, is where it gets argued.
+- **The 3.0 horizon opens on durable sessions, via the daemonized
+  monolith** (2026-09-04). A headless spyc owns the PTYs, agent children and
+  Model; a thin client attaches over the existing unix socket and renders.
+  One user, one machine, one attached client — not a multiplexer. What
+  changed is the premise, not the appetite: the `^Z` entry above reasons
+  about children tied to a dying spyc PID under a dying TTY, and a daemon's
+  children hang off a process that doesn't die. That entry stays as written;
+  the log records what was decided when, and doesn't rewrite it. This is the
+  CounterTop pattern a second time — the parking rationale named mechanisms
+  (mirroring, forwarding, discovery), not the goal, and those mechanisms stay
+  archived, while a monolith needs none of them. Positioning never says "tmux
+  replacement": the claim is only that our user's stack stops containing
+  tmux, and the tmux-command-compatibility non-goal is unchanged. Vocabulary
+  is fixed to detach/attach, with "session" reserved for agent
+  conversations. Scope does not commit until the VT-engine spike reports —
+  reattaching into a different terminal emulator is the bug class to price
+  first.
 
 ## Doc map
 
 | Doc | Role |
 |---|---|
-| `ROADMAP.md` | This file — strategy, the 2.2 and 2.3 arcs, non-goals, decisions log. |
+| `ROADMAP.md` | This file — strategy, the 2.2, 2.3 and 3.0 arcs, non-goals, decisions log. |
 | [GitHub Issues](https://github.com/Tripstack-Corp/spyc/issues) + [roadmap board](https://github.com/orgs/Tripstack-Corp/projects/1) | The live backlog — features, fixes, ideas; labeled + milestoned. |
 | `docs/archive/BACKLOG_DRAFT_NOTES.md` | Archived raw intake backlog — open items migrated to Issues (2026-07); kept as history. |
 | `CHANGELOG.md` | Shipped history (git-cliff, conventional commits). |
@@ -334,7 +393,7 @@ so we don't re-litigate them. Full history in CHANGELOG.md.
 | `docs/archive/V1_60_PLAN.md` | Archived design — CounterTop multi-instance hub. Parked as an architecture; the multi-project goal it targeted is reopened for 2.3 on the monolith route (see the decisions log). |
 | `docs/archive/V1_70_PLAN.md` | Archived design — Mise en Place typed addressability + crate split. Speculative; MCP already covers the basics. |
 | `docs/archive/engagements/` | Engagement briefs and deliverables (the review-remediation and cleanup rounds) — which PR closed which finding. |
-| `docs/COMPETITIVE_REVIEW.md` | Consolidated competitive review + GTM: the AI coding-agent-manager category (§1–§1c: herdr, psmux, claude-code-ide.el) plus the TUI file-manager lane (§1d: Yazi, folded 2026-07-02). Refresh on a competitor's next major. (Standalone Yazi original archived at `docs/archive/YAZI_COMPETITIVE_REVIEW.md`.) |
+| `docs/COMPETITIVE_REVIEW.md` | Consolidated competitive review + GTM: the AI coding-agent-manager category (§1–§1c: herdr, psmux, claude-code-ide.el), the TUI file-manager lane (§1d: Yazi, folded 2026-07-02; §1e: lf), and the session layer beneath both (§1f: Superlogical, zmx). Refresh on a competitor's next major. (Standalone Yazi original archived at `docs/archive/YAZI_COMPETITIVE_REVIEW.md`.) |
 | `docs/archive/` | Shipped plans, kept as historical record. |
 
 > **Note on pending plans:** `AUTO_APPROVAL_PLAN`, `PANE_STARTUP_TABS_PLAN`

--- a/docs/COMPETITIVE_REVIEW.md
+++ b/docs/COMPETITIVE_REVIEW.md
@@ -7,7 +7,9 @@ for verbatim text and correct attribution. spyc straddles two lanes — the
 agent-manager category (§1, §1a–§1c) and the TUI **file-commander** lane, whose
 incumbent Yazi is covered in §1d (folded in 2026-07-01 from the standalone Yazi
 review; the raw original is archived at `docs/archive/YAZI_COMPETITIVE_REVIEW.md`)
-and whose minimalist counterweight lf is covered in §1e.
+and whose minimalist counterweight lf is covered in §1e. §1f records a third
+thing — the **session layer** beneath both lanes (Superlogical, zmx), added
+2026-09-04 on a stated-facts basis rather than the mine-and-verify standard.
 
 > **Method.** Two deep-research passes. The first (v1) drew only on vendor
 > primary sources (GitHub READMEs, changelogs, marketing pages) and produced a
@@ -76,6 +78,8 @@ lane** is where spyc lives — and it already has occupants.
 | **claude-code-ide.el** | editor plugin | 1.6k★ · 109 forks · Emacs. The closest **architectural** twin outside the TUI-manager space: Claude Code runs in a hosted terminal pane (vterm/eat/ghostty) behind a **bidirectional MCP bridge** that pushes live editor context (file, selection, diagnostics, project) to Claude automatically. Different host (a 40-year-old editor, not a file commander) and different center of gravity — the buffer/editor is the noun, dired is a visited mode, not the driving UI. See §1c. |
 | **Yazi** | TUI · cross-plat · **file manager** | ~41.3k★ (2026-08-12) · Rust · the gold-standard TUI file commander (image preview, plugins + package manager, async scheduler). A *different lane* — no agent concept, no MCP; it sets the bar for the file-manager half of spyc's identity, not the agent half. See §1d. |
 | **lf** | TUI · cross-plat · **file manager** | 9.5k★ · Go · MIT · ranger-inspired minimalist, now **community-maintained** (founder's last commit 2024-03-31). Ships the lane's only external **read+write** control surface (`lf -remote send`/`query`) — yet zero agent framing, and its README *Non-Features* (no tabs, no builtin pager/editor, no builtin file ops) are the precise inverse of spyc's integration bet. See §1e. |
+| **Superlogical** | session layer | Launched 2026-07-29 · Hashimoto, Pearkes, Monk, Simpson · Notable Capital + Amplify Partners. Server-side terminal multiplexer on MIT libghostty — "the multiplexer for all work." **Waitlist only, nothing shipped** as of 2026-09-04. A *layer beneath* spyc, not a manager. See §1f. |
+| **zmx** | session layer | Zig · the unbundled form of tmux persistence: daemon per session over a unix socket, passthrough to the PTY, libghostty-vt as a shadow state machine for rehydrating a client on reattach. Deliberately **no windows, tabs or splits**. See §1f. |
 | **long tail** | mixed | Chorus · Vibetunnel · VibeKanban · Mux · Happy · AutoClaude · Codirigent · Centurion · AgentWire · Baton … |
 | **spyc** | TUI · cross-plat | Rust/ratatui · in-process gix worktrees · MCP bridge · vi-keyboard **file+process+agent manager** (not just a multiplexer). |
 
@@ -698,6 +702,52 @@ the agent axis (§4) and not file-manager feature parity.
 6. **Re-run this section** when lf cuts r43, or the moment anyone publishes an MCP
    shim over `lf -remote`. That shim is the entry vector into spyc's lane, and it
    would show up on GitHub well before it shows up in an HN thread.
+
+---
+
+## 1f. The session layer — Superlogical and zmx (2026-09-04)
+
+A second wave forming under the manager category: not agent managers at all,
+but the **session layer** those managers sit on. Recorded here because it is
+the closest thing to a structural challenge spyc has, and because it sharpens
+the thesis by contrast rather than by overlap.
+
+> **Provenance.** Unlike §1a–§1e, this section was not produced by the mine-and-
+> verify pass described in the Method note. It records the facts as supplied in
+> the strategy brief that prompted it — launch date, people, backers, licence
+> basis, shipping status, and stated architecture. Nothing here is a fetched
+> quote, and no claim is made about either project's unshipped internals. Apply
+> the document's normal standard when either ships something to read.
+
+**[Superlogical](https://superlogical.com)** launched **2026-07-29** — Mitchell
+Hashimoto's new company, founded with Jack Pearkes, Alasdair Monk and Hector
+Simpson, backed by Notable Capital and Amplify Partners. The stated aim is a
+**server-side terminal multiplexer** built on MIT-licensed **libghostty** — "the
+multiplexer for all work." As of 2026-09-04 it is **waitlist only; nothing has
+shipped**, so there is no surface to evaluate and none is guessed at here.
+
+**[zmx](https://github.com/neurosnap/zmx)** (Zig) shipped the unbundled form of
+what tmux's persistence actually is: a **daemon per session** over a unix
+socket, passthrough to the PTY, with **libghostty-vt as a shadow state machine**
+used only to rehydrate a client on reattach. Deliberately **no windows, no tabs,
+no splits** — persistence without the multiplexer wrapped around it.
+
+**Why this does not move the thesis — and what it confirms.** Both share a
+*screen* with the agent: cells, bytes, scrollback to scrape. spyc shares the
+*working set* — cursor, picks, inventory, filter, branch, worktree — over MCP,
+as state that already means something. A better multiplexer underneath spyc is
+not a competitor to that; it is a better floor.
+
+Where it does touch the roadmap is durability. zmx is the useful proof that the
+persistence half is separable from the multiplexer half, which is the shape
+spyc's 3.0 horizon takes: one headless process, one attached client, no
+mirroring and no protocol ambitions (see ROADMAP.md). The funded, general-purpose
+version of that category is Superlogical's fight, and ROADMAP.md's non-goals now
+say so explicitly.
+
+**Watch conditions.** Superlogical shipping anything at all — the first release
+is the first evaluable fact. zmx growing a context or agent-integration surface,
+which would move it out of the session layer and into this category.
 
 ---
 

--- a/docs/drafts/V2_2_PLAN.md
+++ b/docs/drafts/V2_2_PLAN.md
@@ -342,6 +342,11 @@ plan does not answer them.
    agent-awareness channel — `report_status`, the per-agent status hooks, the
    `Blocked`/`Done` transition, `Effect::Notify`, the visual bell — and what
    has to be new to answer "which agent, in which project, needs me".
+7. **Attach-awareness of the state inventory.** For every field question 1
+   places in a project struct or leaves global, note whether it serializes for
+   a future attach snapshot or is rebuilt client-side. Question 3's recovery
+   manifest is written knowing the 3.0 attach snapshot is its superset — one
+   inventory, two consumers.
 
 ## Non-goals for 2.2
 
@@ -436,7 +441,7 @@ the substitution refuses a non-UTF-8 path the way `expand_percent` does.
 reading half documented and the display half recorded as out of scope. Both
 count as done; shipping neither does not.
 
-**`PROJECTS_PLAN.md` —** All six questions in §7 answered, with a decision and
+**`PROJECTS_PLAN.md` —** All seven questions in §7 answered, with a decision and
 a reason for each, and the doc approved before 2.3 opens.
 
 ## Docs each PR must carry (same commit, not a follow-up)


### PR DESCRIPTION
Documentation only. All nine tasks done; two carry a judgment call, noted below.

## 1–2. Thesis rewrite + the 3.0 horizon

Thesis replaced with the working-set framing. **I cut the "supporting infrastructure" paragraph** rather than keeping it: the new thesis names picks and inventory *as* the working set, so a paragraph two lines below calling them "supporting infrastructure that makes the split-pane workflow fast and comfortable" now contradicts it. Its surviving idea — that agent integration is the defining track — is carried by the new arc paragraph.

New section "The 3.0 horizon: Slow Cooker (durable sessions)" sits directly after the 2.3 horizon: goal, the daemonized-monolith shape with its explicit non-ambitions, why MVU's single message channel already affords the snapshot boundary, the detach/attach vocabulary, and the VT-engine spike as the gate. Prose, not bullets.

## 3. Out-of-scope amendment

"Out of scope in 2.3 and after" → "Out of scope permanently" for mirroring, forwarding, cross-process discovery and CounterTop, with headless split precisely: headless *peers* dead, the *monolith* returning in 3.0 as something that is not a peer, pointing at the new section.

## 4, 7, 8. Decisions entry, self-references, non-goal

Decisions entry dated 2026-09-04, including why the `^Z` premise changed and that the original entry is left untouched. Three self-references updated (header, "Backlog & roadmap" closer, doc-map row) — grepped, and those three are the only ones in the tree.

**Not changed: the milestone signpost list.** Adding a ``3.0`` row would advertise a GitHub milestone that doesn't exist, and this engagement creates none. The 3.0 section says so itself.

## 5. PROJECTS_PLAN acceptance question 7

Added, and the exit-criteria count six → seven. Grepped for other counts: the remaining "six"/"seven" instances refer to the bug set and the work-item table, not §7 — left alone. §7 now has exactly seven numbered questions. "Non-goals for 2.2" untouched.

## 6. README

Two sentences into "Why spyc?" — screen-to-scrape versus working-set-as-queryable-state. No mention of 3.0, detach, attach or Slow Cooker; verified by grep. Tagline unchanged.

## 9. COMPETITIVE_REVIEW — added as §1f

The 1a–1e per-competitor structure took it cleanly. Both projects are the same wave, so they share one section rather than getting one each.

**One thing I added that wasn't asked for:** a provenance note. That document's stated method is that every claim was fetched and verified, and these facts come from the engagement brief instead. Recording them without saying so would quietly lower the document's evidence bar. The note says what standard they meet and asks for the normal one when either ships. Nothing is claimed about Superlogical's unshipped internals. Also updated the document header and landscape table, and ROADMAP's doc-map row — which was already stale, omitting §1e.

## Verification

- ``make check`` green
- ``Slow Cooker`` appears exactly once in the tree, in ROADMAP.md
- All 31 relative links in the changed files resolve. ``docs/drafts/VT_ENGINE_SPIKE.md`` doesn't exist yet, so it's referenced as inline code rather than a link — nothing to break when the separate engagement lands it
- Section order reads 2.2 → 2.3 → 3.0 → backlog