### PR TITLE
docs(demo): land the markdown demo harness as a work in progress

### DIFF
--- a/docs/assets/demo/agents/README.md
+++ b/docs/assets/demo/agents/README.md
@@ -1,0 +1,67 @@
+# Agent orchestration demo — WORK IN PROGRESS, NOT YET SHOOTING
+
+The second harness: a ~90s clip answering one question, *which agent needs me?*
+It opens on four panes already in four states and lets the dots carry it.
+
+| Tab | Dot | What it is |
+| --- | --- | --- |
+| `[1]` | heat-pulse `●` | Haiku, mid-task |
+| `[2]` | steady red `■` | Haiku, waiting on you |
+| `[3]` | calm teal `■` | Haiku, finished its turn |
+| `[4]` | `💤` | rmatrix, `^z`-suspended |
+
+The agents are real (`claude --model haiku`). The fixture is borrowed from the
+markdown harness rather than copied — `fixtureRel` is the one path both the
+locate-check and the staging copy read.
+
+```sh
+osascript spyc-agents-demo.applescript setup   # arrange four panes, stop, no recording
+osascript spyc-agents-demo.applescript dry     # arrange + run the beats, no recording
+osascript spyc-agents-demo.applescript         # film it
+```
+
+## Where it got to
+
+The arrangement runs: four panes spawn, the consent popup is answered, and three
+Haiku agents take their prompts. **It has never reached a take.** Verification of
+the four states through `:activity dump` is where it stops, and the last two runs
+both died on an iTerm error (`Can't get tab 1 of window id N`) that means the
+window lost its session mid-run. Both times a person was also driving that
+window, so it is **not yet established** whether that is a harness bug or an
+interrupted run. Establish that first, from an untouched window.
+
+## Traps, confirmed
+
+- **`blocked` and `done` are the same glyph.** Both render `■` (U+25A0) and
+  differ only in colour — hot red against teal — and `get text` carries no
+  colour. Counting `■` cannot tell "needs me" from "finished". The arrangement
+  is verified through `:activity dump`, which names each state in words. This is
+  the mermaid-beat bug waiting to happen again, and the reason the dump exists.
+- **The status-hooks consent popup is modal and only `y`/`n` closes it.** Esc and
+  every other key are swallowed while it stays up. Miss it and the entire
+  arrangement types itself into a prompt that never closes: no hooks are
+  installed, so no agent can self-report, and every dot silently degrades to
+  output timing. Nothing errors — the run just produces meaningless dots. It is
+  raised on the first agent pane per project root and remembered afterwards, so
+  it reproduces only on a machine that has never consented for that path.
+- **`^a c` prefills the command box** with the default (`claude`). Typing on top
+  of it yields `claudeclaude` and a pane that exits 127. `^u` clears the buffer.
+- **Only `working` is unstable.** `blocked` latches until settled, `done` and
+  `idle` persist, `💤` is a sticky toggle — but `●` lasts only while a turn is
+  running, so tab 1 needs a long read-only task and the take has to be shot while
+  it is still going. Read is not gated by default, which is what keeps that pane
+  `working` rather than stopping on a prompt like tab 2 deliberately does.
+- **Never assert on agent prose.** Real agents are non-deterministic; spyc's own
+  state is not. The beats wait on the dots, the `💤`, and the file list moving
+  under a `navigate_to` — never on what an agent said.
+- **Do not zoom to watch a dot.** The dots live in the divider, so `^a z` on a
+  pane hides the thing the beat is about. And `:activity dump` is a setup
+  instrument only — it throws a pager over the frame, which is fine while
+  arranging and wrong on camera.
+
+## Next
+
+1. Reproduce the `tab 1` error in a window nobody touches; decide bug or interrupt.
+2. Confirm tab 2 actually reaches `blocked` — a permission prompt depends on the
+   local Claude config, and an allowlisted Bash would leave it `working` instead.
+3. Then a `dry` run, then a take.

