### PR TITLE
fix(pane): the hook-consent prompt no longer eats the first message to an agent

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -274,9 +274,12 @@ spyc's workflow: browse files above, talk to Claude below.
     in a repo pops a `[Y/n]` ("let spyc show this agent's live status? writes
     hooks to `<config>`, removed on exit"), and the answer is **saved per repo** —
     never nags again. The write preserves your existing hooks/config; on exit
-    spyc removes only what it added (and never a git-tracked file). The popup
-    requires an explicit decision — `y` or `n`; Esc and any other key keep it up
-    (it can't be dismissed accidentally), and a saved `n` is undoable, so
+    spyc removes only what it added (and never a git-tracked file). Only `y`
+    or `n` answers it; **any other key defers** — the popup closes, nothing is
+    saved, and the next launch asks again. It has to work that way because the
+    popup appears once the pane already has focus, so the first words of a
+    message to the agent would otherwise be swallowed until one of them
+    contained a `y`, which would then answer it. A saved `n` is undoable, so
     **`:hooks on|on!|off`** changes a project's choice later — `on` also installs
     the hooks for an already-running agent (claude live-reloads → kicks in on the
     next message; codex/agy pick them up on their next launch). That's the undo

--- a/docs/AGENT_ORCHESTRATION.md
+++ b/docs/AGENT_ORCHESTRATION.md
@@ -78,7 +78,10 @@ than either: agy re-drives the tool, which ran a probe turn to 17 invocations be
 it timed out, never reaching `Stop`. spyc's handler therefore prints its decision
 unconditionally and discards the reporter's own output to keep stdout pure JSON.
 It asks first — a `[Y/n]` on the first launch per repo, saved; change it later
-with **`:hooks on|on!|off`**.
+with **`:hooks on|on!|off`**. Only `y`/`n` answers it: the prompt is raised
+after the pane has focus, so any other key defers (saving nothing, asked again
+next launch) and goes to the agent, rather than being eaten by a dialogue the
+user was not typing at.
 
 **Debug:** **`:why-status`** flashes the active tab's state + source; **`:activity
 dump`** opens a pager with every pane's derivation.

--- a/src/app/harness_tests/pane.rs
+++ b/src/app/harness_tests/pane.rs
@@ -1171,3 +1171,96 @@ fn opening_the_scrollback_pager_does_not_sleep_on_the_loop() {
         );
     });
 }
+
+/// **#326 — the first keystrokes into a freshly spawned agent pane are eaten
+/// by the status-hook consent dialogue, and one of them answers it.**
+///
+/// `^a c` on an agent, in a project that has not been asked yet, raises the
+/// `[Y/n]` `HookConsent` prompt AFTER the pty spawns and after focus has moved
+/// to the pane. `handle_hook_consent_key` swallows every key that is not
+/// `y`/`n` and re-raises itself, so text aimed at the child is consumed until
+/// the typed words happen to contain a `y` — which then records consent.
+///
+/// The issue reported losing exactly `"how is spy"` and the child reading
+/// `"c structured, per these three docs?"`. Both halves are asserted here: the
+/// keystrokes must reach the child, and consent must not be granted by a
+/// letter the user aimed somewhere else.
+#[test]
+fn typing_into_a_fresh_agent_pane_is_not_eaten_by_the_consent_prompt() {
+    let tmp = tempfile::tempdir().unwrap();
+    crate::state::with_state_root(tmp.path(), || {
+        use std::os::unix::fs::PermissionsExt as _;
+        let proj = tmp.path().join("proj");
+        let bin = proj.join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let got = tmp.path().join("received.txt");
+        // Stands in for the agent: reads one line and records what it got, so
+        // the assertion is about DELIVERY, not about the echo.
+        let claude = bin.join("claude");
+        std::fs::write(
+            &claude,
+            format!(
+                "#!/usr/bin/env bash\nread -r q\nprintf '%s' \"$q\" > {}\nsleep 5\n",
+                got.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&claude, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut app = App::test_app(proj.clone());
+        app.state.left.git_cache.current_repo_root = Some(proj.clone());
+        // The consent offer is gated on MCP running; without this the pane
+        // spawns with no prompt and the bug cannot appear.
+        app.view.mcp_running = true;
+        app.open_pane_tab(claude.to_str().unwrap());
+
+        // The reported question. The `y` in "spy" is the tenth character.
+        let typed = "how is spyc structured, per these three docs?";
+        for ch in typed.chars().chain(std::iter::once('\r')) {
+            let key = KeyEvent::new(
+                if ch == '\r' {
+                    KeyCode::Enter
+                } else {
+                    KeyCode::Char(ch)
+                },
+                KeyModifiers::empty(),
+            );
+            for e in app.handle_key(key).unwrap() {
+                if let Effect::SendToPane { input, .. } = e {
+                    let tabs = app.runtime.pane_tabs.as_mut().expect("a pane tab");
+                    match input {
+                        crate::app::effect::PaneInput::Bytes(b) => {
+                            tabs.active_mut().send_bytes(&b).unwrap();
+                        }
+                        crate::app::effect::PaneInput::Key(k) => {
+                            tabs.active_mut().send_key(k).unwrap();
+                        }
+                    }
+                }
+            }
+        }
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while std::time::Instant::now() < deadline && !got.exists() {
+            app.runtime
+                .pane_tabs
+                .as_mut()
+                .expect("a pane tab")
+                .active_mut()
+                .drain_output();
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        let received =
+            std::fs::read_to_string(&got).unwrap_or_else(|_| "<child never read>".into());
+
+        assert_eq!(
+            received, typed,
+            "every typed character must reach the child; the consent prompt ate the prefix"
+        );
+        assert_ne!(
+            crate::state::hook_consent::consent_for(&proj),
+            Some(true),
+            "a `y` typed at the agent must not answer the consent dialogue"
+        );
+    });
+}

--- a/src/app/key_dispatch/confirms.rs
+++ b/src/app/key_dispatch/confirms.rs
@@ -266,15 +266,21 @@ impl App {
 
     /// First-launch consent before spyc writes Claude status hooks. Only an
     /// explicit `y`/`n` records a decision — `y` installs the hooks for the
-    /// launching cwd, `n` remembers the denial. Any other key (including Esc)
-    /// keeps the prompt open; the dialogue cannot be bypassed without choosing.
+    /// launching cwd, `n` remembers the denial.
+    ///
+    /// **Any other key defers and is re-dispatched** (#326). This prompt is
+    /// raised AFTER the pane spawns and after focus moved into it, so a user
+    /// typing their first message to the agent types into this dialogue. It
+    /// used to swallow each key and re-raise itself, which meant the message
+    /// was eaten until it happened to contain a `y` — and that `y` then
+    /// recorded consent. `how is spyc structured…` lost its first ten
+    /// characters and silently installed hooks. Deferring records nothing, so
+    /// the next launch asks again; `:hooks on` sets it up directly.
     pub(super) fn handle_hook_consent_key(&mut self, key: KeyEvent) -> Vec<Effect> {
         let prev_mode = std::mem::replace(&mut self.state.mode, Mode::Normal);
         let Mode::Prompting(Prompt {
             kind: PromptKind::HookConsent { root, cwd, agent },
-            prefix,
-            buffer,
-            editor,
+            ..
         }) = prev_mode
         else {
             return Vec::new();
@@ -301,15 +307,15 @@ impl App {
                     .flash_info("status hooks declined for this project (`:hooks on` to enable)");
             }
             _ => {
-                // Restore the prompt — y/n is required; Esc does not defer.
-                self.state.mode = Mode::Prompting(Prompt {
-                    kind: PromptKind::HookConsent { root, cwd, agent },
-                    prefix,
-                    buffer,
-                    editor,
-                });
-                self.state.flash_info("press y or n");
-                return Vec::new();
+                // Defer: nothing recorded, so the next launch asks again. The
+                // key was aimed at whatever has focus — usually the agent that
+                // just spawned — so re-dispatch it now that the prompt is
+                // closed rather than consuming it. `mode` is already `Normal`
+                // (taken above), so this cannot re-enter this arm.
+                self.state
+                    .flash_info("status hooks not set up — `:hooks on` to enable");
+                self.view.needs_full_repaint = true;
+                return self.handle_key(key).unwrap_or_default();
             }
         }
         self.view.needs_full_repaint = true;
@@ -407,10 +413,16 @@ mod tests {
         )
     }
 
-    /// The consent dialogue cannot be dismissed without an explicit decision:
-    /// Esc (and Enter, ^C, a stray letter) leave it open with a y/n nudge.
+    /// A key that is neither `y` nor `n` DEFERS the consent dialogue: it
+    /// closes, records nothing, and the next launch asks again.
+    ///
+    /// This replaces the "cannot be dismissed without an explicit decision"
+    /// contract, which #326 showed to be the bug: the dialogue is raised after
+    /// the agent pane already has focus, so a user typing their first message
+    /// typed into it, every key was swallowed, and the first `y` in their own
+    /// words recorded consent.
     #[test]
-    fn non_yn_keys_keep_hook_consent_prompt_open() {
+    fn non_yn_keys_defer_hook_consent_without_recording_it() {
         let tmp = tempfile::tempdir().unwrap();
         crate::state::with_state_root(tmp.path(), || {
             for code in [
@@ -423,10 +435,14 @@ mod tests {
                 seed_hook_consent(&mut app);
                 let _ = app.handle_key(key(code)).unwrap();
                 assert!(
-                    is_hook_consent_prompt(&app),
-                    "{code:?} must not dismiss the consent dialogue"
+                    !is_hook_consent_prompt(&app),
+                    "{code:?} must defer the consent dialogue, not hold it open"
                 );
-                assert_eq!(app.flash_text(), Some("press y or n"));
+                assert_eq!(
+                    crate::state::hook_consent::consent_for(&PathBuf::from("/repo")),
+                    None,
+                    "{code:?} must record no decision, so the next launch asks again"
+                );
             }
         });
     }


### PR DESCRIPTION
Closes #326.

## It is not the pane input path

The issue pointed at `open_pane_tab_into` and the key path into
`Pane::send_bytes`. Those are clean, and each was ruled out by measurement
rather than by reading:

| layer | probe | result |
|---|---|---|
| routing | type 45 chars right after `open_pane_tab`, count `SendToPane` effects | 45/45 produced |
| encoding + executor + pty | deliver them to a real `cat` pane, read the echo | 45/45 echoed |
| the wrapper shell | same, through the real `/bin/zsh -i -c 'exec …'` spawn | 45/45 |
| the child's `clear` | same, against a script that does `clear`, banner, `read -r` | `read` got all 45 |

Typing before the child is even ready loses nothing — the kernel buffers the
pty. So the bytes were never leaving spyc.

## What it actually is

The status-hook consent dialogue. `maybe_offer_status_hooks` raises
`PromptKind::HookConsent` **after** the pty spawns and after focus moved into
the pane, gated on `view.mcp_running` — which is why it never appeared in a
test harness until that flag was set. `handle_hook_consent_key` then did this:

```rust
_ => {
    // Restore the prompt — y/n is required; Esc does not defer.
    self.state.mode = Mode::Prompting(Prompt { kind: PromptKind::HookConsent {..}, .. });
    self.state.flash_info("press y or n");
    return Vec::new();      // key consumed, never forwarded
}
```

So the user's first message types into the dialogue and is swallowed — until
the words contain a `y`. With the reported sentence:

```
swallowed by prompt: "how is spy"          <- ten chars, the tenth is the `y` in "spy"
child `read` got   : "c structured, per these three docs?"
consent recorded   : Some(true)
```

The middle line is character-for-character the string in the issue. And every
"what it is not" follows: a modal waits forever so no `Sleep` helps; a modal
outranks focus, so `^a j` changed nothing; the bytes never reached the pty, so
the child's `clear` was never in it.

**The half the issue did not catch is the more serious one.** That stray `y`
recorded consent — spyc wrote status hooks into the project because the user's
question contained the letter y. A consent dialogue answered by accident.

## The fix

Only `y`/`n` answers it. Any other key **defers**: the prompt closes, nothing
is recorded (so the next launch asks again), and the key is re-dispatched
through `handle_key` so it reaches whatever has focus — normally the agent that
just spawned. `mode` is already `Normal` by then, so it cannot re-enter the
arm. `:hooks on` still sets hooks up directly.

## Tests

Both watched failing against the old behaviour, then passing, then bite-checked
by restoring the old arm:

- `typing_into_a_fresh_agent_pane_is_not_eaten_by_the_consent_prompt` — spawns
  a real agent pane, types the reported sentence, asserts the child received
  **all** of it and that consent was not granted. Asserts delivery (the child
  writes what it read to a file), not echo.
- `non_yn_keys_defer_hook_consent_without_recording_it` — the rewritten unit
  test. It previously pinned "cannot be dismissed without an explicit
  decision", which is the contract that turned out to be the bug; it now pins
  deferral, and that nothing is recorded.

## Observed, not changed

`handle_skill_update_key` has the same swallow-and-re-raise shape. It is raised
at startup rather than after a pane spawn, so no keystroke aimed at a child can
reach it, and changing it was not in scope here. Worth a look if that ever
moves.

Docs updated in the same commit: `FEATURES.md` documented the old "Esc and any
other key keep it up" contract explicitly, and `docs/AGENT_ORCHESTRATION.md`
describes the `[Y/n]`.

Gate: `=== GATE: PASS ===`.
