### PR TITLE
ci: reclaim the Actions cache budget

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,58 @@
+# Delete a pull request's Actions caches when it closes.
+#
+# GitHub scopes a cache to the ref that wrote it, so every `refs/pull/N/merge`
+# entry is unreadable by any other branch the moment that PR closes — dead
+# weight against a repo-wide budget that is a HARD 10 GB, not a soft target.
+# `Swatinem/rust-cache` writes ~560 MB (test) + ~320 MB (lint) per distinct
+# source state, so a handful of parked PRs is measured in gigabytes: the sweep
+# that prompted this workflow found ~3 GB held by PRs already merged.
+#
+# Over budget, GitHub evicts least-recently-used — which takes MAIN's caches,
+# the ones every new PR restores from. The failure mode is therefore not "the
+# cache is full", it is cold builds on unrelated PRs, with nothing in the log
+# naming the cause.
+#
+# Runs on `closed` (not `merged`) so an abandoned PR is reclaimed too.
+name: Cache cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Drop the closed PR's caches
+    runs-on: ubuntu-latest
+    permissions:
+      # `gh cache delete` writes; nothing here reads the repo's contents.
+      actions: write
+    steps:
+      - name: Delete caches for this PR's ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+          # `gh cache list` exits 0 with no rows when a PR never cached, which
+          # is the common case for a docs-only change — not an error.
+          ids=$(gh cache list --ref "$REF" --limit 100 --json id --jq '.[].id')
+          if [ -z "$ids" ]; then
+            echo "no caches held by $REF"
+            exit 0
+          fi
+          freed=0
+          for id in $ids; do
+            if gh cache delete "$id"; then
+              freed=$((freed + 1))
+            else
+              # A cache can vanish between list and delete (concurrent eviction
+              # or a re-run of this workflow). That is the desired end state, so
+              # it must not fail the job.
+              echo "cache $id already gone"
+            fi
+          done
+          echo "deleted $freed cache(s) held by $REF"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - run: rustup component add llvm-tools-preview
+      # The instrumented build writes to `target-cov` (CARGO_TARGET_DIR on the
+      # coverage step below), but rust-cache resolves the target dir at ITS OWN
+      # step — so without `workspaces` it saved an empty `target/` and every run
+      # recompiled the whole dependency tree. Measured: 123s of the step's 139s
+      # went to compiling, starting at proc-macro2. The tell was cache size —
+      # 126 MB here against the test job's 564 MB.
       - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target-cov"
       - name: Install cargo-llvm-cov (pinned, sha256-verified)
         run: |
           CARGO_LLVM_COV_VERSION=0.8.7

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -285,7 +285,10 @@ are the source of truth — Actions *call them* so local and CI never drift.
   --all-targets --fail-under-lines 35`) on pushes to `main`. Supply-chain
   (cargo-deny) moved to `audit.yml` — see §6. Toolchain cached via
   `Swatinem/rust-cache`; `cargo-llvm-cov` is the same sha-pinned prebuilt binary
-  as before; `CARGO_INCREMENTAL=0` throughout. Make it a required status check in
+  as before; `CARGO_INCREMENTAL=0` throughout. The `coverage` job passes
+  `workspaces: ". -> target-cov"` to rust-cache — it resolves the target dir at
+  its own step, so without that it caches an empty `target/` and recompiles the
+  dependency tree cold every run. Make it a required status check in
   branch protection. The required contexts are exactly `Lint (fmt, clippy)` and
   `Tests (cargo test --all-targets)` — a job's **`name` IS its context**, so
   renaming either one is a three-step operation: drop the old context from
@@ -395,6 +398,18 @@ in `ci.yml`); the `apt-publish` environment holds `APT_GPG_PRIVATE_KEY` +
 `APT_GPG_PASSPHRASE`, the `homebrew-tap` environment holds `HOMEBREW_APP_ID` +
 `HOMEBREW_APP_KEY` (org GitHub App). The apt push uses the built-in
 `GITHUB_TOKEN` and cosign uses OIDC — no personal tokens stored.
+
+### `cache-cleanup.yml` — reclaim a closed PR's caches — **IMPLEMENTED**
+- On `pull_request: closed`, deletes every cache keyed to `refs/pull/N/merge`.
+- The Actions cache budget is a **hard 10 GB**, and a cache is scoped to the ref
+  that wrote it — so a merged PR's entries are unreadable by anything else and
+  are pure dead weight. rust-cache writes ~560 MB (test) + ~320 MB (lint) per
+  distinct source state; the sweep that prompted this found ~3 GB held by
+  already-merged PRs.
+- Over budget GitHub evicts least-recently-used, which takes **main's** caches —
+  the ones every new PR restores from. The symptom is cold builds on unrelated
+  PRs, with nothing in the log naming the cause.
+- Fires on `closed` rather than `merged` so abandoned PRs are reclaimed too.
 
 ## 9. Artifacts, signing & distribution
 


### PR DESCRIPTION
## Why

The Actions cache is at **9.25 GB against a hard 10 GB limit**, and ~3 GB of
that is held by PRs that already merged:

```
564MB  refs/pull/446/merge   v0-rust-test-Linux-x64-…
563MB  refs/pull/465/merge   v0-rust-test-Linux-x64-…
537MB  refs/pull/445/merge   v0-rust-test-Linux-x64-…
319MB  refs/pull/465/merge   v0-rust-lint-Linux-x64-…
…
```

A cache is scoped to the ref that wrote it, so a `refs/pull/N/merge` entry is
unreadable by anything else the moment that PR closes. Over budget GitHub
evicts least-recently-used — and what that takes is **main's** caches, the ones
every new PR restores from. The symptom would not be "the cache is full", it
would be cold builds on unrelated PRs with nothing in the log naming the cause.

**This is prevention, not a fix.** I checked before writing it: recent runs
still report `Cache hit for restore-key … full match: false`, which is
rust-cache's normal partial hit. Nothing is degraded today.

## Two changes

**1. `cache-cleanup.yml`** — deletes a PR's caches on `closed` (not `merged`,
so abandoned PRs are reclaimed too).

**2. `coverage` gets a working cache.** `CARGO_TARGET_DIR: target-cov` is set on
the cargo *step*, but rust-cache resolves the target dir at **its own** step —
so it saved an empty `target/` and recompiled the dependency tree cold every
run. From the job log:

```
02:25:45  Compiling proc-macro2 v1.0.106     ← from scratch, every run
02:27:46  Finished `test` profile … in 2m 03s
```

**123s of the step's 139s was compilation.** The tell was cache size: 126 MB for
coverage against the test job's 564 MB.

## Considered and rejected

`save-if` restricted to `main`, which would stop PRs writing caches at all.
It punishes exactly the PRs that need a cache most — a lockfile change no
longer matches main's key, so every push rebuilds the dependency tree from
scratch until merge. Dependabot opens those routinely.

## Verification

- `make check-ci` → `=== GATE: PASS ===`
- `actionlint` clean on both workflow files

Generated with [Claude Code](https://claude.com/claude-code)