--- a/docs/assets/demo/agents/spyc-agents-demo.applescript
+++ b/docs/assets/demo/agents/spyc-agents-demo.applescript
@@ -1,0 +1,604 @@
+-- ===========================================================================
+--  spyc · agent orchestration demo — "Four agents. One glance."
+--  --------------------------------------------------------------------------
+--  The clip answers one question: WHICH AGENT NEEDS ME? It opens on four panes
+--  already in four different states and lets the dots carry the point.
+--
+--    [1] heat-pulse ●  a Haiku agent mid-task
+--    [2] steady red ■  a Haiku agent waiting on you        <- the point
+--    [3] calm teal  ■  a Haiku agent that finished its turn
+--    [4] 💤            rmatrix, ^z-suspended
+--
+--  The agents are REAL (`claude --model haiku`), so their prose is
+--  non-deterministic. Every assertion therefore reads spyc's own state rather
+--  than agent output -- see the two traps below.
+--
+--  Run:       osascript spyc-agents-demo.applescript
+--  Rehearse:  osascript spyc-agents-demo.applescript dry    (no recording)
+--  Arrange only, then stop (to eyeball the dots):
+--             osascript spyc-agents-demo.applescript setup
+--
+--  TRAP 1 -- `blocked` and `done` are THE SAME GLYPH. Both render `■`
+--  (U+25A0); only the colour differs (hot red vs teal) and `get text` carries
+--  no colour. Counting `■` cannot tell "needs me" from "finished", so the
+--  arrangement is verified through `:activity dump`, which names each pane's
+--  state in words. Asserting on the glyph would repeat the mermaid-beat bug.
+--
+--  TRAP 2 -- only `working` is unstable. `blocked` is latched until you settle
+--  it, `done` and `idle` persist, `💤` is a sticky toggle -- but `●` lasts only
+--  while a turn is actually running. Tab 1 therefore gets a long read-only task
+--  kicked off during setup, and the clip has to be shot while it is still going.
+-- ===========================================================================
+
+property stageDir    : "/private/tmp/spyc-demo"
+property demoDir     : "/private/tmp/spyc-demo/aurora-docs"
+property outDir      : "/private/tmp/spyc-demo/out"
+property colCount    : 200
+property rowCount    : 50
+property recorder    : "screencapture"
+property typeDelay   : 0.042
+property tagName     : "SPYC-AGENTS"
+--  Read-only work: Read is not gated by default, so this pane stays `working`
+--  instead of stopping on a permission prompt like tab 2 deliberately does.
+property workPrompt  : "Read every markdown file under this directory tree, one at a time, and then describe how the docs are organized."
+--  Needs approval -> the hook reports `blocked` -> the dot latches red.
+property blockPrompt : "Run the shell command: date"
+--  Finishes in one turn -> `done`.
+property donePrompt  : "Reply with just the word: ready"
+--  After the block is answered, this drives spyc's own MCP tool so the file
+--  list moves under the user.
+property mcpPrompt    : "Use the navigate_to tool to open the guides directory."
+property paneCmd     : "claude --model haiku"
+--  The fixture is the markdown harness's tree, borrowed rather than copied.
+--  One path, used by both the locate-check and the staging copy -- deriving it
+--  twice is how the check passed while the copy looked somewhere else.
+property fixtureRel  : "../markdown/aurora-docs"
+
+global sess, win, isDry, isSetupOnly
+
+on sh(c)
+	return do shell script c
+end sh
+
+-- Where this script (and its aurora-docs/ fixture) lives. `path to me` is the
+-- script itself under `osascript file.applescript`, but resolves to the
+-- osascript binary under some hosts -- so verify the fixture is really there
+-- and fall back to an override rather than staging an empty tree.
+on harnessDir()
+	try
+		set d to my sh("dirname " & quoted form of (POSIX path of (path to me)))
+	on error
+		set d to ""
+	end try
+	if d is not "" and (my sh("test -d " & quoted form of (d & "/" & fixtureRel) & " && echo y || echo n")) is "y" then
+		return d
+	end if
+	set o to my sh("printf %s \"${SPYC_DEMO_HARNESS_DIR:-}\"")
+	if o is not "" then return o
+	error "cannot locate the harness: run this from its folder in the repo, or set SPYC_DEMO_HARNESS_DIR to the folder holding " & fixtureRel
+end harnessDir
+
+-- Fresh disposable copy of the fixture + a clean output dir. This is also the
+-- RESET between runs: no git, no leftover .swp, no edited RELEASE-NOTES.md.
+on stageFixture()
+	set src to my harnessDir() & "/" & fixtureRel
+	my sh("rm -rf " & quoted form of demoDir & " && mkdir -p " & quoted form of demoDir & " " & quoted form of outDir & ¬
+		" && cp -R " & quoted form of (src & "/.") & " " & quoted form of demoDir)
+end stageFixture
+
+on trace(m)
+	log "  ‣ " & m
+end trace
+
+on stateFile()
+	return outDir & "/.demo-window-id"
+end stateFile
+
+-- one key, no newline: a KEYPRESS, not a command
+on emit(s)
+	tell application "iTerm2" to tell sess to write text s newline no
+end emit
+
+on typeSlow(s)
+	repeat with i from 1 to length of s
+		my emit(character i of s)
+		delay typeDelay
+	end repeat
+end typeSlow
+
+on ctrlKey(c)
+	my emit(ASCII character ((ASCII number c) - 96))   -- ^a=1 ^d=4 ^s=19
+end ctrlKey
+
+on enter()
+	my emit(ASCII character 13)
+end enter
+
+on escKey()
+	my emit(ASCII character 27)
+end escKey
+
+on chordA(c)
+	my ctrlKey("a")
+	delay 0.14
+	my emit(c)
+	delay 1.0
+end chordA
+
+on chordZ(c)
+	my emit("z")
+	delay 0.32
+	my emit(c)
+	delay 1.0
+end chordZ
+
+-- iTerm2 hands back the WHOLE SCROLLBACK (617 lines for a 50-row window), and
+-- `contents` is no different. Matching against that is how an assertion passes
+-- on stale output from earlier in the session, and how a `▸` count ends up
+-- tallying folds from three beats ago. The visible screen is the LAST rowCount
+-- lines, so slice it.
+on screenText()
+	tell application "iTerm2" to set t to (get text of sess)
+	set ps to paragraphs of t
+	set n to count of ps
+	set i0 to n - rowCount + 1
+	if i0 < 1 then set i0 to 1
+	set acc to ""
+	repeat with i from i0 to n
+		set acc to acc & (item i of ps) & linefeed
+	end repeat
+	return acc
+end screenText
+
+-- right half only. The payoff assertion MUST be scoped: vim shows the same text
+-- bottom-left, so a whole-screen match would prove nothing about the preview.
+on rightText()
+	set cut to (colCount / 2) as integer
+	set acc to ""
+	repeat with para in (paragraphs of (my screenText()))
+		set l to (para as text)
+		if (length of l) > cut then set acc to acc & (text (cut + 1) thru -1 of l) & linefeed
+	end repeat
+	return acc
+end rightText
+
+on dumpScreen(tag)
+	try
+		set f to outDir & "/dump-" & (my sh("date +%H%M%S")) & ".txt"
+		my sh("cat > " & quoted form of f & " <<'SPYCEOF'" & linefeed & (my screenText()) & linefeed & "SPYCEOF")
+		my trace("  ✗ " & tag & " — screen dumped to " & f)
+	end try
+end dumpScreen
+
+-- poll the real screen instead of guessing with delay
+on waitFor(pat, secs)
+	repeat with i from 1 to (secs * 4)
+		try
+			if (my screenText()) contains pat then
+				my trace("  ✓ " & pat)
+				return true
+			end if
+		end try
+		delay 0.25
+	end repeat
+	my dumpScreen("waitFor " & pat)
+	error "timed out waiting for: " & pat
+end waitFor
+
+on waitForRight(pat, secs)
+	repeat with i from 1 to (secs * 4)
+		try
+			if (my rightText()) contains pat then
+				my trace("  ✓ right column: " & pat)
+				return true
+			end if
+		end try
+		delay 0.25
+	end repeat
+	my dumpScreen("waitForRight " & pat)
+	error "timed out waiting for " & pat & " in the RIGHT column"
+end waitForRight
+
+on countOf(needle)
+	set t to my screenText()
+	set tid to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to needle
+	set n to (count of text items of t) - 1
+	set AppleScript's text item delimiters to tid
+	return n
+end countOf
+
+on waitForCount(needle, want, secs)
+	repeat with i from 1 to (secs * 4)
+		if (my countOf(needle)) is want then
+			my trace("  ✓ " & want & " × " & needle)
+			return true
+		end if
+		delay 0.25
+	end repeat
+	my dumpScreen("waitForCount " & needle)
+	error "wanted " & want & " × " & needle & ", saw " & (my countOf(needle))
+end waitForCount
+
+-- ------------------------------------------------- one window, found or made
+on acquireWindow()
+	set w to missing value
+
+	-- 1. the window we used last time
+	try
+		set wid to (my sh("cat " & quoted form of (my stateFile()))) as integer
+		tell application "iTerm2" to set w to (first window whose id is wid)
+		my trace("reusing window " & wid)
+	end try
+
+	-- 2. any window still carrying our tag
+	if w is missing value then
+		tell application "iTerm2"
+			repeat with ww in windows
+				try
+					if (name of current session of ww) contains tagName then
+						set w to ww
+						my trace("reusing tagged window")
+						exit repeat
+					end if
+				end try
+			end repeat
+		end tell
+	end if
+
+	-- 3. make one
+	if w is missing value then
+		tell application "iTerm2" to set w to (create window with default profile)
+		my trace("created a new window")
+	end if
+
+	set win to w
+	-- A fresh TAB in the reused window. Trying to quit the previous spyc with
+	-- ^d is unreliable (it needs ^d^d, and a half-quit instance then eats the
+	-- launch command as keystrokes); a new tab is unconditional. New tab first,
+	-- so the window is never left with zero tabs and cannot disappear.
+	tell application "iTerm2"
+		set nOld to count of tabs of w
+		tell w to create tab with default profile
+		delay 1
+		repeat nOld times
+			try
+				tell tab 1 of w to close
+				delay 0.5
+			end try
+		end repeat
+		delay 0.5
+		set sess to current session of w
+		tell sess
+			set name to tagName
+			set columns to colCount
+			set rows to rowCount
+		end tell
+	end tell
+	my sh("echo " & (id of w) & " > " & quoted form of (my stateFile()))
+	return w
+end acquireWindow
+
+-- leave whatever ran last time; get back to a shell prompt WITHOUT sending a
+-- bare ^d at a shell (that would exit the shell and close the tab)
+on ensureShell()
+	repeat with i from 1 to 6
+		set t to ""
+		try
+			set t to my screenText()
+		end try
+		if t contains "picks:" then          -- spyc's status bar => spyc is up
+			my trace("quitting the previous spyc")
+			my ctrlKey("d")
+			delay 1.5
+		else if t contains "E325" or t contains "swap file" then
+			my emit("q")                     -- dismiss a vim recovery prompt
+			delay 1
+		else
+			return true
+		end if
+	end repeat
+	return true
+end ensureShell
+
+-- ----------------------------------------------------------------- recording
+on screenPoints()
+	-- `zoomed` maximizes to the visible frame, so reading the bounds back gives
+	-- the screen size IN POINTS with no extra dependency. A scaled display is
+	-- NOT 2x -- this machine is 3456px over 2056pt = 1.68 -- so this matters.
+	tell application "iTerm2"
+		set old to bounds of win
+		set zoomed of win to true
+		delay 0.6
+		set b to bounds of win
+		set zoomed of win to false
+		delay 0.4
+		set bounds of win to old
+		delay 0.3
+	end tell
+	return {item 3 of b, item 4 of b}
+end screenPoints
+
+-- rect_ is "x,y,w,h" in POINTS -- screencapture captures it at native scale.
+on startRec(path_, rect_)
+	if isDry then
+		my trace("[dry] recording skipped")
+		return
+	end if
+	if recorder is "quicktime" then
+		tell application "QuickTime Player"
+			activate
+			-- `new screen recording` declares NO <result> in QuickTime's sdef,
+			-- while `new audio recording` and `new movie recording` both return
+			-- a document -- so `set x to new screen recording` can never bind,
+			-- and reports the useless "the variable x is not defined". Take the
+			-- document off the app instead.
+			new screen recording
+			delay 1
+			if (count of documents) is 0 then
+				error "QuickTime made no recording document. It reports \"encountered an error while recording your screen -- try using the Screenshot app instead\", which is what the screencapture recorder already is. Use recorder \"screencapture\"."
+			end if
+			start document 1
+		end tell
+		delay 3
+		tell application "iTerm2" to activate
+		delay 1
+	else
+		my sh("nohup screencapture -v -R " & rect_ & " " & quoted form of path_ & " >/dev/null 2>&1 &")
+		delay 2.5
+		if (my sh("pgrep -x screencapture >/dev/null && echo y || echo n")) is not "y" then
+			error "screencapture did not start -- grant Screen Recording to your terminal in System Settings > Privacy & Security"
+		end if
+	end if
+end startRec
+
+on stopRec(path_)
+	if isDry then return
+	if recorder is "quicktime" then
+		tell application "QuickTime Player"
+			stop document 1
+			delay 2
+			save document 1 in file (POSIX file path_)
+			delay 3
+			close document 1 saving no
+			quit saving no
+		end tell
+	else
+		my sh("pkill -INT -x screencapture || true")
+		delay 3
+	end if
+end stopRec
+
+
+-- ------------------------------------------------------- pane orchestration
+on newTab(cmd)
+	my chordA("c")
+	delay 1.0
+	-- `^a c` PREFILLS the command box with the default (`claude`). Typing on
+	-- top of it yields `claudeclaude` and a pane that exits 127. `^u` clears
+	-- the prompt buffer; the cwd prompt that follows is prefilled correctly,
+	-- so that one just takes an Enter.
+	my ctrlKey("u")
+	delay 0.35
+	my typeSlow(cmd)
+	my enter()          -- the command
+	delay 1.0
+	my enter()          -- the cwd, prefilled
+	delay 2.5
+	my acceptHookConsent()
+end newTab
+
+-- The first agent pane per project raises a MODAL `[Y/n]` popup asking to write
+-- status hooks into the project config. Only `y`/`n` dismisses it -- Esc and
+-- every other key are swallowed and it stays up. Miss it and the whole
+-- arrangement types itself into a prompt that never closes: no hooks get
+-- installed, so no agent can self-report, and every dot falls back to output
+-- timing. Answering it is what makes `working`/`blocked`/`done` mean anything.
+-- Consent is remembered per project root, so this is a no-op after the first run.
+on acceptHookConsent()
+	repeat with i from 1 to 24
+		try
+			if (my screenText()) contains "agent status" then
+				my emit("y")
+				delay 1.4
+				my trace("  ✓ accepted the status-hooks consent")
+				return true
+			end if
+		end try
+		delay 0.5
+	end repeat
+	return false          -- already consented for this root: nothing to answer
+end acceptHookConsent
+
+on focusTab(n)
+	my chordA(n as text)
+	delay 1.0
+end focusTab
+
+on zoomToggle()
+	my chordA("z")
+	delay 1.2
+end zoomToggle
+
+-- ^z is NOT an ^a chord: it goes to the pane directly.
+on suspendToggle()
+	my ctrlKey("z")
+	delay 1.5
+end suspendToggle
+
+-- Type a prompt into the focused agent pane and submit it.
+on promptAgent(p)
+	my typeSlow(p)
+	delay 0.4
+	my enter()
+end promptAgent
+
+-- `:activity dump` names every pane's state in WORDS, which is the only way to
+-- tell a red ■ from a teal one. Opens a pager; read it, then close it.
+on dumpSays(wanted, secs)
+	repeat with i from 1 to secs
+		my chordA("k")       -- `:` reaches spyc only from LIST focus
+		delay 0.5
+		my emit(":")
+		delay 0.4
+		my typeSlow("activity dump")
+		my enter()
+		delay 1.6
+		set t to my screenText()
+		set ok to true
+		repeat with w in wanted
+			if t does not contain (w as text) then set ok to false
+		end repeat
+		my escKey()          -- close the pager
+		delay 0.6
+		if ok then
+			my trace("  ✓ activity dump has: " & (wanted as text))
+			return true
+		end if
+		delay 2
+	end repeat
+	my dumpScreen("activity-dump")
+	error "activity dump never showed all of: " & (wanted as text)
+end dumpSays
+
+-- =========================================================================
+on run argv
+	set isDry to (argv contains "dry")
+	set isSetupOnly to (argv contains "setup")
+	set stamp to my sh("date +%Y%m%d-%H%M%S")
+	set rawPath to outDir & "/qt-raw-" & stamp & ".mov"
+	set outPath to outDir & "/spyc-agents-" & stamp & ".mp4"
+
+	my trace("staging the demo tree")
+	my stageFixture()
+	my sh("pkill -x rmatrix 2>/dev/null; true")
+
+	my acquireWindow()
+
+	my trace("launching spyc at " & colCount & "x" & rowCount)
+	tell application "iTerm2" to tell sess to ¬
+		write text "cd " & quoted form of demoDir & " && clear && spyc"
+	my waitFor("CONTRIBUTING.md", 25)
+	delay 2
+
+	--------------------------------------------------------------- ARRANGE
+	-- Not filmed. Four panes are driven into four states, and the whole point
+	-- of the clip is that they hold those states at once -- so verify before
+	-- spending a take.
+	my trace("arranging four panes")
+
+	my trace("  [1] a long read-only task -> working")
+	my newTab(paneCmd)
+	my promptAgent(workPrompt)
+	delay 3
+
+	my trace("  [2] a command needing approval -> blocked")
+	my newTab(paneCmd)
+	my promptAgent(blockPrompt)
+	delay 3
+
+	my trace("  [3] a one-turn reply -> done")
+	my newTab(paneCmd)
+	my promptAgent(donePrompt)
+	delay 3
+
+	my trace("  [4] rmatrix -- a pane that is not an agent at all")
+	my newTab("rmatrix")
+	delay 2
+
+	my trace("verifying the arrangement through :activity dump")
+	my focusTab(1)
+	my dumpSays({"working", "blocked", "done"}, 12)
+
+	if isSetupOnly then
+		my trace("setup only -- four panes are arranged, nothing recorded")
+		return
+	end if
+
+	set pts to my screenPoints()
+	tell application "iTerm2" to set wb to bounds of win
+	set rectStr to "" & (item 1 of wb) & "," & (item 2 of wb) & "," & ¬
+		((item 3 of wb) - (item 1 of wb)) & "," & ((item 4 of wb) - (item 2 of wb))
+	my trace("recording (" & recorder & ") rect " & rectStr)
+	my startRec(rawPath, rectStr)
+	delay 1.5
+
+	try
+		------------------------------------------------------------- beat 1
+		-- Cold open on the rain, zoomed. Suspending WHILE zoomed freezes it on
+		-- camera, and the unzoom then reveals the frame with 💤 already set --
+		-- so the glance that follows is complete from its first frame.
+		my trace("beat 1 — cold open: rmatrix, zoomed")
+		my focusTab(4)
+		my zoomToggle()
+		delay 4
+		my suspendToggle()
+		delay 1.2
+		my zoomToggle()
+		delay 1.5
+
+		------------------------------------------------------------- beat 2
+		my trace("beat 2 — the glance: four tabs, four states")
+		my waitFor("💤", 10)
+		-- a little movement so the frame is alive while the dots do the talking
+		my chordA("k")
+		delay 1.2
+		my emit("j")
+		delay 0.7
+		my emit("j")
+		delay 0.7
+		my emit("k")
+		delay 3.5
+
+		------------------------------------------------------------- beat 3
+		-- Deliberately NOT zoomed: the dot lives in the divider, so zooming the
+		-- pane hides the very thing the beat is about. And no `:activity dump`
+		-- here -- it is the right instrument for setup, but it throws a pager
+		-- over the frame, and this is the shot.
+		my trace("beat 3 — answer the one that needs me")
+		my focusTab(2)
+		delay 3.5
+		my enter()                       -- approve the permission prompt
+		delay 5
+
+		------------------------------------------------------------- beat 4
+		my trace("beat 4 — the agent moves the view")
+		my promptAgent(mcpPrompt)
+		delay 1.2
+		-- This is the assertion that proves the whole chain: the prompt was
+		-- approved, the agent resumed, took a new instruction, and called
+		-- spyc's own tool. Agent prose is non-deterministic; the file list
+		-- moving is not.
+		my waitFor("quickstart.md", 40)  -- navigate_to landed: the list moved
+		my trace("      the file list moved under the user, driven over MCP")
+		delay 4
+
+		------------------------------------------------------------- beat 5
+		my trace("beat 5 — wake the rain, close")
+		my focusTab(4)
+		my suspendToggle()
+		delay 4
+	on error e
+		my trace("BEAT FAILED: " & e)
+	end try
+
+	my trace("stopping recording")
+	my stopRec(rawPath)
+
+	if not isDry then
+		set cmd to "set -e" & ¬
+			"; RAW=" & quoted form of rawPath & ¬
+			"; OUT=" & quoted form of outPath & ¬
+			"; test -s \"$RAW\" || { echo 'no take was written'; exit 1; }" & ¬
+			"; ffmpeg -v error -i \"$RAW\" -an -c:v libx264 -crf 18 -pix_fmt yuv420p -movflags +faststart \"$OUT\" -y" & ¬
+			"; echo \"$(ffprobe -v error -select_streams v -show_entries stream=width,height -of csv=p=0 \"$OUT\") -> $OUT\""
+		try
+			my trace(my sh(cmd))
+		on error e2
+			my trace("post-processing failed: " & e2)
+			my trace("raw take kept at " & rawPath)
+		end try
+	end if
+
+	my trace("done — the panes are left running for another take")
+end run

