### PR TITLE
docs(spike): isolate the formatter's viewport offset, and PR 15's fuzz criterion

### DIFF
--- a/crates/spyc-vt-sys/src/pin.rs
+++ b/crates/spyc-vt-sys/src/pin.rs
@@ -45,3 +45,15 @@ pub const REQUIRED_ZIG: &str = "0.16.0";
 ///
 /// A pin bump that skips step 3 is the failure this crate exists to prevent.
 pub const BUMP_POLICY: () = ();
+
+/// Defects reported upstream against this pin, so a bump checks them off
+/// instead of re-investigating them.
+///
+/// - **The VT formatter loses the last scroll on replay.** Reported as
+///   <https://github.com/ghostty-org/ghostty/discussions/14148>. Replaying the
+///   formatter's output into a fresh terminal puts the viewport one row high
+///   and history one row short whenever the source had scrolled. It does not
+///   affect us: the mechanism spyc consumes is `ghostty_snapshot_*`, which
+///   round-trips these states exactly. On a pin bump, check whether it is
+///   fixed before re-investigating.
+pub const REPORTED_UPSTREAM: () = ();

--- a/docs/drafts/V2_2_PLAN.md
+++ b/docs/drafts/V2_2_PLAN.md
@@ -602,8 +602,8 @@ dependencies; the rest is scheduling.
 | 12 | Engine — `spyc-vt-sys` | 11 | New crate owning the pin, the FFI, the vendored archives + checksums, ghostty's MIT attribution. |
 | 13 | Engine — harness re-run at the pin (**the gate**) | 12 | Re-measure everything at the shipping pin and append a dated addendum to the spike report. Not green ⇒ the series stops here and the docs say so. |
 | 14 | Engine — extract the `Engine` trait, vt100 behind it | 11 | Behaviour-identical strangler-fig work that touches no input timing, so it is **not** gated on #326. May land any time after 11, in parallel with 12-13 if the tree makes that convenient. `insta` snapshots unchanged. |
