### PR TITLE
fix(capture): render `ssh -v` output instead of blank pager lines

### DIFF
--- a/src/app/mod_tests.rs
+++ b/src/app/mod_tests.rs
@@ -1372,6 +1372,38 @@ mod strip_crlf_tests {
         let input = b"a\tb\nc\x1b[31md";
         assert_eq!(strip_crlf(input), b"a\tb\nc\x1b[31md");
     }
+
+    #[test]
+    fn cr_run_before_lf_collapses_to_one_lf() {
+        // `ssh -v` writes its own `\r\n` to stderr, and the capture pty's
+        // ONLCR turns that into `\r\r\n` -- so every line arrives with a CR
+        // still ahead of the LF. Collapsing only the LAST pair leaves each
+        // segment ending in a CR, which pass 2 reads as "the line was
+        // overwritten by nothing" and blanks it. Real bytes off a live
+        // `ssh -v` capture.
+        let input = b"debug1: OpenSSH_10.3p1, LibreSSL 3.3.6\r\r\n\
+debug1: Connecting to 127.0.0.1 [127.0.0.1] port 22.\r\r\n";
+        assert_eq!(
+            strip_crlf(input),
+            b"debug1: OpenSSH_10.3p1, LibreSSL 3.3.6\n\
+debug1: Connecting to 127.0.0.1 [127.0.0.1] port 22.\n"
+        );
+    }
+
+    #[test]
+    fn trailing_cr_does_not_erase_its_line() {
+        // A CR moves the cursor to column 0; it erases nothing. A segment
+        // whose last CR sits at its end therefore keeps its text -- both
+        // mid-stream (a progress frame whose overwrite hasn't arrived) and
+        // when a CR run precedes the terminator.
+        assert_eq!(strip_crlf(b"Counting: 50%\r"), b"Counting: 50%");
+        assert_eq!(strip_crlf(b"Counting: 50%\r\r\r"), b"Counting: 50%");
+        // The overwrite still wins when there IS text after the CR.
+        assert_eq!(
+            strip_crlf(b"Counting: 18%\rCounting: 50%\r"),
+            b"Counting: 50%"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/app/util.rs
+++ b/src/app/util.rs
@@ -159,11 +159,16 @@ pub fn eof_marker_line(tail: &str) -> ratatui::text::Line<'static> {
 ///
 /// Three passes:
 ///
-/// 1. CRLF (`\r\n`) → LF (`\n`). The pty's slave side enables ONLCR by
-///    default, so a child writing `\n` produces `\r\n` on the master
-///    we read from. Without this, ratatui rendering interprets the
-///    literal `\r` as carriage return and shorter following lines
-///    overlay just the prefix of longer prior ones.
+/// 1. A run of CRs terminating a line (`\r+\n`) → LF (`\n`). The pty's
+///    slave side enables ONLCR by default, so a child writing `\n`
+///    produces `\r\n` on the master we read from. Without this,
+///    ratatui rendering interprets the literal `\r` as carriage return
+///    and shorter following lines overlay just the prefix of longer
+///    prior ones. It is a *run* because a child that writes its own
+///    `\r\n` — OpenSSH's `do_log`, so every `ssh -v` line — comes off
+///    the master as `\r\r\n`; collapsing only the last pair leaves a
+///    CR at the end of each segment, which pass 2 then reads as an
+///    overwrite by nothing and blanks the whole line.
 /// 2. Bare `\r` collapse. `git pull`, `npm`, `cargo`, etc. use bare
 ///    `\r` (no newline) to overwrite a progress line on the same
 ///    terminal row -- `Counting: 18%\rCounting: 27%\rCounting: 100%`.
@@ -171,8 +176,10 @@ pub fn eof_marker_line(tail: &str) -> ratatui::text::Line<'static> {
 ///    a fix we render every frame side-by-side as one super-wide
 ///    line. For each `\n`-delimited segment, we keep only the text
 ///    after the *last* `\r` -- the same final state a real terminal
-///    would show. Streaming pagers re-run this every tick, so the
-///    user sees live progress (latest frame each redraw).
+///    would show. Trailing CRs are excluded from that search: a CR
+///    moves the cursor to column 0 and erases nothing, so a segment
+///    ending in one keeps its text. Streaming pagers re-run this every
+///    tick, so the user sees live progress (latest frame each redraw).
 /// 3. Strip stray ASCII control bytes that aren't whitespace or ANSI
 ///    escape. Some `git log` commit messages, mboxen, and old-school
 ///    formatter output carry `\b` (man-page bold trick), `\v`, `\f`,
@@ -188,17 +195,23 @@ pub fn eof_marker_line(tail: &str) -> ratatui::text::Line<'static> {
 /// other control bytes pass 3 strips, so the byte-level passes are
 /// safe.
 pub fn strip_crlf(bytes: &[u8]) -> Vec<u8> {
-    // Pass 1: \r\n -> \n.
+    // Pass 1: a RUN of \r immediately before \n -> one \n.
     let mut step1 = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
-        if bytes[i] == b'\r' && bytes.get(i + 1) == Some(&b'\n') {
-            step1.push(b'\n');
-            i += 2;
-        } else {
-            step1.push(bytes[i]);
-            i += 1;
+        if bytes[i] == b'\r' {
+            let mut end = i;
+            while bytes.get(end) == Some(&b'\r') {
+                end += 1;
+            }
+            if bytes.get(end) == Some(&b'\n') {
+                step1.push(b'\n');
+                i = end + 1;
+                continue;
+            }
         }
+        step1.push(bytes[i]);
+        i += 1;
     }
     // Pass 2: collapse bare \r within each line to the last frame.
     let step2: Vec<u8> = if step1.contains(&b'\r') {
@@ -209,8 +222,11 @@ pub fn strip_crlf(bytes: &[u8]) -> Vec<u8> {
                 out.push(b'\n');
             }
             first = false;
-            let start = line.iter().rposition(|&b| b == b'\r').map_or(0, |i| i + 1);
-            out.extend_from_slice(&line[start..]);
+            // A CR at the very end overwrote nothing, so it erases nothing.
+            let end = line.iter().rposition(|&b| b != b'\r').map_or(0, |i| i + 1);
+            let head = &line[..end];
+            let start = head.iter().rposition(|&b| b == b'\r').map_or(0, |i| i + 1);
+            out.extend_from_slice(&head[start..]);
         }
         out
     } else {
@@ -329,6 +345,23 @@ mod tests {
         let (user, host) = s.split_once('@').expect("user@host shape");
         assert!(!user.is_empty(), "user half empty: {s}");
         assert!(!host.is_empty(), "host half empty: {s}");
+    }
+
+    /// The pager renders `ssh -v` output as text, not as blank rows. Its
+    /// stderr lines carry their own `\r\n`, which the capture pty's ONLCR
+    /// doubles into `\r\r\n` -- the shape that used to leave every line
+    /// empty while the title still counted them.
+    #[test]
+    fn buffer_to_lines_keeps_cr_cr_lf_terminated_text() {
+        let lines = buffer_to_lines(b"debug1: Connecting to 10.49.8.42\r\r\ndebug1: connect\r\r\n");
+        let plain: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert_eq!(
+            plain,
+            vec!["debug1: Connecting to 10.49.8.42", "debug1: connect"]
+        );
     }
 
     /// `buffer_to_lines` normalizes CRLF and bare-CR progress overwrites the


### PR DESCRIPTION
## The bug

`! ssh -v <host> '<cmd>'` renders as blank rows in the capture pager. The
title counts them correctly — `(9 lines)` — and the line-number gutter
numbers them, but every row is empty.

Not the ghostty engine swap: this path never touches the pane engine.

## Root cause

OpenSSH's `do_log` writes every `-v` line to stderr with an explicit
`\r\n`. The capture child runs under a pty whose slave has `ONLCR` on, so
that `\n` picks up a CR of its own and each line reaches the master as
**`\r\r\n`**. Measured on a live capture: 716 bytes, 11 line terminators,
all `\r\r\n`.

`strip_crlf` (`src/app/util.rs`) then unwound it exactly backwards:

1. Pass 1 collapsed only the trailing `\r\n` pair, leaving one CR at the
   end of every segment.
2. Pass 2 — bare-CR progress overwrite, "keep the text after the last
   CR" — found that CR at the end and kept what followed it: nothing.

716 bytes of `ssh -v` normalized to 11 empty lines.

stderr was never the problem: fds 1 and 2 share the pty slave, so those
lines were captured, buffered and counted. They were normalized away on
the last step to the pager.

## The fix

- **Pass 1** collapses a *run* of CRs before a newline (`\r+\n` → `\n`),
  so ONLCR doubling can't leave one behind.
- **Pass 2** excludes trailing CRs from the last-frame search. A CR moves
  the cursor to column 0 and erases nothing, so a segment ending in one
  keeps its text. Defence in depth — an unanticipated CR shape can no
  longer blank a line by itself.

`buffer_to_lines` is shared, so this also covers the `^Z` background
tasks, the `:fg` re-attach and the task viewer.

## Tests

Landed red and watched fail before the fix (`left: [10, 10]` — two bare
LFs where the text belongs):

- `cr_run_before_lf_collapses_to_one_lf` — real bytes off a live `ssh -v`.
- `trailing_cr_does_not_erase_its_line` — including that the overwrite
  still wins when there *is* text after the CR.
- `buffer_to_lines_keeps_cr_cr_lf_terminated_text` — the symptom itself,
  at the pager's data model.

`make check-ci` → `=== GATE: PASS ===`.

Generated with [Claude Code](https://claude.com/claude-code)