--- a/docs/assets/demo/markdown/README.md
+++ b/docs/assets/demo/markdown/README.md
@@ -1,0 +1,116 @@
+# Markdown demo harness — WORK IN PROGRESS
+
+Scripted clips of spyc's markdown viewing: the full-height rendered preview, live
+re-render on save, outline folding, and the mermaid diagram painted in the terminal.
+
+**Status: the harness runs, the film does not exist yet.** All five beats of the
+AppleScript driver assert green in rehearsal, but no take has been shot. No video
+is committed here on purpose — a `.mov` belongs on a release, not in git history,
+and nothing is worth keeping until we have a demo we are sure of. Recordings are
+written to `/private/tmp/spyc-demo/out/`.
+
+## Layout
+
+| Path | What it is |
+| --- | --- |
+| `spyc-quicktime-demo.applescript` | The real driver. Films a live iTerm2 window with QuickTime. Five beats, each asserted. |
+| `demo.sh` | Earlier pipeline: `tui-test` drives spyc, `agg` renders the cast. Preview + live-reload clip. |
+| `fold.sh` | Same pipeline, outline-folding clip. |
+| `mermaid-beat.md` | Hand-recording recipe for the one beat no scripted recorder can capture. |
+| `aurora-docs/` | The fixture doc tree the demo browses. Multiple top-level headings, on purpose — see below. |
+
+The fixture is inside spyc's repo, so `prose_is_canadian_english` scans it like
+any other prose — an American spelling in a demo doc fails the gate.
+
+## Running it
+
+```sh
+osascript spyc-quicktime-demo.applescript dry   # rehearse, no recording
+osascript spyc-quicktime-demo.applescript       # film it
+./demo.sh && ./fold.sh                          # the tui-test clips
+```
+
+Paths resolve from the script's own folder. The fixture is copied to
+`/private/tmp/spyc-demo/aurora-docs` per run and edited there, so the copy in this
+repo stays pristine; override the staging root with `SPYC_DEMO_STAGE`, and the
+harness location with `SPYC_DEMO_HARNESS_DIR` if `path to me` cannot resolve it.
+The `.sh` drivers need `tui-test` (`brew tap microsoft/tui-test`, then `brew
+trust`), `agg`, and `ffmpeg`. macOS asks once for Screen Recording permission.
+
+## Why two pipelines
+
+`tui-test` drives spyc well — a Ghostty backend, Playwright-style `expect text`,
+and waits that beat vhs's blind `Sleep` against spyc's off-thread preview reload.
+But **its recorder is a glyph rasterizer**, and so is vhs's: spyc emits the mermaid
+bitmap (the footer reports `mermaid diagram · WxH`) and the recorder throws it
+away, leaving a blank area. There is no text fallback — spyc's own
+`detect_image_picker()` notes that halfblocks render nothing useful for a diagram.
+So the mermaid beat needs a real screen capture of a real terminal, which is what
+the AppleScript does.
+
+It drives **iTerm2, not System Events**: exact geometry (`set columns` / `set
+rows`), no focus stealing (keys go to the session, so you can keep working), and
+`get text` gives readback so the script asserts instead of sleeping. spyc supports
+iTerm2's image protocol explicitly (`SPYC-TRAP` `iterm-osc1337`), so diagrams paint.
+
+## Traps, all confirmed by experiment
+
+Recording:
+
+- **`get text of sess` returns the WHOLE SCROLLBACK** (617 lines for a 50-row
+  window), and `contents` is identical. Assertions silently match stale output
+  from earlier beats. Slice the last `rowCount` paragraphs.
+- **Never assert on a spyc flash message** — `pane exited` fades before the poll
+  sees it. Assert the persistent divider (`[exited`) instead.
+- **`vim -n`**, no swap file. A stale `.swp` from an interrupted run opens vim on
+  its `E325` recovery prompt and silently breaks every later beat.
+- **Reserved AppleScript words** that will not compile as handler or variable
+  names: `say`, `cr`, `put`, `before`. And `set rows to rows` is self-referential
+  inside `tell session` — the property name collides with iTerm's own, the window
+  silently stays short, and assertion strings fall below the fold. Name them
+  `rowCount` / `colCount`.
+- **Reuse one window**: remember `id of window` in a state file and tag the session
+  name, then swap in a fresh tab. Do not try to talk the previous spyc into
+  quitting with `^d` — it needs `^d^d`, and a half-quit instance eats the launch
+  command as keystrokes.
+- **A scaled Retina display is not 2x** — 3456px over 2056pt is 1.68 on this
+  machine, so a hardcoded 2 crops the video wrong. Read `bounds` back after
+  `set zoomed to true`.
+- **Identifying "my" windows by screen content is unsafe.** The heuristic flagged
+  the user's own Claude Code session, because that session's transcript contained
+  the demo paths.
+- Ghostty is a poor target on macOS: it refuses CLI launch, `+new-window` is not
+  supported on this platform, and `open -na ... --args` is ignored while an
+  instance is running.
+- **U+FE0F breaks `tui-test`'s rasterizer.** spyc's logo is `U+1F336 U+FE0F`; bare
+  `U+1F336` renders and the variation selector fails, and no font fixes it. The
+  selector is load-bearing (`ui/line_select.rs`: bare `U+1F336` measures 1 cell,
+  not 2), so this is not spyc's bug — render the cast with `agg` instead.
+- **`expect text` needs a unique match** — pass `--no-strict` or a repeated string
+  fails. `--match` is not a valid flag.
+
+Driving spyc:
+
+- **spyc restores pager scroll positions**, so a re-recorded take starts mid-file.
+  Force `gg` after opening any pager or preview, or the shot is not reproducible.
+- **`za` keys off the top of the view, not a cursor.** In a folded table of contents
+  shorter than the screen the view cannot scroll, so `za` is unreachable and `j`
+  does nothing. Use `]]` on the expanded doc — it scrolls the heading to the view
+  top — then `za`.
+- **`zM` folds under the outermost heading present**, so a doc with a single
+  `# Title` collapses to one line. The fixture has several top-level headings for
+  exactly this reason.
+- **Focus:** `^a k` / `^a j` switch pane and list; `^a a` / `^a b` only switch file
+  columns. A bare `^s` while the pane has focus goes to the child — use the `^a |`
+  alias.
+- **`^a c` is a two-step prompt** (command, then cwd), so two Enters.
+  `$SPYC_PANE_CMD` prefills the command.
+- **Quitting vim does not close the pane** — spyc keeps the tab showing
+  `vim [exited 0]`. Close it with `^a x`.
+- A full-height vsplit plus a pane gives list top-left, pane bottom-left, preview
+  full-height right. It also confines the status bar to the left column, which
+  truncates the path segment to about one character.
+
+**Assertions must bite.** The first fold clip asserted on `lines`, which matched
+the pager header `(149 lines)` and proved nothing. Counting `▸` markers is the
+assertion that actually fails when folding breaks.

--- a/docs/assets/demo/markdown/README.md
+++ b/docs/assets/demo/markdown/README.md
@@ -63,10 +63,18 @@ only for older systems: see the first trap below.
 
 Recording:
 
-- **QuickTime's AppleScript recording API is dead on macOS 26.** `new screen
-  recording` returns no document at all, so the next line fails with `The variable
-  r is not defined` — an error that names a variable and says nothing about the
-  cause. `screencapture -v -R` is the working path and is now the default.
+- **QuickTime cannot be scripted into recording here, for two independent
+  reasons — and the error names neither.** `set r to new screen recording` fails
+  with `The variable r is not defined`, which sounds like a typo. It is not.
+  First, `new screen recording` declares **no `<result>`** in QuickTime's own
+  dictionary (`QuickTimePlayerX.sdef`), while its siblings `new audio recording`
+  and `new movie recording` both return a `document` — so the assignment can
+  never bind, whatever else is true. Second, even called correctly it creates no
+  document, because QuickTime Player holds no Screen Recording grant: its only
+  TCC row is `kTCCServiceUbiquity`. Driven by AppleScript it fails silently
+  instead of prompting. Fixing either alone changes nothing.
+  `screencapture -v -R` is the working path and is now the default — it runs
+  under the terminal's own grant (`kTCCServiceScreenCapture | com.googlecode.iterm2`).
 - **`get text of sess` returns the WHOLE SCROLLBACK** (617 lines for a 50-row
   window), and `contents` is identical. Assertions silently match stale output
   from earlier beats. Slice the last `rowCount` paragraphs.

--- a/docs/assets/demo/markdown/README.md
+++ b/docs/assets/demo/markdown/README.md
@@ -63,18 +63,28 @@ only for older systems: see the first trap below.
 
 Recording:
 
-- **QuickTime cannot be scripted into recording here, for two independent
-  reasons — and the error names neither.** `set r to new screen recording` fails
-  with `The variable r is not defined`, which sounds like a typo. It is not.
-  First, `new screen recording` declares **no `<result>`** in QuickTime's own
-  dictionary (`QuickTimePlayerX.sdef`), while its siblings `new audio recording`
-  and `new movie recording` both return a `document` — so the assignment can
-  never bind, whatever else is true. Second, even called correctly it creates no
-  document, because QuickTime Player holds no Screen Recording grant: its only
-  TCC row is `kTCCServiceUbiquity`. Driven by AppleScript it fails silently
-  instead of prompting. Fixing either alone changes nothing.
-  `screencapture -v -R` is the working path and is now the default — it runs
-  under the terminal's own grant (`kTCCServiceScreenCapture | com.googlecode.iterm2`).
+- **Do not try to script QuickTime into recording. Apple's own answer is to use
+  something else.** Driven this way it puts up: *"QuickTime Player encountered an
+  error while recording your screen. Try using the Screenshot app instead."*
+  `screencapture` IS the Screenshot app's command line, so the harness is already
+  on the prescribed path.
+
+  Two separate things go wrong, and the error text names neither. `set r to new
+  screen recording` fails with `The variable r is not defined`, which sounds like
+  a typo — it is not: `new screen recording` declares **no `<result>`** in
+  QuickTime's own dictionary (`QuickTimePlayerX.sdef`), while its siblings `new
+  audio recording` and `new movie recording` both return a `document`. So the
+  assignment can never bind, whatever else is true, and every pre-Mojave recipe
+  on the web that uses `start document 1` is working around exactly this. Called
+  correctly it then creates no document or window at all (`{0, 0}`) and raises
+  the dialog above.
+
+  QuickTime also holds no Screen Recording grant — its only TCC row is
+  `kTCCServiceUbiquity`. Whether granting one would fix the recording error is
+  **untested**, and the dialog argues against it: a TCC refusal prompts, it does
+  not report a generic recording error. `screencapture -v -R` needs none of this,
+  running under the terminal's own grant
+  (`kTCCServiceScreenCapture | com.googlecode.iterm2`).
 - **`get text of sess` returns the WHOLE SCROLLBACK** (617 lines for a 50-row
   window), and `contents` is identical. Assertions silently match stale output
   from earlier beats. Slice the last `rowCount` paragraphs.

--- a/docs/assets/demo/markdown/README.md
+++ b/docs/assets/demo/markdown/README.md
@@ -4,9 +4,15 @@ Scripted clips of spyc's markdown viewing: the full-height rendered preview, liv
 re-render on save, outline folding, and the mermaid diagram painted in the terminal.
 
 **Status: it films.** All five beats assert green and a full take has been shot —
-about 90 seconds, ending on the mermaid diagram rendered as a real bitmap in the
-terminal, with the `c` theme toggle flipping it dark to light. Pacing and framing
-are still open. No video is committed here on purpose — a `.mov` belongs on a
+about 67 seconds, ending on the mermaid diagram rendered as a real bitmap in the
+terminal, with the `c` theme toggle flipping it dark to light.
+
+Pacing is set by scaling every `delay` in the beats region together, so the rhythm
+stays and only the length changes; the first cut took 91s to 67s at a factor of
+0.68. Delays at or below 0.15s are keystroke gaps rather than pacing (the `g`-`g`
+of a `gg`) and are left alone. The dwells that survive a cut are the ones the
+viewer reads: the preview appearing, the `CAUTION` block re-rendering, the folded
+table of contents, and the diagram in each theme. No video is committed here on purpose — a `.mov` belongs on a
 release, not in git history, and nothing is worth keeping until we have a demo we
 are sure of. Takes are written to `/private/tmp/spyc-demo/out/`.
 

--- a/docs/assets/demo/markdown/README.md
+++ b/docs/assets/demo/markdown/README.md
@@ -3,11 +3,12 @@
 Scripted clips of spyc's markdown viewing: the full-height rendered preview, live
 re-render on save, outline folding, and the mermaid diagram painted in the terminal.
 
-**Status: the harness runs, the film does not exist yet.** All five beats of the
-AppleScript driver assert green in rehearsal, but no take has been shot. No video
-is committed here on purpose — a `.mov` belongs on a release, not in git history,
-and nothing is worth keeping until we have a demo we are sure of. Recordings are
-written to `/private/tmp/spyc-demo/out/`.
+**Status: it films.** All five beats assert green and a full take has been shot —
+about 90 seconds, ending on the mermaid diagram rendered as a real bitmap in the
+terminal, with the `c` theme toggle flipping it dark to light. Pacing and framing
+are still open. No video is committed here on purpose — a `.mov` belongs on a
+release, not in git history, and nothing is worth keeping until we have a demo we
+are sure of. Takes are written to `/private/tmp/spyc-demo/out/`.
 
 ## Layout
 
@@ -53,10 +54,19 @@ rows`), no focus stealing (keys go to the session, so you can keep working), and
 `get text` gives readback so the script asserts instead of sleeping. spyc supports
 iTerm2's image protocol explicitly (`SPYC-TRAP` `iterm-osc1337`), so diagrams paint.
 