-| 15 | Engine — ghostty impl, threading, flip ([#34](https://github.com/Tripstack-Corp/spyc/issues/34) engine half) | 13, 14, **#326 merged** | The half that does restructure the pane input path, so it waits for #326 (dispatched as its own engagement) and re-verifies its test. |
-| 16 | Engine — fuzz target graduates | 15 | `fuzz_diff`'s generator into `fuzz/fuzz_targets/` against the shipped engine, on the weekly CI fuzz job. |
+| 15 | Engine — ghostty impl, threading, flip ([#34](https://github.com/Tripstack-Corp/spyc/issues/34) engine half) | 13, 14, **#326 merged** | The half that does restructure the pane input path, so it waits for #326 (dispatched as its own engagement) and re-verifies its test. Carries one exit criterion from 16, which landed ahead of it: **tighten `pane_engine` to never-panics-never-poisons and drop the vt100 allowance.** The target asserts recovery rather than absence of panics only because the engine under it still panics; once the flip lands, the weaker property is a lie about the shipped engine. |
+| 16 | Engine — fuzz target graduates | 14 | `fuzz_diff`'s generator into `fuzz/fuzz_targets/` on the weekly CI fuzz job. Landed early ([#462](https://github.com/Tripstack-Corp/spyc/pull/462)), against vt100 rather than the shipped engine — which is why its property is recovery, and why 15 owes the tightening. |
 | — | `PROJECTS_PLAN.md` | 4 (informs §2) | Written across the release, reviewed at the end. Not a PR in the sequence; a deliverable gating 2.3. |
 
 Bugs are interleaved on purpose. 1 and 2 open the release so a daily driver
@@ -611,7 +611,8 @@ sees the difference early. 10 no longer sits last "because its scope may shrink
 on contact" — the spike removed that uncertainty, and what is left of #34 is a
 small display fix (10) plus an engine swap (14).
 
-The engine stages are strictly ordered and 13 is a gate, not a formality: the
+The engine stages are ordered, with one exception the tree argued for (16
+landed before 15 — see its row), and 13 is a gate, not a formality: the
 figures the adoption rests on were measured at a ghostty commit that cannot
 ship, so 13 either reproduces them at the shipping pin or the series ends at
 11 with the decisions log amended to say adoption did not proceed. The engine work adds one cross-item ordering constraint, and only to

--- a/docs/drafts/VT_ENGINE_SPIKE.md
+++ b/docs/drafts/VT_ENGINE_SPIKE.md
@@ -1123,11 +1123,22 @@ viewport rows" and concluded the emit drops a row. It does not: that count
 treats a **blank** viewport row as content the emit owes. An instrument whose
 model of "what should be there" is wrong reports the subject as wrong.
 
-**What it is worth.** `formatter.h` documents the API as content output —
-plain text, VT or HTML, with "the entire screen is formatted" when no
-selection is given — and claims no round-trip guarantee anywhere. The
-mechanism spyc adopts is `ghostty_snapshot_*`, which does make that claim and
-grades 100%. So the upstream report is written as a question about intended
-scope rather than a defect claim, and offers a one-sentence `formatter.h`
-clarification if the answer is that round-trip is out of scope.
+**Reported upstream as a defect:**
+[ghostty discussion 14148](https://github.com/ghostty-org/ghostty/discussions/14148).
+
+An earlier draft framed it as a question about intended scope, because
+`formatter.h` documents the API as content output and claims no round-trip
+guarantee anywhere. That framing was wrong on the project's own record.
+[ghostty#13876](https://github.com/ghostty-org/ghostty/pull/13876) ("terminal:
+preserve pending wrap in VT formatter", merged 2026-08-17) fixed a replay
+defect in this same formatter and added a regression test that formats a
+terminal, feeds the output into a fresh one, and asserts the two agree. Replay
+is in scope by demonstration, so this is the same class of bug and the report
+says so. The pin is 442 commits ahead of that fix, so it is not a stale
+measurement.
+
+It does not affect the adoption either way: the mechanism spyc consumes is
+`ghostty_snapshot_*`, which round-trips these states exactly. The note in
+`spyc_vt_sys::pin` carries the reference so a pin bump checks it off rather
+than re-investigating it.
 

--- a/docs/drafts/VT_ENGINE_SPIKE.md
+++ b/docs/drafts/VT_ENGINE_SPIKE.md
@@ -837,6 +837,7 @@ pin. `snapshot_grade`, `sbprobe` and `membudget` replace them.
 | memory at a FULL row budget | `cargo run --release --features ghostty,wezterm --bin membudget` |
 | `Send` bounds | `cargo run --release --features wezterm --bin sendprobe` |
 | #34 engine vs adapter | `cargo run --release --bin adapter_probe` |
+| the viewport offset, isolated | `cargo run --release --features ghostty --bin offset_isolate` |
 | binary size deltas | `cd sizeprobe && cargo build --release [--features e-vt100\|e-ghostty\|e-wezterm]` |
 | crate counts | `cargo tree --target all --prefix none --features <f> \| awk 'NF{print $1}' \| sort -u \| wc -l` |
 | archive sizes | `find <target> -name libghostty-vt.a`, `strip -S`, `gzip -9`, `nm -g \| grep -c ' [TDSB] _ghostty_'` |
@@ -1089,3 +1090,44 @@ costs 6.94. Twenty-four pane tabs is 639 MiB against 167 MiB.
 The adoption case never leaned on memory — it rests on rehydration, robustness
 and fidelity — but the figure should be right in the direction it actually
 points.
+
+## Addendum — the viewport offset, isolated (2026-09-04)
+
+`offset_isolate` reduces the formatter's one-row shift to a 2x12 grid fed two
+lines, and separates the two causes that look identical from outside.
+
+**The emit is content-complete; the replay is one scroll short.** At that
+geometry the original viewport is `["L001", ""]` over one row of history, and
+the 33-byte emit is
+`\x1b[3g\x1b[9G\x1bH\x1b[HL000\r\nL001\x1b[2;1H\x1b[0m` — every row that
+holds content, history included. Rows are **joined** by `\r\n` rather than
+terminated by it, so the final newline that performed the last scroll is not
+in the stream. Replayed, `L000` stays in the viewport instead of moving to
+history: shift `+1`, history one row short.
+
+Two independent confirmations, because a row count cannot tell these apart:
+
+- **Control.** The same content with no trailing newline — nothing scrolled,
+  so nothing can be lost — round-trips 2/2 with no offset. The emit differs
+  only in the cursor restore (`\x1b[2;5H` against `\x1b[2;1H`).
+- **By construction.** Replaying the emit gives 0/2 rows aligned; replaying it
+  with one `\r\n` appended gives 2/2.
+
+It reproduces at 2, 3, 4 and 24 rows, at 1 through 11 rows of history, always
+exactly `+1`, and at the library's own default limits as well as the shipped
+ones — so it is not downstream of spyc's scrollback configuration.
+
+**A method note, the same shape as the withdrawn adapter finding in §4.** The
+first discriminator counted `L###` labels in the emit against "history +
+viewport rows" and concluded the emit drops a row. It does not: that count
+treats a **blank** viewport row as content the emit owes. An instrument whose
+model of "what should be there" is wrong reports the subject as wrong.
+
+**What it is worth.** `formatter.h` documents the API as content output —
+plain text, VT or HTML, with "the entire screen is formatted" when no
+selection is given — and claims no round-trip guarantee anywhere. The
+mechanism spyc adopts is `ghostty_snapshot_*`, which does make that claim and
+grades 100%. So the upstream report is written as a question about intended
+scope rather than a defect claim, and offers a one-sentence `formatter.h`
+clarification if the answer is that round-trip is out of scope.
+

--- a/spikes/vt-engine/src/bin/offset_isolate.rs
+++ b/spikes/vt-engine/src/bin/offset_isolate.rs
@@ -195,5 +195,7 @@ fn main() {
         println!("    scrollback {sb}, aligned {aligned}/{rows}, emit {} bytes -> {}",
             dd.len(),
             if aligned == usize::from(rows) { "NO OFFSET" } else { "OFFSET" });
+        println!("    emit: {:?}", String::from_utf8_lossy(&dd).escape_debug().to_string());
+        println!("    identical to the configured emit: {}", dd == dump);
     }
 }

--- a/spikes/vt-engine/src/bin/offset_isolate.rs
+++ b/spikes/vt-engine/src/bin/offset_isolate.rs
@@ -1,0 +1,199 @@
+//! Isolate ghostty's one-row viewport offset on scrollback-bearing state.
+//!
+//! The symptom: emit a terminal's state with the VT formatter, replay it into a
+//! fresh terminal, and the viewport comes back one row higher than the
+//! original. Content is present and correctly ordered; the window is shifted.
+//!
+//! Two candidate causes that look identical from outside and need different
+//! fixes:
+//!   A. the emit is INCOMPLETE — one row at the history/viewport boundary is
+//!      never written;
+//!   B. the emit is complete and the REPLAY lands differently, because the
+//!      trailing row does not trigger the scroll the original did.
+//!
+//! This separates them by counting rows in the emitted bytes, which is
+//! something only the emit can be wrong about.
+#[cfg(not(feature = "ghostty"))]
+fn main() {
+    eprintln!("build with --features ghostty");
+}
+
+#[cfg(feature = "ghostty")]
+fn main() {
+    use vt_engine_spike::engine::Engine;
+    use vt_engine_spike::engines::GhosttyEngine;
+
+    const BUDGET: usize = 10_000;
+
+    /// Feed `lines` numbered lines into a `rows`-row terminal, emit, replay,
+    /// and report the alignment.
+    fn probe(rows: u16, cols: u16, lines: usize) -> (usize, i32, usize, usize) {
+        let mut a = GhosttyEngine::create_with_budget(rows, cols, BUDGET);
+        let mut feed = Vec::new();
+        for i in 0..lines {
+            feed.extend_from_slice(format!("L{i:03}\r\n").as_bytes());
+        }
+        a.feed(&feed);
+        let orig = a.screen();
+        let sb_in = a.scrollback_rows();
+        let dump = a.rehydrate().unwrap_or_default();
+
+        let mut b = GhosttyEngine::create_with_budget(rows, cols, BUDGET);
+        b.feed(&dump);
+        let re = b.screen();
+        let sb_out = b.scrollback_rows();
+
+        // Best shift that aligns the two viewports.
+        let best = (-2i32..=2)
+            .map(|s| {
+                let n = (0..rows)
+                    .filter(|r| {
+                        let src = i32::from(*r) + s;
+                        src >= 0
+                            && src < i32::from(rows)
+                            && orig.row_text(*r) == re.row_text(src as u16)
+                    })
+                    .count();
+                (n, s)
+            })
+            .max_by_key(|(n, s)| (*n, -s.abs()))
+            .unwrap_or((0, 0));
+        (best.0, best.1, sb_in, sb_out)
+    }
+
+    println!("ghostty VT-formatter viewport offset — isolation");
+    println!("pin {}", spyc_vt_sys::pin::GHOSTTY_COMMIT);
+    println!();
+
+    // ---- 1. find the smallest case that shows it -------------------------
+    println!("== 1. smallest reproducing geometry ==");
+    println!("  {:>4} {:>4} {:>6}  {:>8} {:>6}  {:>9}", "rows", "cols", "lines", "aligned", "shift", "sb in/out");
+    let mut smallest: Option<(u16, u16, usize)> = None;
+    for rows in [2u16, 3, 4, 24] {
+        for lines in [
+            usize::from(rows),         // exactly fills, no scrollback
+            usize::from(rows) + 1,     // one row of scrollback
+            usize::from(rows) + 2,
+            usize::from(rows) + 10,
+        ] {
+            let (aligned, shift, sb_in, sb_out) = probe(rows, 12, lines);
+            let flag = if shift != 0 { "  <= OFFSET" } else { "" };
+            println!(
+                "  {rows:>4} {:>4} {lines:>6}  {aligned:>8} {shift:>+6}  {sb_in:>4}/{sb_out:<4}{flag}",
+                12
+            );
+            if shift != 0 && smallest.is_none() {
+                smallest = Some((rows, 12, lines));
+            }
+        }
+    }
+
+    // ---- 2. is the EMIT incomplete, or is the REPLAY misplacing it? ------
+    println!();
+    println!("== 2. cause A (emit drops a row) vs cause B (replay scrolls differently) ==");
+    let Some((rows, cols, lines)) = smallest else {
+        println!("  no offset reproduced — nothing to isolate");
+        return;
+    };
+    println!("  using the smallest reproducer: {rows}x{cols}, {lines} lines fed");
+
+    let mut a = GhosttyEngine::create_with_budget(rows, cols, BUDGET);
+    let mut feed = Vec::new();
+    for i in 0..lines {
+        feed.extend_from_slice(format!("L{i:03}\r\n").as_bytes());
+    }
+    a.feed(&feed);
+    let orig = a.screen();
+    let sb_in = a.scrollback_rows();
+    let dump = a.rehydrate().unwrap_or_default();
+
+    println!();
+    println!("  original viewport:");
+    for r in 0..rows {
+        println!("    row {r}: {:?}", orig.row_text(r));
+    }
+    println!("  original scrollback rows: {sb_in}");
+    println!();
+    println!("  emitted {} bytes:", dump.len());
+    println!("    {:?}", String::from_utf8_lossy(&dump).escape_debug().to_string());
+
+    // The decisive test is NOT a row count. An earlier version of this probe
+    // counted `L###` labels against "scrollback + viewport rows" and concluded
+    // the emit drops a row — wrong, because it counted a BLANK viewport row as
+    // content the emit owes. The emit carries every row that has content.
+    //
+    // The real question is whether the emit reproduces the last SCROLL, and the
+    // control for that is a feed with no trailing newline: nothing scrolled, so
+    // nothing can be lost, so the offset must disappear.
+    println!();
+    println!("  control — same content, no trailing newline (so nothing scrolled):");
+    {
+        let mut ctl = GhosttyEngine::create_with_budget(rows, cols, BUDGET);
+        let mut f = Vec::new();
+        for i in 0..lines {
+            f.extend_from_slice(format!("L{i:03}").as_bytes());
+            if i + 1 < lines {
+                f.extend_from_slice(b"\r\n");
+            }
+        }
+        ctl.feed(&f);
+        let o = ctl.screen();
+        let sb = ctl.scrollback_rows();
+        let d = ctl.rehydrate().unwrap_or_default();
+        let mut r2 = GhosttyEngine::create_with_budget(rows, cols, BUDGET);
+        r2.feed(&d);
+        let re2 = r2.screen();
+        let aligned = (0..rows).filter(|r| o.row_text(*r) == re2.row_text(*r)).count();
+        println!("    scrollback {sb}, aligned {aligned}/{rows}  -> {}",
+            if aligned == usize::from(rows) { "NO OFFSET" } else { "still offset" });
+        println!("    emit: {:?}", String::from_utf8_lossy(&d).escape_debug().to_string());
+    }
+
+    // ---- 3. does an explicit trailing newline fix the replay? ------------
+    println!();
+    println!("== 3. confirm by construction: does one more newline align it? ==");
+    let mut b = GhosttyEngine::create_with_budget(rows, cols, BUDGET);
+    b.feed(&dump);
+    let plain = b.screen();
+    let plain_aligned = (0..rows).filter(|r| orig.row_text(*r) == plain.row_text(*r)).count();
+
+    let mut patched = dump.clone();
+    patched.extend_from_slice(b"\r\n");
+    let mut c = GhosttyEngine::create_with_budget(rows, cols, BUDGET);
+    c.feed(&patched);
+    let fixed = c.screen();
+    let fixed_aligned = (0..rows).filter(|r| orig.row_text(*r) == fixed.row_text(*r)).count();
+
+    println!("  replay as emitted:        {plain_aligned}/{rows} rows aligned");
+    println!("  replay + one trailing CRLF: {fixed_aligned}/{rows} rows aligned");
+    println!();
+    for r in 0..rows {
+        println!(
+            "    row {r}: orig {:?} | replay {:?} | +CRLF {:?}",
+            orig.row_text(r),
+            plain.row_text(r),
+            fixed.row_text(r)
+        );
+    }
+
+    // ---- 4. same at the library's own defaults ---------------------------
+    // The upstream report has to be reproducible without spyc's scrollback
+    // configuration in the picture, so re-run the smallest case with no
+    // `ghostty_terminal_set` calls at all.
+    println!();
+    println!("== 4. at the library's default limits (no ghostty_terminal_set) ==");
+    {
+        let mut d = GhosttyEngine::create_at_defaults(rows, cols);
+        d.feed(&feed);
+        let o = d.screen();
+        let sb = d.scrollback_rows();
+        let dd = d.rehydrate().unwrap_or_default();
+        let mut r2 = GhosttyEngine::create_at_defaults(rows, cols);
+        r2.feed(&dd);
+        let re2 = r2.screen();
+        let aligned = (0..rows).filter(|r| o.row_text(*r) == re2.row_text(*r)).count();
+        println!("    scrollback {sb}, aligned {aligned}/{rows}, emit {} bytes -> {}",
+            dd.len(),
+            if aligned == usize::from(rows) { "NO OFFSET" } else { "OFFSET" });
+    }
+}

--- a/spikes/vt-engine/src/engines/ghostty_engine.rs
+++ b/spikes/vt-engine/src/engines/ghostty_engine.rs
@@ -204,6 +204,16 @@ impl GhosttyEngine {
         scrollback::limits_for_row_budget(budget)
     }
 
+    /// Create at the library's OWN defaults — no `ghostty_terminal_set` at
+    /// all, so a probe can show behaviour that is not downstream of spyc's
+    /// scrollback configuration.
+    pub fn create_at_defaults(rows: u16, cols: u16) -> Self {
+        let mut t: ffi::GhosttyTerminal = std::ptr::null_mut();
+        let ok = unsafe { ffi::ghostty_terminal_new(std::ptr::null(), &raw mut t, cols, rows) };
+        assert_eq!(ok, spyc_vt_sys::SUCCESS, "ghostty_terminal_new failed");
+        Self { t, rows, cols }
+    }
+
     /// Create at an explicit budget, for `sbprobe`'s sweep.
     pub fn create_with_budget(rows: u16, cols: u16, budget: usize) -> Self {
         let mut t: ffi::GhosttyTerminal = std::ptr::null_mut();


### PR DESCRIPTION
Record-keeping for work already done — no production code touched, and the
spike crate is outside the workspace, so the gate covers the two docs only.

## The isolation probe

`spikes/vt-engine/src/bin/offset_isolate.rs` reduces ghostty's one-row
viewport shift to a 2x12 grid fed two lines, and separates the two causes
that look identical from outside:

- **A** — the emit is incomplete, a row at the history/viewport boundary is
  never written.
- **B** — the emit is complete and the replay lands differently, because the
  trailing row does not trigger the scroll the original did.

It is **B**. The emit carries every row that holds content, history included,
but joins rows with `\r\n` rather than terminating them, so the final newline
that performed the last scroll is not in the stream. Replayed, the last
history row stays in the viewport: shift `+1`, history one row short.

Two independent confirmations, because a row count cannot tell A from B:

| check | result |
|---|---|
| control — same content, no trailing newline (nothing scrolled) | 2/2 aligned, **no offset** |
| replay the emit as-is | 0/2 aligned |
| replay the emit with one `\r\n` appended | **2/2 aligned** |

Reproduces at 2, 3, 4 and 24 rows, at 1 through 11 rows of history, always
exactly `+1`, and at the library's own default limits as well as the shipped
ones — so it is not downstream of spyc's scrollback configuration.

## The spike report

Takes a dated addendum section (appended, not a rewrite) with the mechanism,
both confirmations, and a method note worth keeping: the **first**
discriminator counted `L###` labels against "history + viewport rows" and
concluded the emit drops a row. Wrong — it counted a blank viewport row as
content the emit owed. Same shape as the withdrawn adapter finding in §4: an
instrument whose model of "what should be there" is wrong reports the subject
as wrong.

The appendix gains the command that produces the figure.

## PR 15's exit criterion

Until now this lived only in #462's commit message. PR 15's row now carries
it: **tighten `pane_engine` to never-panics-never-poisons and drop the vt100
allowance.** The target asserts recovery rather than absence of panics only
because the engine under it still panics; once the flip lands, the weaker
property is a lie about the shipped engine. Row 16 is corrected to record
that it landed ahead of 15, which is why 15 owes the tightening, and the
"strictly ordered" claim above the table is corrected with it.

## Filed upstream

[ghostty discussion 14148](https://github.com/ghostty-org/ghostty/discussions/14148),
as a defect report rather than the question an earlier draft asked. Issue
creation on `ghostty-org/ghostty` is maintainer-only; bug reports go through
"Issue Triage" discussions, which is how
[13269](https://github.com/ghostty-org/ghostty/discussions/13269) — the
tabstop-clobbers-cursor defect in this same formatter — was filed and fixed.

The reframing rests on
[ghostty#13876](https://github.com/ghostty-org/ghostty/pull/13876): it fixed a
replay defect in this formatter and added `test "Terminal vt cursor preserves
pending wrap"`, which formats a terminal, feeds the output into a fresh one and
asserts the two agree. Replay is in scope by the project's own record.
Confirmed before citing, and the pin is 442 commits ahead of that fix.

`spyc_vt_sys::pin` gains a `REPORTED_UPSTREAM` note so a pin bump checks the
defect off rather than re-investigating it.

Gate: `=== GATE: PASS ===`.
