### PR TITLE
ci: take CodeQL off the PR path

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,61 @@
+# CodeQL static analysis — deliberately OFF the PR path.
+#
+# CodeQL is not a required status check, so a per-PR run gated nothing while
+# adding ~12 minutes to every push: the `rust` analysis alone measured 601-737s
+# across recent runs, against a ~70s `ci.yml` gate. It runs here on merge to
+# `main` — so everything that lands is still analyzed — plus a weekly sweep,
+# which is what catches newly published queries against unchanged code.
+#
+# Migrated off GitHub's *default setup*, whose triggers are fixed (pull request
+# + default branch + weekly) and cannot be narrowed; owning the workflow is the
+# only way to choose when it runs. Default setup must therefore stay DISABLED in
+# repo settings — while it is on, an advanced-setup upload is rejected outright.
+#
+# `python` is deliberately not in the matrix. Default setup analyzed it for
+# exactly one file, `scripts/aislop-baseline.py`, a local dev helper that ships
+# in no artifact.
+#
+# build-mode `none` on both legs is not a shortcut: CodeQL's Rust extractor
+# reads source directly and never invokes cargo, which is why no build cache
+# shortens this and why moving it off the PR path was the only lever.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Mondays 05:00 UTC — an hour ahead of Audit (06:00) and two ahead of Fuzz
+    # (07:00), so the three weeklies don't contend for the runner queue.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+# A newer push to main supersedes an in-flight analysis: HEAD is what the
+# security posture is measured against, and the weekly sweep re-covers the rest.
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, rust]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -265,7 +265,7 @@ previous minor for a short tail.** Expand windows as the user base grows.
 
 ## 8. CI/CD pipelines (GitHub Actions)
 
-Five workflows under `.github/workflows/`. All pin the toolchain via
+The workflows under `.github/workflows/`. All pin the toolchain via
 `rust-toolchain.toml` and run cargo with `--locked`. The local `make` targets
 are the source of truth — Actions *call them* so local and CI never drift.
 
@@ -342,6 +342,21 @@ are the source of truth — Actions *call them* so local and CI never drift.
   `cargo tree --duplicates` (Mon 06:00 UTC + manual dispatch). Ported from the
   retired Bitbucket `weekly-deps` pipeline. The old Bitbucket→Slack failure
   notification does *not* carry over — add a GitHub-issue/Slack step if wanted.
+
+### `codeql.yml` — static analysis (push to `main` + schedule) — **IMPLEMENTED**
+- `actions` + `rust` legs, both `build-mode: none` — CodeQL's Rust extractor
+  reads source and never invokes cargo, so no build cache shortens it.
+- **Deliberately off the PR path.** CodeQL is not a required context, so a
+  per-PR run gated nothing while costing ~12 min a push (the `rust` leg measured
+  601-737s; the `ci.yml` gate is ~70s). Merge to `main` still analyzes
+  everything that lands; the Monday 05:00 UTC sweep re-runs newly published
+  queries against unchanged code.
+- Migrated off GitHub's **default setup**, whose triggers are fixed and cannot
+  be narrowed. Default setup must stay **disabled** in repo settings — an
+  advanced-setup upload is rejected while it is on. Re-enabling it in the UI
+  silently restores the per-PR cost this workflow exists to avoid.
+- `python` is not analyzed: default setup covered one dev helper,
+  `scripts/aislop-baseline.py`, which ships in no artifact.
 
 ### `homebrew.yml` — tap bump (on release published) — **TAP LIVE**
 - `Tripstack-Corp/homebrew-tap` is live with `Formula/spyc.rb` (pins the release


### PR DESCRIPTION
## Why

CodeQL is **not a required status check**, yet it dominated PR wall-clock:

| | duration | required? |
|---|---|---|
| `ci.yml` gate (`max(lint, test)`) | **~70s** | ✅ yes |
| CodeQL `rust` leg | **601–737s** | ❌ no |

That is ~91% of a PR's CI time spent on a check no merge can depend on — and it
was paid twice per merge, once on the PR and once on the push to `main`.

Measured across the last 25 runs; `ci.yml` itself is flat (lint 49–80s, tests
61–114s over three weeks) and was never the problem.

## What changed

Replaces GitHub's **default setup** — whose triggers are fixed (PR + default
branch + weekly) and cannot be narrowed — with an owned workflow that runs on
merge to `main` plus the weekly sweep. Everything that lands is still analyzed.

Two findings recorded in the workflow header, because they are why no cheaper
fix exists:

- **`build-mode: none`.** CodeQL's Rust extractor reads source and never invokes
  cargo. No build cache shortens this; taking it off the PR path was the only
  lever.
- **`python` dropped.** It analyzed exactly one file,
  `scripts/aislop-baseline.py`, a dev helper shipping in no artifact. It ran in
  parallel so it cost no wall-clock, but it scanned nothing user-facing.

## ⚠️ Merge order

**CodeQL default setup must be disabled in repo settings** — while it is on, an
advanced-setup upload is rejected outright and this workflow will fail. Disable
it immediately before or after merging:

```sh
gh api -X DELETE repos/Tripstack-Corp/spyc/code-scanning/default-setup
```

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- `make lint-workflows` (actionlint + shellcheck) clean on the new file
- Existing alert state unaffected: the 7 `actions/missing-workflow-permissions`
  alerts are already **fixed** and the one `rust/cleartext-logging` is
  **dismissed** — there are no open alerts this changes the handling of.

Generated with [Claude Code](https://claude.com/claude-code)