+The recorder is `screencapture -v -R <x,y,w,h>`, which films **only the window
+rect**. Nothing else on the desktop is ever in the file, and no crop pass is
+needed — a region take is already the right size. The `quicktime` recorder is kept
+only for older systems: see the first trap below.
+
 ## Traps, all confirmed by experiment
 
 Recording:
 
+- **QuickTime's AppleScript recording API is dead on macOS 26.** `new screen
+  recording` returns no document at all, so the next line fails with `The variable
+  r is not defined` — an error that names a variable and says nothing about the
+  cause. `screencapture -v -R` is the working path and is now the default.
 - **`get text of sess` returns the WHOLE SCROLLBACK** (617 lines for a 50-row
   window), and `contents` is identical. Assertions silently match stale output
   from earlier beats. Slice the last `rowCount` paragraphs.
@@ -91,8 +101,16 @@ Recording:
 
 Driving spyc:
 
-- **spyc restores pager scroll positions**, so a re-recorded take starts mid-file.
-  Force `gg` after opening any pager or preview, or the shot is not reproducible.
+- **spyc restores pager scroll positions**, so a re-recorded take starts wherever
+  the LAST take ended. Force `gg` after opening any pager or preview — and do it
+  **before the assertion, not after**. Three beats here asserted on a near-top
+  string first and took the top second; they passed for as long as the restored
+  position happened to be the top, then all failed the moment a run ended on the
+  mermaid fence at the bottom of the file. The preview was working perfectly; the
+  anchor was just off-screen above.
+- **A wide `graph LR` overflows the frame.** Five nodes left-to-right renders at
+  3200px against a 200-column window and the last node is severed at the right
+  edge. `graph TD` fits the terminal's aspect ratio — the fixture uses it.
 - **`za` keys off the top of the view, not a cursor.** In a folded table of contents
   shorter than the screen the view cannot scroll, so `za` is unreachable and `j`
   does nothing. Use `]]` on the expanded doc — it scrolls the heading to the view
@@ -111,6 +129,16 @@ Driving spyc:
   full-height right. It also confines the status bar to the left column, which
   truncates the path segment to about one character.
 
-**Assertions must bite.** The first fold clip asserted on `lines`, which matched
-the pager header `(149 lines)` and proved nothing. Counting `▸` markers is the
-assertion that actually fails when folding breaks.
+**Assertions must bite**, and this harness has now proved it twice.
+
+The first fold clip asserted on `lines`, which matched the pager header
+`(149 lines)` and proved nothing. Counting `▸` markers is the assertion that
+actually fails when folding breaks.
+
+Worse, the mermaid beat asserted on `mermaid diagram` — and **passed on spyc's own
+refusal**, `no mermaid diagram in view`. The beat was opening `HANDBOOK.md`, which
+has no fence at all, and filming a plain page of text while reporting green. That
+string occurs in three places: the refusal, the rendered placeholder block
+(`▣ mermaid diagram — i: view in terminal …`), and the image overlay. Only the
+overlay means a diagram is on screen, so the assertion is `c theme` — a verb the
+overlay offers only for a mermaid origin, and which cannot match anything else.

--- a/docs/assets/demo/markdown/aurora-docs/CHANGELOG.md
+++ b/docs/assets/demo/markdown/aurora-docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 3.0 — unreleased
+- zstd is the default codec

--- a/docs/assets/demo/markdown/aurora-docs/CONTRIBUTING.md
+++ b/docs/assets/demo/markdown/aurora-docs/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Run `just check` before opening a PR.

--- a/docs/assets/demo/markdown/aurora-docs/HANDBOOK.md
+++ b/docs/assets/demo/markdown/aurora-docs/HANDBOOK.md
@@ -1,0 +1,154 @@
+---
+title: Aurora Handbook
+audience: operators
+---
+
+## 1. Overview
+
+Aurora moves records from producers to consumers with a bounded tail.
+
+### 1.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 1.2 Example
+
+```sh
+aurora overview --describe
+```
+
+## 2. Concepts
+
+A **topic** is an ordered log. A **segment** is an immutable chunk of one.
+
+### 2.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 2.2 Example
+
+```sh
+aurora concepts --describe
+```
+
+## 3. Producers
+
+Producers batch by time or bytes, whichever trips first.
+
+### 3.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 3.2 Example
+
+```sh
+aurora producers --describe
+```
+
+## 4. Consumers
+
+A consumer group splits partitions across members.
+
+### 4.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 4.2 Example
+
+```sh
+aurora consumers --describe
+```
+
+## 5. Storage
+
+Segments land on local NVMe, then tier to object storage.
+
+### 5.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 5.2 Example
+
+```sh
+aurora storage --describe
+```
+
+## 6. Compaction
+
+Compaction keeps the newest record per key.
+
+### 6.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 6.2 Example
+
+```sh
+aurora compaction --describe
+```
+
+## 7. Security
+
+mTLS between brokers; SASL for clients.
+
+### 7.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 7.2 Example
+
+```sh
+aurora security --describe
+```
+
+## 8. Operations
+
+Roll one broker at a time and wait for ISR to catch up.
+
+### 8.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 8.2 Example
+
+```sh
+aurora operations --describe
+```
+
+## 9. Tuning
+
+Start from the defaults. Change one knob at a time.
+
+### 9.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 9.2 Example
+
+```sh
+aurora tuning --describe
+```
+
+## 10. Troubleshooting
+
+Run `aurora doctor` before reading any logs.
+
+### 10.1 Details
+
+Each case behaves differently under backpressure;
+the parked producer is the one to watch.
+
+### 10.2 Example
+
+```sh
+aurora troubleshooting --describe
+```

--- a/docs/assets/demo/markdown/aurora-docs/README.md
+++ b/docs/assets/demo/markdown/aurora-docs/README.md
@@ -1,0 +1,3 @@
+# Aurora
+
+A streaming ingest layer. Start with [the quickstart](guides/quickstart.md).

--- a/docs/assets/demo/markdown/aurora-docs/RELEASE-NOTES.md
+++ b/docs/assets/demo/markdown/aurora-docs/RELEASE-NOTES.md
@@ -49,7 +49,7 @@ pub fn frame(buf: &[u8]) -> Result<Frame<'_>> {
 ## Architecture
 
 ```mermaid
-graph LR
+graph TD
     P[Producer] --> B[Broker]
     B --> C[(Segment store)]
     B --> D[Consumer group]

