### PR TITLE
fix(ci): let a CodeQL analysis finish instead of cancelling it on every merge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,11 +29,15 @@ on:
     - cron: "0 5 * * 1"
   workflow_dispatch:
 
-# A newer push to main supersedes an in-flight analysis: HEAD is what the
-# security posture is measured against, and the weekly sweep re-covers the rest.
+# NOT cancel-in-progress. The rust leg runs 10-12 minutes and merges land more
+# often than that during a working session, so cancelling on each new push meant
+# no analysis ever finished: four consecutive main pushes were cancelled mid-leg
+# (the last at 461s) and `main` went unscanned. Queueing instead is bounded — a
+# concurrency group holds at most ONE pending run, so a burst drops the
+# superseded middles and still converges on HEAD being analyzed.
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/docs/RELEASE_ENGINEERING.md
+++ b/docs/RELEASE_ENGINEERING.md
@@ -351,9 +351,14 @@ are the source of truth — Actions *call them* so local and CI never drift.
   reads source and never invokes cargo, so no build cache shortens it.
 - **Deliberately off the PR path.** CodeQL is not a required context, so a
   per-PR run gated nothing while costing ~12 min a push (the `rust` leg measured
-  601-737s; the `ci.yml` gate is ~70s). Merge to `main` still analyzes
-  everything that lands; the Monday 05:00 UTC sweep re-runs newly published
-  queries against unchanged code.
+  601-737s; the `ci.yml` gate is ~70s). Every push to `main` queues an analysis;
+  the Monday 05:00 UTC sweep re-runs newly published queries against unchanged
+  code.
+- **The concurrency group must not cancel in progress.** The `rust` leg outlasts
+  the gap between merges, so `cancel-in-progress: true` meant no analysis ever
+  finished — four consecutive main pushes were cancelled mid-leg (the last at
+  461s) and `main` went unscanned. Queueing is bounded: a group holds at most one
+  pending run, so a burst drops the superseded middles and converges on HEAD.
 - Migrated off GitHub's **default setup**, whose triggers are fixed and cannot
   be narrowed. Default setup must stay **disabled** in repo settings — an
   advanced-setup upload is rejected while it is on. Re-enabling it in the UI


### PR DESCRIPTION
## A defect in #467, found by watching it run

`cancel-in-progress: true` assumed merges are spaced further apart than the
analysis takes. They are not — the `rust` leg runs 10–12 minutes and merges land
more often than that during a working session. **Four consecutive main pushes
were cancelled mid-leg, none completed:**

| commit | `Analyze (rust)` |
|---|---|
| `01218fe` | cancelled |
| `e70b5d0` | cancelled |
| `8694bc1` | cancelled |
| `97d3323` | cancelled at **461s** |

So `main` went unscanned between weekly sweeps — a **worse** posture than the
per-PR runs #467 replaced, which is the opposite of the point. The `actions` leg
always survived (39–43s), which is why the runs looked healthy at a glance.

## Why queueing is safe here

`cancel-in-progress: false` does **not** trade this for an unbounded backlog: a
concurrency group holds at most **one** pending run. A burst of merges therefore
drops the superseded middles and converges on HEAD being analyzed. The runs are
off the critical path and the repo is public, so the extra minutes cost nothing.

Because GitHub evaluates concurrency from the *new* run's workflow file, merging
this will **queue** behind the in-flight `d303536` analysis rather than cancel
it — so that one should be the first to actually finish.

## Also corrected

`RELEASE_ENGINEERING.md` claimed merging to `main` "analyzes everything that
lands". Under queueing the superseded middles are dropped, and under the
cancelling config nothing landed analyzed at all. Both now stated accurately.

## Verification

`make check-ci` → `=== GATE: PASS ===`; `actionlint` clean.

Generated with [Claude Code](https://claude.com/claude-code)
