### PR TITLE
chore(build): give the panic net a rationale that is still true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,15 +211,35 @@ lto = "thin"
 codegen-units = 1
 strip = "symbols"
 # `unwind` instead of `abort` so `std::panic::catch_unwind` actually
-# catches panics — used in `pane::Pane::process_bytes_safe` to recover
-# from vt100 0.15's known unwrap-on-edge-case panic (hits
-# `Option::unwrap` deep in screen.rs for some valid escape sequences,
-# e.g. nvim's exit-from-alt-screen after specific scroll state). With
-# `abort` a single panicking byte stream took down the entire spyc
-# process, dropping every other pane along with it. Slightly larger
-# binary + minor codegen change is a fine trade for not crashing the
-# user's session. Worth keeping as a safety net even after a vt100
-# upgrade.
+# catches panics — `pane::parser_worker` wraps every `process()` call in
+# one and rebuilds a torn parser, so one bad byte stream costs a blank
+# grid instead of the whole process and every other pane with it.
+#
+# This comment used to give the reason as vt100's DECRC-after-resize
+# panic (nvim leaving the alternate screen). **That one was fixed
+# upstream in 0.16.2, which we ship** — so the stated reason had
+# expired while the net stayed load-bearing, which is an invitation to
+# delete a net that is still catching things. What it actually catches
+# on 0.16.2, measured by the spike's `vt100_panics` probe over the open
+# upstream reports (see `docs/drafts/VT_ENGINE_SPIKE.md` §5):
+#
+#   * a wrap on a 1-row screen                 (issue #37)
+#   * a double-width char on a 1-column screen (issue #37)
+#   * a wide char split by a shrink, then written  (#37 / #28)
+#   * the same setup, then erased                  (#28)
+#
+# All four are reachable: `Pane::resize` and `pane_spawn_size` clamp
+# both dimensions with `.max(1)`, which lands exactly on the 1-row and
+# 1-column cases. Structured-random escape streams panic vt100 on 2.87%
+# of iterations. We are not carrying patches for these and not adding a
+# geometry floor — the engine swap lands this release (V2_2_PLAN.md §8),
+# and patching a parser we are leaving would make spyc its fork.
+#
+# When the engine flips, this list stops being the reason but the
+# setting stays: `catch_unwind` around any terminal state machine's
+# byte processing is cheap insurance against a parser bug in untrusted
+# input, and the alternative is `abort`. Retiring it is not part of
+# removing vt100.
 panic = "unwind"
 
 [profile.release-static]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -742,8 +742,10 @@ impl crossterm::Command for DisableWheelReporting {
 /// A process-global rather than a field on `ViewState`, because two of the three
 /// things that change this state run outside `App` and cannot reach its fields:
 /// [`restore_terminal`] and the **panic hook**. The hook is not exit-only —
-/// `pane::Pane` deliberately `catch_unwind`s a known vt100 panic (nvim leaving
-/// the alternate screen is the documented trigger) and spyc keeps running — so
+/// `pane::parser_worker` deliberately `catch_unwind`s a parser panic on
+/// untrusted child output (vt100 0.16.2 has four such classes reachable at
+/// spyc's geometry clamp; `Cargo.toml`'s `[profile.release]` lists them) and
+/// spyc keeps running — so
 /// with the flag on `ViewState` that path disabled reporting at the terminal
 /// while `App` still believed it was on. `settle_mouse_mode` then saw no
 /// divergence and never re-enabled: the mouse was dead for the rest of the

--- a/src/pane/mod.rs
+++ b/src/pane/mod.rs
@@ -661,9 +661,12 @@ fn append_pty_debug(bytes: &[u8]) {
 }
 
 /// Replace a torn parser with a fresh one at its CURRENT size — NOT a captured
-/// adopt-time size. (vt100 0.15 can panic on some valid escape sequences, e.g.
-/// nvim's exit-from-alt-screen; the worker's `catch_unwind` calls this to
-/// recover.) `Pane::resize` coalesces same-size resizes, so a stale size would
+/// adopt-time size. (vt100 0.16.2 still panics on valid input at a 1-row or
+/// 1-column screen and on a wide char split by a shrink — all reachable,
+/// because the geometry clamps stop at 1; the worker's `catch_unwind` calls
+/// this to recover. The nvim exit-from-alt-screen panic this used to name was
+/// fixed in 0.16.2. `Cargo.toml`'s `[profile.release]` carries the full list.)
+/// `Pane::resize` coalesces same-size resizes, so a stale size would
 /// never get corrected. Reading the live size off the parser keeps the
 /// recovered grid the right shape; the size fields survive a `process` panic
 /// (it tears cell/cursor state, not dimensions).


### PR DESCRIPTION
Stage 3 of the engine series. Comment-only; no behaviour change.

## The problem with the old comment

`[profile.release]`'s `panic = "unwind"` explained itself as recovery from
vt100's DECRC-after-resize panic — nvim leaving the alternate screen. **That was
fixed upstream in 0.16.2, which we ship** (`git merge-base --is-ancestor
7076e0f v0.16.2`). So a load-bearing setting was justified by an expired
reason, which is an invitation to delete a net that is still catching things.

It also named `pane::Pane::process_bytes_safe` — a function that no longer
exists. The `catch_unwind` moved into `pane::parser_worker` when parsing went
off-thread.

## What the net actually catches

From the spike's `vt100_panics` probe over the open upstream reports
(`VT_ENGINE_SPIKE.md` §5), on 0.16.2:

| case | upstream |
|---|---|
| a wrap on a 1-row screen | doy/vt100-rust#37 |
| a double-width char on a 1-column screen | #37 |
| a wide char split by a shrink, then written | #37 / #28 |
| the same setup, then erased | #28 |

All four are **reachable**: `Pane::resize` and `pane_spawn_size` clamp both
dimensions with `.max(1)`, which lands exactly on the 1-row and 1-column cases.
Structured-random escape streams panic vt100 on 2.87% of iterations.

## Three sites, not one

Two sibling comments cited the same fixed panic and are corrected in the same
commit — `rebuild_parser_preserving_size`, and `MOUSE_CAPTURE_ON`'s note about
why the panic hook is not exit-only. Fixing one of three named sites and calling
it done is the failure mode AGENTS.md records as *"a finding naming N sites is
closed when N are fixed"*, so all three go together.

## Deliberately not done

No vt100 patches and no geometry floor, per `V2_2_PLAN.md` §8. The engine swap
lands this release; patching a parser we are leaving would make spyc its fork,
and a floor is a second mechanism to maintain for one release. The comment says
so, so the next reader does not re-litigate it.

The comment also records what survives the flip: this list stops being the
reason but the **setting stays**, because `catch_unwind` around any terminal
state machine's byte processing is cheap insurance against a parser bug in
untrusted input, and the alternative is `abort`. Retiring it is not part of
removing vt100 (#453).

`make check-ci`: `=== GATE: PASS ===`, including the
`comments_carry_no_reasoning_leakage` and Canadian-English prose guards.

Generated with [Claude Code](https://claude.com/claude-code)