--- a/docs/assets/demo/markdown/aurora-docs/RELEASE-NOTES.md
+++ b/docs/assets/demo/markdown/aurora-docs/RELEASE-NOTES.md
@@ -1,0 +1,69 @@
+---
+title: Aurora 3.0 — Release Notes
+author: platform-team
+status: draft
+---
+
+# Aurora 3.0
+
+Aurora is a **streaming ingest layer** with *predictable* tail latency.
+Full docs live at [the handbook](https://example.com/handbook).
+
+> [!NOTE]
+> This release changes the default compression codec.
+
+> [!WARNING]
+> `zstd` level 19 will saturate a single core. Cap it at 9 in production.
+
+## Highlights
+
+- Zero-copy record framing
+- Backpressure that ~~drops~~ *parks* the producer
+- Per-topic retention policy
+
+### Benchmarks
+
+| Codec  | Throughput | p99 latency | Ratio |
+|:-------|-----------:|------------:|:-----:|
+| none   |  1.9 GB/s  |      0.4 ms |  1.0x |
+| lz4    |  1.4 GB/s  |      0.7 ms |  2.1x |
+| zstd-3 |  0.9 GB/s  |      1.2 ms |  3.4x |
+| zstd-9 |  0.3 GB/s  |      4.8 ms |  4.1x |
+
+### Configuration
+
+```toml
+[ingest]
+codec = "zstd"
+level = 9
+parked_producer_timeout_ms = 250
+```
+
+```rust
+pub fn frame(buf: &[u8]) -> Result<Frame<'_>> {
+    let (hdr, rest) = buf.split_at(HEADER_LEN);
+    Ok(Frame { hdr: Header::parse(hdr)?, body: rest })
+}
+```
+
+## Architecture
+
+```mermaid
+graph LR
+    P[Producer] --> B[Broker]
+    B --> C[(Segment store)]
+    B --> D[Consumer group]
+    C --> E[Compaction]
+```
+
+## Migration
+
+> Upgrade the brokers before the clients. The wire format is
+> backward compatible, not forward compatible.
+
+1. Drain the consumer group
+2. Roll the brokers
+3. Re-enable the group
+
+> [!TIP]
+> `aurora doctor --pre-upgrade` checks all three in one pass.

--- a/docs/assets/demo/markdown/aurora-docs/adr/001-codec-choice.md
+++ b/docs/assets/demo/markdown/aurora-docs/adr/001-codec-choice.md
@@ -1,0 +1,3 @@
+# ADR 001 — codec choice
+
+Accepted.

--- a/docs/assets/demo/markdown/aurora-docs/adr/002-backpressure.md
+++ b/docs/assets/demo/markdown/aurora-docs/adr/002-backpressure.md
@@ -1,0 +1,3 @@
+# ADR 002 — backpressure
+
+Accepted.

--- a/docs/assets/demo/markdown/aurora-docs/aurora.yaml
+++ b/docs/assets/demo/markdown/aurora-docs/aurora.yaml
@@ -1,0 +1,3 @@
+ingest:
+  codec: zstd
+  level: 9

--- a/docs/assets/demo/markdown/aurora-docs/guides/quickstart.md
+++ b/docs/assets/demo/markdown/aurora-docs/guides/quickstart.md
@@ -1,0 +1,3 @@
+# quickstart
+
+TODO.

--- a/docs/assets/demo/markdown/aurora-docs/guides/troubleshooting.md
+++ b/docs/assets/demo/markdown/aurora-docs/guides/troubleshooting.md
@@ -1,0 +1,3 @@
+# troubleshooting
+
+TODO.

--- a/docs/assets/demo/markdown/aurora-docs/guides/tuning.md
+++ b/docs/assets/demo/markdown/aurora-docs/guides/tuning.md
@@ -1,0 +1,3 @@
+# tuning
+
+TODO.

--- a/docs/assets/demo/markdown/aurora-docs/package.json
+++ b/docs/assets/demo/markdown/aurora-docs/package.json
@@ -1,0 +1,1 @@
+{ "name": "aurora", "version": "3.0.0" }

--- a/docs/assets/demo/markdown/aurora-docs/reference/api-grpc.md
+++ b/docs/assets/demo/markdown/aurora-docs/reference/api-grpc.md
@@ -1,0 +1,3 @@
+# api-grpc
+
+TODO.

--- a/docs/assets/demo/markdown/aurora-docs/reference/api-http.md
+++ b/docs/assets/demo/markdown/aurora-docs/reference/api-http.md
@@ -1,0 +1,3 @@
+# api-http
+
+TODO.

--- a/docs/assets/demo/markdown/aurora-docs/reference/metrics.md
+++ b/docs/assets/demo/markdown/aurora-docs/reference/metrics.md
@@ -1,0 +1,3 @@
+# Metrics
+
+TODO.

--- a/docs/assets/demo/markdown/aurora-docs/reference/wire-format.md
+++ b/docs/assets/demo/markdown/aurora-docs/reference/wire-format.md
@@ -1,0 +1,3 @@
+# wire-format
+
+TODO.

--- a/docs/assets/demo/markdown/demo.sh
+++ b/docs/assets/demo/markdown/demo.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env zsh
+set -u
+HERE=${0:A:h}
+STAGE=${SPYC_DEMO_STAGE:-/private/tmp/spyc-demo}
+R="$STAGE/aurora-docs"
+CAST="$STAGE/out/take.cast"
+# Disposable copy of the fixture that ships beside this script: a beat edits
+# RELEASE-NOTES.md, and the repo copy stays pristine.
+mkdir -p "$STAGE/out"
+rm -rf "$R" && mkdir -p "$R" && cp -R "$HERE/aurora-docs/." "$R"
+export TUI_TEST_SESSION=spycdemo
+TT=tui-test
+
+say()  { print -r -- "  ‣ $*" }
+k()    { $TT key press "$1" >/dev/null; sleep "${2:-0.5}" }
+chord(){ $TT key press Ctrl+a >/dev/null; $TT type "$1" >/dev/null; sleep "${2:-1.1}" }
+slowtype(){ local s=$1 d=${2:-0.05} i; for (( i=1; i<=${#s}; i++ )); do $TT type "${s[i]}" >/dev/null; sleep $d; done }
+xp()   { $TT expect text "$1" --no-strict --timeout "${2:-15000}" >/dev/null || { print -u2 "  ✗ FAIL expect: $1"; return 1; } }
+# assert text in the RIGHT column only (cols 101-200) -- proves the PREVIEW re-rendered,
+# not vim's copy of the same string
+xp_right(){ local pat=$1 i
+  for i in {1..40}; do
+    $TT text 2>/dev/null | cut -c101-200 | grep -q -- "$pat" && { print -r -- "  ✓ right column has: $pat"; return 0 }
+    sleep 0.5
+  done
+  print -u2 "  ✗ FAIL right column: $pat"; return 1 }
+
+cp "$HERE/aurora-docs/RELEASE-NOTES.md" "$R/RELEASE-NOTES.md"
+rm -f "$CAST"
+$TT close --all >/dev/null 2>&1
+
+say "open ghostty session, truecolor"
+$TT open --backend ghostty --cols 200 --rows 50 --cwd "$R" --shell zsh \
+   --env "SPYC_PANE_CMD=vim RELEASE-NOTES.md" \
+   --env "COLORTERM=truecolor" >/dev/null
+$TT record start "$CAST" >/dev/null
+
+say "beat 1 — launch"
+$TT submit "spyc" >/dev/null
+xp "CONTRIBUTING.md" || exit 1
+sleep 2.2
+
+say "beat 2 — browse"
+for i in 1 2 3; do k j 0.38; done
+sleep 0.6; k G 1.5
+
+say "beat 3 — full-height rendered markdown"
+k Ctrl+s 0.15; $TT type "|" >/dev/null
+xp "parked_producer" || exit 1
+sleep 2.8
+
+say "beat 4 — scroll the render"
+chord b 0.9
+k g 0.1; k g 1.0
+sleep 1.2
+for i in 1 2 3 4; do k Ctrl+d 1.0; done
+sleep 1.0
+k g 0.1; k g 1.3
+
+say "beat 5 — vim in the bottom pane"
+chord a 0.9
+chord c 1.5
+k Enter 1.0
+k Enter 3.2
+xp "1485B" || exit 1
+sleep 1.2
+
+say "beat 6 — edit + save"
+k G 0.8
+$TT type "o" >/dev/null; sleep 0.6
+k Enter 0.3                    # leave a blank line: an alert must be its OWN block
+slowtype '## Rollback'; k Enter 0.3
+k Enter 0.3
+slowtype '> [!CAUTION]'; k Enter 0.3
+slowtype '> Roll back with `aurora rollback --to 2.9`.'
+sleep 0.5
+k Escape 0.9
+slowtype ':w'; k Enter 0.3
+
+say "beat 7 — preview re-renders; scroll it to the new block"
+xp "written" || exit 1          # vim confirms the write
+sleep 1.6
+chord b 0.9                    # focus the preview
+k G 1.6                        # jump to the end of the RENDERED doc
+xp_right "CAUTION" || exit 1   # the payoff, proven in the right column
+sleep 4
+
+$TT record stop >/dev/null
+say "cast -> $CAST"
+$TT close --all >/dev/null 2>&1
+cp "$HERE/aurora-docs/RELEASE-NOTES.md" "$R/RELEASE-NOTES.md"

--- a/docs/assets/demo/markdown/fold.sh
+++ b/docs/assets/demo/markdown/fold.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env zsh
+set -u
+HERE=${0:A:h}
+STAGE=${SPYC_DEMO_STAGE:-/private/tmp/spyc-demo}
+R="$STAGE/aurora-docs"
+CAST="$STAGE/out/fold.cast"
+mkdir -p "$STAGE/out"
+rm -rf "$R" && mkdir -p "$R" && cp -R "$HERE/aurora-docs/." "$R"
+export TUI_TEST_SESSION=spycfold
+TT=tui-test
+say(){ print -r -- "  ‣ $*" }
+k(){ $TT key press "$1" >/dev/null; sleep "${2:-0.5}" }
+z(){ $TT type "$1" >/dev/null; sleep 0.35; $TT type "$2" >/dev/null; sleep "${3:-1.8}" }   # chord, keyed slowly
+xp(){ $TT expect text "$1" --no-strict --timeout "${2:-15000}" >/dev/null || { print -u2 "  ✗ FAIL: $1"; return 1; } }
+# assert the NUMBER of fold markers -- an assertion that actually bites
+folds(){ $TT text 2>/dev/null | grep -c "▸" }
+want_folds(){ local want=$1 i n
+  for i in {1..30}; do n=$(folds); [[ "$n" == "$want" ]] && { print -r -- "  ✓ $want folds"; return 0 }; sleep 0.4; done
+  print -u2 "  ✗ FAIL: wanted $want folds, saw $(folds)"; return 1 }
+
+rm -f "$CAST"; $TT close --all >/dev/null 2>&1
+$TT open --backend ghostty --cols 170 --rows 44 --cwd "$R" --shell zsh --env "COLORTERM=truecolor" >/dev/null
+$TT record start "$CAST" >/dev/null
+
+say "open the handbook in the pager"
+$TT submit "spyc" >/dev/null
+xp "HANDBOOK.md" || exit 1
+sleep 2
+$TT type "/HAND" >/dev/null; sleep 0.5; k Enter 0.6; k Escape 0.5
+k Enter 2.6
+k g 0.1; k g 1.0
+xp "audience: operators" || exit 1
+sleep 2.5
+
+say "]] then za — fold just the section you are reading"
+$TT type "]]" >/dev/null; sleep 1.4
+$TT type "za" >/dev/null; sleep 1.0
+want_folds 1 || exit 1
+sleep 3
+$TT type "za" >/dev/null; sleep 1.0
+want_folds 0 || exit 1
+sleep 1.5
+k g 0.1; k g 1.2
+
+say "zM — the whole doc becomes a table of contents"
+z z M 1.0
+want_folds 10 || exit 1
+sleep 4.5
+
+say "]] — walk the table of contents"
+for i in 1 2 3; do $TT type "]]" >/dev/null; sleep 1.0; done
+sleep 1
+
+say "zR — expand everything again"
+z z R 1.0
+want_folds 0 || exit 1
+sleep 2
+k g 0.1; k g 1.5
+
+say "m — flip to raw markdown source and back"
+$TT type "m" >/dev/null; sleep 3
+$TT type "m" >/dev/null; sleep 2.5
+
+$TT record stop >/dev/null
+say "cast -> $CAST"
+$TT close --all >/dev/null 2>&1

--- a/docs/assets/demo/markdown/mermaid-beat.md
+++ b/docs/assets/demo/markdown/mermaid-beat.md
@@ -1,0 +1,34 @@
+# The mermaid beat — must be a REAL screen capture
+
+No scripted recorder can capture it (both vhs and tui-test rasterize text cells
+only; spyc emits the bitmap and the recorder drops it). Do this take live.
+
+1. Stage the fixture (the AppleScript harness does this for you; by hand it is
+   a copy), open a REAL Ghostty window, size it ~200x50, and enter the tree:
+       rm -rf /private/tmp/spyc-demo/aurora-docs
+       mkdir -p /private/tmp/spyc-demo/aurora-docs
+       cp -R aurora-docs/. /private/tmp/spyc-demo/aurora-docs
+       cd /private/tmp/spyc-demo/aurora-docs && spyc
+
+2. Start capture in another terminal (window-only, retina, 30fps).
+   List devices first, then pick the screen index:
+       ffmpeg -f avfoundation -list_devices true -i "" 2>&1 | grep -i screen
+       ffmpeg -f avfoundation -framerate 30 -i "<screen-index>:none" \
+              -c:v libx264 -preset ultrafast -crf 14 -pix_fmt yuv420p mermaid-raw.mov
+   (Needs Screen Recording permission for your terminal in System Settings →
+   Privacy & Security. QuickTime "New Screen Recording" works just as well.)
+
+3. Keystrokes, slowly:
+       /HAND  <Enter>  <Esc>      select HANDBOOK.md   (or RELEASE-NOTES.md)
+       <Enter>                    open the in-app pager
+       /mermaid <Enter>           jump to the fence
+       i                          render the diagram inline, full screen
+       c                          light/dark toggle  <- nice beat
+       q                          dismiss
+
+4. Trim and mute:
+       ffmpeg -i mermaid-raw.mov -ss <start> -to <end> -an \
+              -c:v libx264 -crf 18 -pix_fmt yuv420p mermaid-beat.mp4
+
+Splice it after beat 4 of spyc-markdown-demo.mp4. Match the font size so the cut
+is invisible: the scripted clips render at MesloLGL Nerd Font Mono, 15px.

--- a/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
+++ b/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
@@ -1,0 +1,542 @@
+-- ===========================================================================
+--  spyc · markdown demo — driven live in ONE reused iTerm window, and filmed
+--  --------------------------------------------------------------------------
+--  Why a real recording: spyc paints mermaid diagrams with a terminal graphics
+--  protocol, and every scripted terminal recorder (vhs, tui-test) rasterizes
+--  text cells only -- it renders the bitmap and the recorder throws it away.
+--  So we drive the real app and film the real screen.
+--
+--  Why iTerm2 rather than System Events:
+--    · exact geometry     -- `set columns to 200` / `set rows to 50`
+--    · no focus stealing  -- keys go to the SESSION, so you can keep working
+--    · readback           -- `get text` lets the script ASSERT, not just sleep
+--  spyc supports iTerm2's native image protocol explicitly (SPYC-TRAP
+--  iterm-osc1337), so diagrams paint correctly here.
+--
+--  ONE WINDOW, REUSED. The window id is remembered in a state file and the
+--  session is tagged, so repeat runs land in the same window instead of
+--  littering your desktop. Each run leaves it at a shell prompt.
+--
+--  Run:       osascript spyc-quicktime-demo.applescript
+--  Rehearse:  osascript spyc-quicktime-demo.applescript dry    (no recording)
+--
+--  Paths resolve from this script's own folder; the fixture is staged to
+--  /private/tmp/spyc-demo and takes are written there too, never into the repo.
+--
+--  macOS prompts once for Screen Recording (QuickTime Player, or this terminal
+--  if you set recorder to "screencapture").
+-- ===========================================================================
+
+--  The fixture tree ships beside this script. It is COPIED to a disposable
+--  staging dir per run, because a beat edits RELEASE-NOTES.md and the repo copy
+--  must stay pristine -- a `git checkout --` against the repo copy would reach
+--  into spyc's own working tree.
+property stageDir    : "/private/tmp/spyc-demo"
+property demoDir     : "/private/tmp/spyc-demo/aurora-docs"
+--  Takes land OUTSIDE the repo on purpose: a .mov belongs in a release asset,
+--  never in git history.
+property outDir      : "/private/tmp/spyc-demo/out"
+property colCount    : 200
+property rowCount    : 50
+property recorder    : "quicktime"   -- "quicktime" (full screen + crop) | "screencapture" (region)
+property typeDelay   : 0.055
+property tagName     : "SPYC-DEMO"
+property paneCmd     : "vim -n RELEASE-NOTES.md"   -- -n = NO SWAP FILE. A stale
+--  .swp from an interrupted run makes vim open on its E325 recovery prompt
+--  instead of the file, which silently breaks every later beat.
+
+global sess, win, isDry
+
+-- ------------------------------------------------------------------ plumbing
+on sh(c)
+	return do shell script c
+end sh
+
+-- Where this script (and its aurora-docs/ fixture) lives. `path to me` is the
+-- script itself under `osascript file.applescript`, but resolves to the
+-- osascript binary under some hosts -- so verify the fixture is really there
+-- and fall back to an override rather than staging an empty tree.
+on harnessDir()
+	try
+		set d to my sh("dirname " & quoted form of (POSIX path of (path to me)))
+	on error
+		set d to ""
+	end try
+	if d is not "" and (my sh("test -d " & quoted form of (d & "/aurora-docs") & " && echo y || echo n")) is "y" then
+		return d
+	end if
+	set o to my sh("printf %s \"${SPYC_DEMO_HARNESS_DIR:-}\"")
+	if o is not "" then return o
+	error "cannot locate the harness: run this from its folder in the repo, or set SPYC_DEMO_HARNESS_DIR to the folder holding aurora-docs/"
+end harnessDir
+
+-- Fresh disposable copy of the fixture + a clean output dir. This is also the
+-- RESET between runs: no git, no leftover .swp, no edited RELEASE-NOTES.md.
+on stageFixture()
+	set src to my harnessDir() & "/aurora-docs"
+	my sh("rm -rf " & quoted form of demoDir & " && mkdir -p " & quoted form of demoDir & " " & quoted form of outDir & ¬
+		" && cp -R " & quoted form of (src & "/.") & " " & quoted form of demoDir)
+end stageFixture
+
+on trace(m)
+	log "  ‣ " & m
+end trace
+
+on stateFile()
+	return outDir & "/.demo-window-id"
+end stateFile
+
+-- one key, no newline: a KEYPRESS, not a command
+on emit(s)
+	tell application "iTerm2" to tell sess to write text s newline no
+end emit
+
+on typeSlow(s)
+	repeat with i from 1 to length of s
+		my emit(character i of s)
+		delay typeDelay
+	end repeat
+end typeSlow
+
+on ctrlKey(c)
+	my emit(ASCII character ((ASCII number c) - 96))   -- ^a=1 ^d=4 ^s=19
+end ctrlKey
+
+on enter()
+	my emit(ASCII character 13)
+end enter
+
+on escKey()
+	my emit(ASCII character 27)
+end escKey
+
+on chordA(c)
+	my ctrlKey("a")
+	delay 0.14
+	my emit(c)
+	delay 1.0
+end chordA
+
+on chordZ(c)
+	my emit("z")
+	delay 0.32
+	my emit(c)
+	delay 1.0
+end chordZ
+
+-- iTerm2 hands back the WHOLE SCROLLBACK (617 lines for a 50-row window), and
+-- `contents` is no different. Matching against that is how an assertion passes
+-- on stale output from earlier in the session, and how a `▸` count ends up
+-- tallying folds from three beats ago. The visible screen is the LAST rowCount
+-- lines, so slice it.
+on screenText()
+	tell application "iTerm2" to set t to (get text of sess)
+	set ps to paragraphs of t
+	set n to count of ps
+	set i0 to n - rowCount + 1
+	if i0 < 1 then set i0 to 1
+	set acc to ""
+	repeat with i from i0 to n
+		set acc to acc & (item i of ps) & linefeed
+	end repeat
+	return acc
+end screenText
+
+-- right half only. The payoff assertion MUST be scoped: vim shows the same text
+-- bottom-left, so a whole-screen match would prove nothing about the preview.
+on rightText()
+	set cut to (colCount / 2) as integer
+	set acc to ""
+	repeat with para in (paragraphs of (my screenText()))
+		set l to (para as text)
+		if (length of l) > cut then set acc to acc & (text (cut + 1) thru -1 of l) & linefeed
+	end repeat
+	return acc
+end rightText
+
+on dumpScreen(tag)
+	try
+		set f to outDir & "/dump-" & (my sh("date +%H%M%S")) & ".txt"
+		my sh("cat > " & quoted form of f & " <<'SPYCEOF'" & linefeed & (my screenText()) & linefeed & "SPYCEOF")
+		my trace("  ✗ " & tag & " — screen dumped to " & f)
+	end try
+end dumpScreen
+
+-- poll the real screen instead of guessing with delay
+on waitFor(pat, secs)
+	repeat with i from 1 to (secs * 4)
+		try
+			if (my screenText()) contains pat then
+				my trace("  ✓ " & pat)
+				return true
+			end if
+		end try
+		delay 0.25
+	end repeat
+	my dumpScreen("waitFor " & pat)
+	error "timed out waiting for: " & pat
+end waitFor
+
+on waitForRight(pat, secs)
+	repeat with i from 1 to (secs * 4)
+		try
+			if (my rightText()) contains pat then
+				my trace("  ✓ right column: " & pat)
+				return true
+			end if
+		end try
+		delay 0.25
+	end repeat
+	my dumpScreen("waitForRight " & pat)
+	error "timed out waiting for " & pat & " in the RIGHT column"
+end waitForRight
+
+on countOf(needle)
+	set t to my screenText()
+	set tid to AppleScript's text item delimiters
+	set AppleScript's text item delimiters to needle
+	set n to (count of text items of t) - 1
+	set AppleScript's text item delimiters to tid
+	return n
+end countOf
+
+on waitForCount(needle, want, secs)
+	repeat with i from 1 to (secs * 4)
+		if (my countOf(needle)) is want then
+			my trace("  ✓ " & want & " × " & needle)
+			return true
+		end if
+		delay 0.25
+	end repeat
+	my dumpScreen("waitForCount " & needle)
+	error "wanted " & want & " × " & needle & ", saw " & (my countOf(needle))
+end waitForCount
+
+-- ------------------------------------------------- one window, found or made
+on acquireWindow()
+	set w to missing value
+
+	-- 1. the window we used last time
+	try
+		set wid to (my sh("cat " & quoted form of (my stateFile()))) as integer
+		tell application "iTerm2" to set w to (first window whose id is wid)
+		my trace("reusing window " & wid)
+	end try
+
+	-- 2. any window still carrying our tag
+	if w is missing value then
+		tell application "iTerm2"
+			repeat with ww in windows
+				try
+					if (name of current session of ww) contains tagName then
+						set w to ww
+						my trace("reusing tagged window")
+						exit repeat
+					end if
+				end try
+			end repeat
+		end tell
+	end if
+
+	-- 3. make one
+	if w is missing value then
+		tell application "iTerm2" to set w to (create window with default profile)
+		my trace("created a new window")
+	end if
+
+	set win to w
+	-- A fresh TAB in the reused window. Trying to quit the previous spyc with
+	-- ^d is unreliable (it needs ^d^d, and a half-quit instance then eats the
+	-- launch command as keystrokes); a new tab is unconditional. New tab first,
+	-- so the window is never left with zero tabs and cannot disappear.
+	tell application "iTerm2"
+		set nOld to count of tabs of w
+		tell w to create tab with default profile
+		delay 1
+		repeat nOld times
+			try
+				tell tab 1 of w to close
+				delay 0.5
+			end try
+		end repeat
+		delay 0.5
+		set sess to current session of w
+		tell sess
+			set name to tagName
+			set columns to colCount
+			set rows to rowCount
+		end tell
+	end tell
+	my sh("echo " & (id of w) & " > " & quoted form of (my stateFile()))
+	return w
+end acquireWindow
+
+-- leave whatever ran last time; get back to a shell prompt WITHOUT sending a
+-- bare ^d at a shell (that would exit the shell and close the tab)
+on ensureShell()
+	repeat with i from 1 to 6
+		set t to ""
+		try
+			set t to my screenText()
+		end try
+		if t contains "picks:" then          -- spyc's status bar => spyc is up
+			my trace("quitting the previous spyc")
+			my ctrlKey("d")
+			delay 1.5
+		else if t contains "E325" or t contains "swap file" then
+			my emit("q")                     -- dismiss a vim recovery prompt
+			delay 1
+		else
+			return true
+		end if
+	end repeat
+	return true
+end ensureShell
+
+-- ----------------------------------------------------------------- recording
+on screenPoints()
+	-- `zoomed` maximizes to the visible frame, so reading the bounds back gives
+	-- the screen size IN POINTS with no extra dependency. A scaled display is
+	-- NOT 2x -- this machine is 3456px over 2056pt = 1.68 -- so this matters.
+	tell application "iTerm2"
+		set old to bounds of win
+		set zoomed of win to true
+		delay 0.6
+		set b to bounds of win
+		set zoomed of win to false
+		delay 0.4
+		set bounds of win to old
+		delay 0.3
+	end tell
+	return {item 3 of b, item 4 of b}
+end screenPoints
+
+on startRec(path_)
+	if isDry then
+		my trace("[dry] recording skipped")
+		return
+	end if
+	if recorder is "quicktime" then
+		tell application "QuickTime Player"
+			activate
+			set r to new screen recording
+			start r
+		end tell
+		delay 3
+		tell application "iTerm2" to activate
+		delay 1
+	else
+		my sh("nohup screencapture -v -D 1 " & quoted form of path_ & " >/dev/null 2>&1 &")
+		delay 2.5
+	end if
+end startRec
+
+on stopRec(path_)
+	if isDry then return
+	if recorder is "quicktime" then
+		tell application "QuickTime Player"
+			stop document 1
+			delay 2
+			save document 1 in file (POSIX file path_)
+			delay 3
+			close document 1 saving no
+			quit saving no
+		end tell
+	else
+		my sh("pkill -INT -x screencapture || true")
+		delay 3
+	end if
+end stopRec
+
+-- =========================================================================
+on run argv
+	set isDry to (argv contains "dry")
+	set stamp to my sh("date +%Y%m%d-%H%M%S")
+	set rawPath to outDir & "/qt-raw-" & stamp & ".mov"
+	set outPath to outDir & "/spyc-mermaid-" & stamp & ".mp4"
+
+	my trace("resetting the demo tree")
+	my stageFixture()
+	-- reap vim panes an interrupted run left behind. The pattern is our own
+	-- launch wrapper, so this cannot touch an unrelated editor.
+	my sh("pkill -f " & quoted form of ("exec " & paneCmd) & " 2>/dev/null; true")
+
+	my acquireWindow()
+
+	my trace("launching spyc at " & colCount & "x" & rowCount)
+	tell application "iTerm2" to tell sess to ¬
+		write text "cd " & quoted form of demoDir & " && clear && SPYC_PANE_CMD=" & quoted form of paneCmd & " spyc"
+	my waitFor("CONTRIBUTING.md", 25)
+	delay 2
+
+	set pts to my screenPoints()
+	tell application "iTerm2" to set wb to bounds of win
+	my trace("window " & (item 1 of wb) & "," & (item 2 of wb) & " → " & (item 3 of wb) & "," & (item 4 of wb) & "   screen " & (item 1 of pts) & "x" & (item 2 of pts))
+
+	my trace("recording (" & recorder & ")")
+	my startRec(rawPath)
+	delay 1.5
+
+	try
+		------------------------------------------------------------- beat 1
+		my trace("beat 1 — browse the docs tree")
+		repeat 3 times
+			my emit("j")
+			delay 0.42
+		end repeat
+		delay 1
+		my emit("G")
+		delay 1.5
+
+		------------------------------------------------------------- beat 2
+		my trace("beat 2 — full-height rendered markdown preview")
+		my ctrlKey("s")
+		delay 0.25
+		my emit("|")
+		my waitFor("compression codec", 15)
+		delay 3
+		my chordA("b")
+		my emit("g")
+		delay 0.12
+		my emit("g")
+		delay 1.5
+		repeat 4 times
+			my ctrlKey("d")
+			delay 1.1
+		end repeat
+		delay 1
+		my emit("g")
+		delay 0.12
+		my emit("g")
+		delay 1.5
+
+		------------------------------------------------------------- beat 3
+		my trace("beat 3 — edit in vim, preview re-renders on save")
+		my chordA("a")
+		my chordA("c")
+		delay 1.4
+		my enter()          -- accept the prefilled command ($SPYC_PANE_CMD)
+		delay 1.2
+		my enter()          -- accept the prefilled cwd
+		my waitFor("1485B", 20)
+		delay 1.5
+		my emit("G")
+		delay 0.9
+		my emit("o")
+		delay 0.7
+		my enter()
+		my typeSlow("## Rollback")
+		my enter()
+		my enter()
+		my typeSlow("> [!CAUTION]")
+		my enter()
+		my typeSlow("> Roll back with `aurora rollback --to 2.9`.")
+		delay 0.5
+		my escKey()
+		delay 0.9
+		my typeSlow(":w")
+		my enter()
+		my waitFor("written", 20)
+		delay 1.5
+
+		my chordA("k")      -- pane -> list. ^a a / ^a b only move between COLUMNS
+		delay 0.8
+		my chordA("b")      -- the preview column
+		my emit("G")
+		my waitForRight("CAUTION", 20)
+		delay 4
+
+		-- Quitting vim does NOT remove the tab: spyc keeps it and shows
+		-- "pane exited — ^a-R to restart, ^a-x to close". So close the tab
+		-- explicitly, and use the ^a | ALIAS for the split, because plain ^s
+		-- never reaches spyc while a pane holds focus.
+		my chordA("j")
+		delay 0.8
+		my typeSlow(":q")
+		my enter()
+		my waitFor("[exited", 15)   -- the DIVIDER, not the flash: "pane exited" fades
+		my chordA("x")      -- close the exited tab (no confirm once the child is gone)
+		delay 2
+		my chordA("|")      -- close the vsplit
+		delay 2
+
+		------------------------------------------------------------- beat 4
+		my trace("beat 4 — outline folding")
+		my emit("/HAND")
+		delay 0.9
+		my enter()
+		delay 0.7
+		my escKey()
+		delay 0.6
+		my enter()
+		my waitFor("audience: operators", 15)
+		my emit("g")
+		delay 0.12
+		my emit("g")
+		delay 1.5
+		my chordZ("M")
+		my waitForCount("▸", 10, 12)
+		delay 4.5
+		repeat 3 times
+			my emit("]]")
+			delay 1
+		end repeat
+		my chordZ("R")
+		my waitForCount("▸", 0, 12)
+		delay 2
+
+		--------------------------------------------- beat 5 — THE MERMAID BEAT
+		my trace("beat 5 — mermaid diagram rendered in the terminal")
+		my emit("/mermaid")
+		delay 1
+		my enter()
+		delay 1.8
+		my emit("i")
+		my waitFor("mermaid diagram", 25)
+		my trace("      diagram is on screen — the frame no scripted recorder can capture")
+		delay 5
+		my emit("c")
+		delay 4
+		my escKey()
+		delay 1.5
+		my escKey()
+		delay 2
+	on error e
+		my trace("BEAT FAILED: " & e)
+	end try
+
+	my trace("stopping recording")
+	my stopRec(rawPath)
+
+	-- always leave the window at a shell prompt, ready to be reused
+	try
+		my escKey()
+		delay 0.5
+		my ctrlKey("d")
+		delay 1.5
+	end try
+	my stageFixture()
+
+	if not isDry then
+		set cmd to "set -e" & ¬
+			"; RAW=" & quoted form of rawPath & ¬
+			"; OUT=" & quoted form of outPath & ¬
+			"; VW=$(ffprobe -v error -select_streams v -show_entries stream=width -of csv=p=0 \"$RAW\")" & ¬
+			"; SC=$(python3 -c \"print(round($VW/" & (item 1 of pts) & ",4))\")" & ¬
+			"; X=$(python3 -c \"print(int(" & (item 1 of wb) & "*$SC)//2*2)\")" & ¬
+			"; Y=$(python3 -c \"print(int(" & (item 2 of wb) & "*$SC)//2*2)\")" & ¬
+			"; W=$(python3 -c \"print(int((" & (item 3 of wb) & "-" & (item 1 of wb) & ")*$SC)//2*2)\")" & ¬
+			"; H=$(python3 -c \"print(int((" & (item 4 of wb) & "-" & (item 2 of wb) & ")*$SC)//2*2)\")" & ¬
+			"; echo \"video=${VW}px scale=$SC crop=${W}x${H}+${X}+${Y}\"" & ¬
+			"; ffmpeg -v error -i \"$RAW\" -vf \"crop=$W:$H:$X:$Y\" -an -c:v libx264 -crf 18 -pix_fmt yuv420p -movflags +faststart \"$OUT\" -y" & ¬
+			"; echo \"$OUT\""
+		try
+			my trace(my sh(cmd))
+		on error e2
+			my trace("crop failed: " & e2)
+			my trace("uncropped take kept at " & rawPath)
+		end try
+	end if
+
+	my trace("done — window left open for the next run")
+end run

--- a/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
+++ b/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
@@ -324,8 +324,17 @@ on startRec(path_, rect_)
 	if recorder is "quicktime" then
 		tell application "QuickTime Player"
 			activate
-			set qtDoc to new screen recording
-			start qtDoc
+			-- `new screen recording` declares NO <result> in QuickTime's sdef,
+			-- while `new audio recording` and `new movie recording` both return
+			-- a document -- so `set x to new screen recording` can never bind,
+			-- and reports the useless "the variable x is not defined". Take the
+			-- document off the app instead.
+			new screen recording
+			delay 1
+			if (count of documents) is 0 then
+				error "QuickTime made no recording document -- it has no Screen Recording grant (System Settings > Privacy & Security > Screen & System Audio Recording). Use the screencapture recorder."
+			end if
+			start document 1
 		end tell
 		delay 3
 		tell application "iTerm2" to activate

--- a/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
+++ b/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
@@ -43,7 +43,7 @@ property rowCount    : 50
 --  path is kept only for older systems: on macOS 26 `new screen recording`
 --  returns no document at all, so `start` fails with "variable is not defined".
 property recorder    : "screencapture"   -- "screencapture" (region) | "quicktime" (dead on macOS 26)
-property typeDelay   : 0.055
+property typeDelay   : 0.042
 property tagName     : "SPYC-DEMO"
 property paneCmd     : "vim -n RELEASE-NOTES.md"   -- -n = NO SWAP FILE. A stale
 --  .swp from an interrupted run makes vim open on its E325 recovery prompt
@@ -401,18 +401,18 @@ on run argv
 		my trace("beat 1 — browse the docs tree")
 		repeat 3 times
 			my emit("j")
-			delay 0.42
+			delay 0.29
 		end repeat
-		delay 1
+		delay 0.68
 		my emit("G")
-		delay 1.5
+		delay 1.02
 
 		------------------------------------------------------------- beat 2
 		my trace("beat 2 — full-height rendered markdown preview")
 		my ctrlKey("s")
-		delay 0.25
+		delay 0.17
 		my emit("|")
-		delay 1.5
+		delay 1.02
 		-- spyc RESTORES the scroll position, so a re-run opens the preview where
 		-- the last run left it -- at the bottom, if that run ended on the mermaid
 		-- fence. Take the top BEFORE asserting, or the anchor is off-screen above
@@ -422,31 +422,31 @@ on run argv
 		delay 0.12
 		my emit("g")
 		my waitFor("compression codec", 15)
-		delay 3
-		repeat 4 times
+		delay 2.04
+		repeat 3 times
 			my ctrlKey("d")
-			delay 1.1
+			delay 0.75
 		end repeat
-		delay 1
+		delay 0.68
 		my emit("g")
 		delay 0.12
 		my emit("g")
-		delay 1.5
+		delay 1.02
 
 		------------------------------------------------------------- beat 3
 		my trace("beat 3 — edit in vim, preview re-renders on save")
 		my chordA("a")
 		my chordA("c")
-		delay 1.4
+		delay 0.95
 		my enter()          -- accept the prefilled command ($SPYC_PANE_CMD)
-		delay 1.2
+		delay 0.82
 		my enter()          -- accept the prefilled cwd
 		my waitFor("1485B", 20)
-		delay 1.5
+		delay 1.02
 		my emit("G")
-		delay 0.9
+		delay 0.61
 		my emit("o")
-		delay 0.7
+		delay 0.48
 		my enter()
 		my typeSlow("## Rollback")
 		my enter()
@@ -454,60 +454,60 @@ on run argv
 		my typeSlow("> [!CAUTION]")
 		my enter()
 		my typeSlow("> Roll back with `aurora rollback --to 2.9`.")
-		delay 0.5
+		delay 0.34
 		my escKey()
-		delay 0.9
+		delay 0.61
 		my typeSlow(":w")
 		my enter()
 		my waitFor("written", 20)
-		delay 1.5
+		delay 1.02
 
 		my chordA("k")      -- pane -> list. ^a a / ^a b only move between COLUMNS
-		delay 0.8
+		delay 0.54
 		my chordA("b")      -- the preview column
 		my emit("G")
 		my waitForRight("CAUTION", 20)
-		delay 4
+		delay 2.72
 
 		-- Quitting vim does NOT remove the tab: spyc keeps it and shows
 		-- "pane exited — ^a-R to restart, ^a-x to close". So close the tab
 		-- explicitly, and use the ^a | ALIAS for the split, because plain ^s
 		-- never reaches spyc while a pane holds focus.
 		my chordA("j")
-		delay 0.8
+		delay 0.54
 		my typeSlow(":q")
 		my enter()
 		my waitFor("[exited", 15)   -- the DIVIDER, not the flash: "pane exited" fades
 		my chordA("x")      -- close the exited tab (no confirm once the child is gone)
-		delay 2
+		delay 1.36
 		my chordA("|")      -- close the vsplit
-		delay 2
+		delay 1.36
 
 		------------------------------------------------------------- beat 4
 		my trace("beat 4 — outline folding")
 		my emit("/HAND")
-		delay 0.9
+		delay 0.61
 		my enter()
-		delay 0.7
+		delay 0.48
 		my escKey()
-		delay 0.6
+		delay 0.41
 		my enter()
-		delay 1.2
+		delay 0.82
 		my emit("g")
 		delay 0.12
 		my emit("g")
 		my waitFor("audience: operators", 15)
-		delay 1.5
+		delay 1.02
 		my chordZ("M")
 		my waitForCount("▸", 10, 12)
-		delay 4.5
+		delay 3.06
 		repeat 3 times
 			my emit("]]")
-			delay 1
+			delay 0.68
 		end repeat
 		my chordZ("R")
 		my waitForCount("▸", 0, 12)
-		delay 2
+		delay 1.36
 
 		--------------------------------------------- beat 5 — THE MERMAID BEAT
 		my trace("beat 5 — mermaid diagram rendered in the terminal")
@@ -515,24 +515,24 @@ on run argv
 		-- the pager on HANDBOOK.md -- so leave it and open the right file, or
 		-- `i` has nothing to render and the beat films a plain page of text.
 		my escKey()
-		delay 1.2
+		delay 0.82
 		my emit("/RELEASE")
-		delay 0.9
+		delay 0.61
 		my enter()
-		delay 0.7
+		delay 0.48
 		my escKey()
-		delay 0.6
+		delay 0.41
 		my enter()
-		delay 1.2
+		delay 0.82
 		my emit("g")
 		delay 0.12
 		my emit("g")
 		my waitFor("streaming ingest layer", 15)
-		delay 1.2
+		delay 0.82
 		my emit("/mermaid")
-		delay 1
+		delay 0.68
 		my enter()
-		delay 1.8
+		delay 1.22
 		my emit("i")
 		-- `mermaid diagram` alone is NOT evidence: it is also the rendered
 		-- placeholder block, and it is inside the refusal "no mermaid diagram
@@ -540,13 +540,13 @@ on run argv
 		-- origin, so it cannot match anything but a diagram actually on screen.
 		my waitFor("c theme", 25)
 		my trace("      diagram is on screen — the frame no scripted recorder can capture")
-		delay 5
+		delay 3.4
 		my emit("c")
-		delay 4
+		delay 2.72
 		my escKey()
-		delay 1.5
+		delay 1.02
 		my escKey()
-		delay 2
+		delay 1.36
 	on error e
 		my trace("BEAT FAILED: " & e)
 	end try

--- a/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
+++ b/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
@@ -332,7 +332,7 @@ on startRec(path_, rect_)
 			new screen recording
 			delay 1
 			if (count of documents) is 0 then
-				error "QuickTime made no recording document -- it has no Screen Recording grant (System Settings > Privacy & Security > Screen & System Audio Recording). Use the screencapture recorder."
+				error "QuickTime made no recording document. It reports \"encountered an error while recording your screen -- try using the Screenshot app instead\", which is what the screencapture recorder already is. Use recorder \"screencapture\"."
 			end if
 			start document 1
 		end tell

--- a/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
+++ b/docs/assets/demo/markdown/spyc-quicktime-demo.applescript
@@ -38,7 +38,11 @@ property demoDir     : "/private/tmp/spyc-demo/aurora-docs"
 property outDir      : "/private/tmp/spyc-demo/out"
 property colCount    : 200
 property rowCount    : 50
-property recorder    : "quicktime"   -- "quicktime" (full screen + crop) | "screencapture" (region)
+--  `screencapture -v -R` films JUST the window rect, so nothing else on the
+--  desktop is ever in the file and no crop pass is needed. The "quicktime"
+--  path is kept only for older systems: on macOS 26 `new screen recording`
+--  returns no document at all, so `start` fails with "variable is not defined".
+property recorder    : "screencapture"   -- "screencapture" (region) | "quicktime" (dead on macOS 26)
 property typeDelay   : 0.055
 property tagName     : "SPYC-DEMO"
 property paneCmd     : "vim -n RELEASE-NOTES.md"   -- -n = NO SWAP FILE. A stale
@@ -311,7 +315,8 @@ on screenPoints()
 	return {item 3 of b, item 4 of b}
 end screenPoints
 
-on startRec(path_)
+-- rect_ is "x,y,w,h" in POINTS -- screencapture captures it at native scale.
+on startRec(path_, rect_)
 	if isDry then
 		my trace("[dry] recording skipped")
 		return
@@ -319,15 +324,18 @@ on startRec(path_)
 	if recorder is "quicktime" then
 		tell application "QuickTime Player"
 			activate
-			set r to new screen recording
-			start r
+			set qtDoc to new screen recording
+			start qtDoc
 		end tell
 		delay 3
 		tell application "iTerm2" to activate
 		delay 1
 	else
-		my sh("nohup screencapture -v -D 1 " & quoted form of path_ & " >/dev/null 2>&1 &")
+		my sh("nohup screencapture -v -R " & rect_ & " " & quoted form of path_ & " >/dev/null 2>&1 &")
 		delay 2.5
+		if (my sh("pgrep -x screencapture >/dev/null && echo y || echo n")) is not "y" then
+			error "screencapture did not start -- grant Screen Recording to your terminal in System Settings > Privacy & Security"
+		end if
 	end if
 end startRec
 
@@ -373,8 +381,10 @@ on run argv
 	tell application "iTerm2" to set wb to bounds of win
 	my trace("window " & (item 1 of wb) & "," & (item 2 of wb) & " → " & (item 3 of wb) & "," & (item 4 of wb) & "   screen " & (item 1 of pts) & "x" & (item 2 of pts))
 
-	my trace("recording (" & recorder & ")")
-	my startRec(rawPath)
+	set rectStr to "" & (item 1 of wb) & "," & (item 2 of wb) & "," & ¬
+		((item 3 of wb) - (item 1 of wb)) & "," & ((item 4 of wb) - (item 2 of wb))
+	my trace("recording (" & recorder & ") rect " & rectStr)
+	my startRec(rawPath, rectStr)
 	delay 1.5
 
 	try
@@ -393,13 +403,17 @@ on run argv
 		my ctrlKey("s")
 		delay 0.25
 		my emit("|")
-		my waitFor("compression codec", 15)
-		delay 3
+		delay 1.5
+		-- spyc RESTORES the scroll position, so a re-run opens the preview where
+		-- the last run left it -- at the bottom, if that run ended on the mermaid
+		-- fence. Take the top BEFORE asserting, or the anchor is off-screen above
+		-- and the beat fails on a preview that is working perfectly.
 		my chordA("b")
 		my emit("g")
 		delay 0.12
 		my emit("g")
-		delay 1.5
+		my waitFor("compression codec", 15)
+		delay 3
 		repeat 4 times
 			my ctrlKey("d")
 			delay 1.1
@@ -469,10 +483,11 @@ on run argv
 		my escKey()
 		delay 0.6
 		my enter()
-		my waitFor("audience: operators", 15)
+		delay 1.2
 		my emit("g")
 		delay 0.12
 		my emit("g")
+		my waitFor("audience: operators", 15)
 		delay 1.5
 		my chordZ("M")
 		my waitForCount("▸", 10, 12)
@@ -487,12 +502,34 @@ on run argv
 
 		--------------------------------------------- beat 5 — THE MERMAID BEAT
 		my trace("beat 5 — mermaid diagram rendered in the terminal")
+		-- The only fence in the fixture is in RELEASE-NOTES.md, and beat 4 left
+		-- the pager on HANDBOOK.md -- so leave it and open the right file, or
+		-- `i` has nothing to render and the beat films a plain page of text.
+		my escKey()
+		delay 1.2
+		my emit("/RELEASE")
+		delay 0.9
+		my enter()
+		delay 0.7
+		my escKey()
+		delay 0.6
+		my enter()
+		delay 1.2
+		my emit("g")
+		delay 0.12
+		my emit("g")
+		my waitFor("streaming ingest layer", 15)
+		delay 1.2
 		my emit("/mermaid")
 		delay 1
 		my enter()
 		delay 1.8
 		my emit("i")
-		my waitFor("mermaid diagram", 25)
+		-- `mermaid diagram` alone is NOT evidence: it is also the rendered
+		-- placeholder block, and it is inside the refusal "no mermaid diagram
+		-- in view". `c theme` is on the image overlay and only for a mermaid
+		-- origin, so it cannot match anything but a diagram actually on screen.
+		my waitFor("c theme", 25)
 		my trace("      diagram is on screen — the frame no scripted recorder can capture")
 		delay 5
 		my emit("c")
@@ -518,23 +555,33 @@ on run argv
 	my stageFixture()
 
 	if not isDry then
-		set cmd to "set -e" & ¬
-			"; RAW=" & quoted form of rawPath & ¬
-			"; OUT=" & quoted form of outPath & ¬
-			"; VW=$(ffprobe -v error -select_streams v -show_entries stream=width -of csv=p=0 \"$RAW\")" & ¬
-			"; SC=$(python3 -c \"print(round($VW/" & (item 1 of pts) & ",4))\")" & ¬
-			"; X=$(python3 -c \"print(int(" & (item 1 of wb) & "*$SC)//2*2)\")" & ¬
-			"; Y=$(python3 -c \"print(int(" & (item 2 of wb) & "*$SC)//2*2)\")" & ¬
-			"; W=$(python3 -c \"print(int((" & (item 3 of wb) & "-" & (item 1 of wb) & ")*$SC)//2*2)\")" & ¬
-			"; H=$(python3 -c \"print(int((" & (item 4 of wb) & "-" & (item 2 of wb) & ")*$SC)//2*2)\")" & ¬
-			"; echo \"video=${VW}px scale=$SC crop=${W}x${H}+${X}+${Y}\"" & ¬
-			"; ffmpeg -v error -i \"$RAW\" -vf \"crop=$W:$H:$X:$Y\" -an -c:v libx264 -crf 18 -pix_fmt yuv420p -movflags +faststart \"$OUT\" -y" & ¬
-			"; echo \"$OUT\""
+		if recorder is "screencapture" then
+			-- already exactly the window rect: transcode only, never crop twice
+			set cmd to "set -e" & ¬
+				"; RAW=" & quoted form of rawPath & ¬
+				"; OUT=" & quoted form of outPath & ¬
+				"; test -s \"$RAW\" || { echo 'no take was written'; exit 1; }" & ¬
+				"; ffmpeg -v error -i \"$RAW\" -an -c:v libx264 -crf 18 -pix_fmt yuv420p -movflags +faststart \"$OUT\" -y" & ¬
+				"; echo \"$(ffprobe -v error -select_streams v -show_entries stream=width,height -of csv=p=0 \"$OUT\") -> $OUT\""
+		else
+			set cmd to "set -e" & ¬
+				"; RAW=" & quoted form of rawPath & ¬
+				"; OUT=" & quoted form of outPath & ¬
+				"; VW=$(ffprobe -v error -select_streams v -show_entries stream=width -of csv=p=0 \"$RAW\")" & ¬
+				"; SC=$(python3 -c \"print(round($VW/" & (item 1 of pts) & ",4))\")" & ¬
+				"; X=$(python3 -c \"print(int(" & (item 1 of wb) & "*$SC)//2*2)\")" & ¬
+				"; Y=$(python3 -c \"print(int(" & (item 2 of wb) & "*$SC)//2*2)\")" & ¬
+				"; W=$(python3 -c \"print(int((" & (item 3 of wb) & "-" & (item 1 of wb) & ")*$SC)//2*2)\")" & ¬
+				"; H=$(python3 -c \"print(int((" & (item 4 of wb) & "-" & (item 2 of wb) & ")*$SC)//2*2)\")" & ¬
+				"; echo \"video=${VW}px scale=$SC crop=${W}x${H}+${X}+${Y}\"" & ¬
+				"; ffmpeg -v error -i \"$RAW\" -vf \"crop=$W:$H:$X:$Y\" -an -c:v libx264 -crf 18 -pix_fmt yuv420p -movflags +faststart \"$OUT\" -y" & ¬
+				"; echo \"$OUT\""
+		end if
 		try
 			my trace(my sh(cmd))
 		on error e2
-			my trace("crop failed: " & e2)
-			my trace("uncropped take kept at " & rawPath)
+			my trace("post-processing failed: " & e2)
+			my trace("raw take kept at " & rawPath)
 		end try
 	end if
 


### PR DESCRIPTION
Lands the markdown demo harness, which until now lived only in a `/private/tmp`
session scratchpad — intact, but one OS sweep from gone.

**Work in progress: the harness runs, the film does not exist yet.** All five
beats assert green in rehearsal; no take has been shot. Sources only — no video
is committed, because a `.mov` belongs on a release rather than in git history,
and nothing is worth keeping until we have a demo we are sure of.

### What is here

`docs/assets/demo/markdown/` — 1113 lines, all text, largest file 20K.

- `spyc-quicktime-demo.applescript` — films a live iTerm2 window with QuickTime.
  Five beats: browse → full-height rendered preview → vim edit re-renders on save
  → outline folding → mermaid diagram in the terminal.
- `demo.sh` / `fold.sh` — the `tui-test` + `agg` pipeline for the text-only clips.
- `mermaid-beat.md` — hand-recording recipe for the beat no scripted recorder can
  capture.
- `aurora-docs/` — the fixture doc tree, several top-level headings on purpose so
  `zM` yields a table of contents rather than one line.

### Why two pipelines

`tui-test` drives spyc well — Ghostty backend, `expect text`, waits that beat vhs's
blind `Sleep` against the off-thread preview reload. But its recorder is a glyph
rasterizer, as is vhs's: spyc emits the mermaid bitmap and the recorder throws it
away. There is no text fallback. So the mermaid beat needs a real screen capture,
which is what the AppleScript is for.

### Changed from the scratchpad original

- Paths resolve from the script's own folder instead of a scratchpad that no
  longer exists.
- The fixture is staged to a disposable copy per run. A beat edits
  `RELEASE-NOTES.md`, and the original `git checkout -- .` reset would now reach
  into spyc's own working tree.
- Recordings go to `/private/tmp/spyc-demo/out/`, so no take can be committed by
  accident.

### Verification

`make check-ci` → `=== GATE: PASS ===`. `osacompile` accepts the AppleScript and
`zsh -n` both drivers. The prose guard was bite-checked against all three new file
types — planted offenders in the README, the fixture tree and a `.sh` were each
reported, so the fixture is policed like any other prose here.

Generated with [Claude Code](https://claude.com/claude-code)
