### PR TITLE
build(changelog): group ci: commits instead of dropping them silently

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -87,6 +87,14 @@ commit_parsers = [
   { message = "^docs", group = "<!-- 4 -->Documentation" },
   { message = "^build", group = "<!-- 5 -->Build & Tooling" },
   { message = "^test", group = "<!-- 6 -->Tests" },
+  # `ci` is a conventional type this repo genuinely uses, but it matched no
+  # parser — and an unmatched commit is dropped with nothing louder than a
+  # WARN, so every CI change ever merged is absent from the log (#441 and
+  # #447 are the two still unreleased; this parser recovers them). Grouped
+  # with Build & Tooling, which already holds `build` and `chore(deps)`.
+  # Anchored `^ci[(:]` rather than a bare `^ci`, which would also swallow a
+  # subject that merely starts with those two letters.
+  { message = "^ci[(:]", group = "<!-- 5 -->Build & Tooling" },
   # Release-bump commits are noise in a per-version changelog — drop them.
   { message = "^chore\\(release\\)", skip = true },
   { message = "^chore\\(version\\)", skip = true },


### PR DESCRIPTION
## The bug

`ci` is a conventional type this repo genuinely uses, but `commit_parsers` in
`cliff.toml` had no entry for it. git-cliff drops a commit matching no parser
with nothing louder than a warning:

```
WARN git_cliff_core::changelog > process_commits: 2 commit(s) were skipped due to grouping error(s)
```

`-vv` names them:

```
6d1a0a4 - Grouping error: `Commit does not belong to any group`
          (ci(apt): deploy the apt repo as a Pages artifact… (#441))
b0c86e6 - Grouping error: `Commit does not belong to any group`
          (ci: lint the workflows in the PR gate (#447))
```

**Every CI change ever merged is absent from `CHANGELOG.md`.** Those two are
simply the ones still unreleased and therefore still recoverable.

This is the failure mode AGENTS.md already warns about for untyped subjects,
reached by a different route — the subject *is* conventional, it just belongs
to no group. Under squash merge the PR title is the only thing parsed, so the
work vanishes with no second chance to correct it.

## The fix

One parser entry, grouped with **Build & Tooling** (which already holds `build`
and `chore(deps)`). Anchored `^ci[(:]` rather than a bare `^ci`, which would
also swallow any subject merely beginning with those two letters.

Because git-cliff applies `cliff.toml` at generation time over all history, this
**retroactively recovers #441 and #447** — no merge-ordering constraint against
other in-flight `ci:` PRs.

## Verification — watched it fail first

| | before | after |
|---|---|---|
| `#441` / `#447` in `git cliff --unreleased` | absent | both render |
| grouping-error warnings | 2 | **0** |

`make check-ci` → `=== GATE: PASS ===`

Generated with [Claude Code](https://claude.com/claude-code)
